### PR TITLE
Fix module imports and cleanup VR prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ development.
 
 1. Install a recent version of the [Meta Quest 3](https://www.meta.com/)
    browser or any WebXR‑capable browser on your VR headset or desktop.
-2. Serve the contents of this `vr_port` folder using a simple HTTP server
+2. Serve the contents of this repository using a simple HTTP server
    (browsers often block local file access for security reasons).  From
    within the repository root, run for example:
 
    ```bash
-   npx http-server vr_port
+   npx http-server .
    ```
 
    Then open the reported URL in your VR browser.  Alternatively you can
-   drag `vr_port/index.html` into a WebXR‑capable desktop browser for a
+   open `index.html` in a WebXR‑capable desktop browser for a
    non‑VR preview.
 3. Use your controllers to grab the blue avatar box and move it around.
    Click the red aberration core to trigger its cooldown and see the UI
@@ -57,20 +57,10 @@ This prototype does **not** include the full Eternal Momentum codebase
 (`modules/bosses.js`, `modules/gameLoop.js`, etc.).  To turn this into a
 complete VR version:
 
-1. **Copy the game modules** — Place the original game’s JavaScript
-   modules and assets into the `vr_port/game` folder.  Preserve their
-   directory structure (e.g. copy the entire `modules/` directory and
-   any required `assets/` subfolders).  The updated `script.js` uses
-   dynamic `import` statements such as:
-
-   ```js
-   import { gameTick } from './game/modules/gameLoop.js';
-   import { state } from './game/modules/state.js';
-   import { activateCorePower } from './game/modules/cores.js';
-   ```
-
-   These imports will resolve once you have copied the corresponding
-   files into `vr_port/game/modules`.
+1. **Ensure the game modules are present** — The core JavaScript modules
+   from Eternal Momentum are included in this repository under the
+   `modules/` directory.  `script.js` imports them directly so no extra
+   copying is required.
 
 2. **Ensure the canvas ID matches** — The hidden canvas element in
    `index.html` has the id `gameCanvas`, which matches what

--- a/script.js
+++ b/script.js
@@ -27,13 +27,16 @@
 // where the script is included with `type="module"`.  Imports of game
 // modules appear at the top level.
   // Import the Eternal Momentum modules.  These imports will be resolved
-  // relative to this file.  The user must copy the original `modules`
-  // directory into `vr_port/game/modules` for these imports to succeed.
-  // Importing at the top level is allowed because this script is loaded as
-  // an ES module in index.html.
-  import { gameTick } from './game/modules/gameLoop.js';
-  import { state } from './game/modules/state.js';
-  import { activateCorePower } from './game/modules/cores.js';
+  // relative to this file.  In this repository the original game source
+  // already lives in the `modules/` directory at the project root, so no
+  // extra copying is required.  The script is loaded as an ES module in
+  // index.html so these imports resolve directly.
+  // Import the core game modules.  The original source lives in the
+  // `modules/` directory at the repository root, so we import from there
+  // directly rather than using the old vr_port path.
+  import { gameTick } from './modules/gameLoop.js';
+  import { state } from './modules/state.js';
+  import { activateCorePower } from './modules/cores.js';
 // Register a component that applies a 2D canvas as a live texture
   // on an entity.  When attached to the cylinder in index.html it
   // continuously copies the canvas contents into the material map.
@@ -218,33 +221,11 @@ window.addEventListener('load', () => {
       }
     });
 
-    // Main render loop.  Attempt to call the original game's `gameTick()`
-    // function to update the 2D canvas.  If the original modules are not
-    // present, fall back to drawing a simple radial grid.  The UI
-    // overlays are updated on every frame as well.
-    function loop() {
-      let ticked = false;
-      try {
-        // Run the original game tick.  gameTick() draws into the canvas
-        // referenced by `gameCanvas` and updates the imported `state`.
-        gameTick();
-        ticked = true;
-      } catch (err) {
-        // If gameTick() isn’t defined because the modules are missing or
-        // errored, draw a fallback canvas so the cylinder is not blank.
-        drawGameCanvasFallback();
-      }
-      // Refresh UI every frame
-      updateUI();
-      requestAnimationFrame(loop);
-    }
-    loop();
 
     // Main animation loop.  It runs at the browser's animation rate (~60 Hz)
-    // and updates the canvas and UI.  If the original game modules have
-    // been copied into `vr_port/game/modules`, we call `gameTick()` to
-    // advance the game and redraw the canvas.  Otherwise we fall back to
-    // drawing a simple grid.
+    // and updates the canvas and UI.  If the original game modules are
+    // available we call `gameTick()` to advance the game and redraw the
+    // canvas.  Otherwise we fall back to drawing a simple grid.
     function animate() {
       // Advance the game if possible
       if (typeof gameTick === 'function') {
@@ -263,4 +244,3 @@ window.addEventListener('load', () => {
     }
     animate();
   });
-})();


### PR DESCRIPTION
## Summary
- update README instructions to match repository layout
- load game modules directly from `modules/`
- remove unused duplicate loop in `script.js`
- clean up comments and stray characters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68858565416c83318e5413fb2f90a052