### PR TITLE
Add VR boss panel and reset control

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ development.
 * **Directional audio** — The aberration core emits a continuous tone
   (`assets/core_sound.wav`) which gets quieter as you move away or turn
   your head, giving a sense of spatial presence.
+* **Boss health display** — When a boss spawns, a panel shows its name and
+  remaining hit points so you can track the encounter without leaving VR.
+* **Quick restart button** — A reset button on the table immediately
+  restarts the run, mirroring the original game’s "retry" functionality.
 
 ## Running the Prototype
 
@@ -96,5 +100,4 @@ complete VR version:
   will be necessary.
 
 Feel free to build upon this foundation to create a fully fledged VR
-experience for Eternal Momentum.  Contributions and pull requests are
-welcome!
+experience for Eternal Momentum.  Contributions and pull requests are welcome!

--- a/index.html
+++ b/index.html
@@ -113,6 +113,19 @@
       <a-text id="statusText" value="" align="center" width="1.2" color="#eaf2ff"></a-text>
     </a-plane>
 
+    <a-plane id="bossPanel" width="1.4" height="0.3"
+             material="color: #141428; opacity: 0.9"
+             position="0 1.7 -1.5" rotation="0 0 0" visible="false">
+      <a-text id="bossNameText" value="" align="center" width="1.2" position="0 0.1 0.01" color="#ff5555"></a-text>
+      <a-text id="bossHpText" value="" align="center" width="1.2" position="0 -0.12 0.01" color="#eaf2ff"></a-text>
+    </a-plane>
+
+    <a-plane id="resetButton" width="0.6" height="0.2"
+             material="color: #141428; opacity: 0.9"
+             position="2 0.8 -1.2" rotation="0 -30 0" class="interactive">
+      <a-text value="Reset" align="center" width="0.5" color="#eaf2ff"></a-text>
+    </a-plane>
+
     <!-- Cylindrical surface that wraps the 2D game canvas around the player.  A
          custom component defined in script.js (canvas-texture) copies the
          canvas into a texture every frame.  The cylinder is open‑ended so

--- a/script.js
+++ b/script.js
@@ -115,6 +115,10 @@ window.addEventListener('load', () => {
     const statusText = document.getElementById('statusText');
     const offPowerText = document.getElementById('offPowerText');
     const defPowerText = document.getElementById('defPowerText');
+    const bossPanel = document.getElementById('bossPanel');
+    const bossNameText = document.getElementById('bossNameText');
+    const bossHpText = document.getElementById('bossHpText');
+    const resetButton = document.getElementById('resetButton');
 
     // Helper to update the scoreboard and health bars.  Values are read
     // directly from the imported game state.  You can customise which
@@ -141,6 +145,17 @@ window.addEventListener('load', () => {
         cooldownText.setAttribute('value', `Core cooldown: ${remaining.toFixed(1)}s`);
       } else {
         cooldownText.setAttribute('value', 'Core cooldown: Ready');
+      }
+
+      if (bossPanel && bossNameText && bossHpText) {
+        const boss = state.enemies.find(e => e.boss);
+        if (boss) {
+          bossPanel.setAttribute('visible', 'true');
+          bossNameText.setAttribute('value', boss.name || 'Boss');
+          bossHpText.setAttribute('value', `HP: ${Math.floor(boss.hp)} / ${boss.maxHP}`);
+        } else {
+          bossPanel.setAttribute('visible', 'false');
+        }
       }
     }
 
@@ -210,6 +225,17 @@ window.addEventListener('load', () => {
         }
       }
     });
+
+    if (resetButton) {
+      resetButton.addEventListener('click', () => {
+        resetGame(false);
+        applyAllTalentEffects();
+        gameState.lastCoreUse = -Infinity;
+        gameOverShown = false;
+        statusText.setAttribute('value', '');
+        updateUI();
+      });
+    }
 
     // Trigger equipped powers when the controller triggers are pressed.
     const leftHand = document.getElementById('leftHand');


### PR DESCRIPTION
## Summary
- display active boss name and health in VR
- add in-game reset button
- document boss panel and reset control

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68859e59272c8331b3691c83604f3ea4