### PR TITLE
Enhance VR prototype with stage selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,34 @@
       <a-text value="Reset" align="center" width="0.5" color="#eaf2ff"></a-text>
     </a-plane>
 
+    <a-plane id="stageSelectToggle" width="0.8" height="0.2"
+             material="color: #141428; opacity: 0.9"
+             position="2 1.05 -1.2" rotation="0 -30 0" class="interactive">
+      <a-text value="Stage Select" align="center" width="0.7" color="#eaf2ff"></a-text>
+    </a-plane>
+
+    <a-plane id="stageSelectPanel" width="1.4" height="0.8" visible="false"
+             material="color: #141428; opacity: 0.95"
+             position="0 1.6 -1.5" rotation="0 0 0">
+      <a-text id="stageSelectLabel" value="Stage: 1" align="center" width="1.2"
+              position="0 0.25 0.01" color="#eaf2ff"></a-text>
+      <a-plane id="prevStageBtn" width="0.4" height="0.2" class="interactive"
+               material="color: #333"
+               position="-0.45 -0.05 0.01">
+        <a-text value="Prev" align="center" width="0.4" color="#eaf2ff"></a-text>
+      </a-plane>
+      <a-plane id="nextStageBtn" width="0.4" height="0.2" class="interactive"
+               material="color: #333"
+               position="0.45 -0.05 0.01">
+        <a-text value="Next" align="center" width="0.4" color="#eaf2ff"></a-text>
+      </a-plane>
+      <a-plane id="startStageBtn" width="0.8" height="0.25" class="interactive"
+               material="color: #555"
+               position="0 -0.35 0.01">
+        <a-text value="Start" align="center" width="0.7" color="#eaf2ff"></a-text>
+      </a-plane>
+    </a-plane>
+
     <!-- Cylindrical surface that wraps the 2D game canvas around the player.  A
          custom component defined in script.js (canvas-texture) copies the
          canvas into a texture every frame.  The cylinder is open‑ended so

--- a/script.js
+++ b/script.js
@@ -39,6 +39,7 @@
   import { activateCorePower } from './modules/cores.js';
   import { usePower, powers } from './modules/powers.js';
   import { applyAllTalentEffects } from './modules/ascension.js';
+  import { STAGE_CONFIG } from './modules/config.js';
 // Register a component that applies a 2D canvas as a live texture
   // on an entity.  When attached to the cylinder in index.html it
   // continuously copies the canvas contents into the material map.
@@ -119,6 +120,21 @@ window.addEventListener('load', () => {
     const bossNameText = document.getElementById('bossNameText');
     const bossHpText = document.getElementById('bossHpText');
     const resetButton = document.getElementById('resetButton');
+    const stageSelectToggle = document.getElementById('stageSelectToggle');
+    const stageSelectPanel = document.getElementById('stageSelectPanel');
+    const stageSelectLabel = document.getElementById('stageSelectLabel');
+    const prevStageBtn = document.getElementById('prevStageBtn');
+    const nextStageBtn = document.getElementById('nextStageBtn');
+    const startStageBtn = document.getElementById('startStageBtn');
+
+    const maxStage = STAGE_CONFIG.length;
+    let selectedStage = state.currentStage;
+
+    function updateStageSelectDisplay() {
+      if (stageSelectLabel) {
+        stageSelectLabel.setAttribute('value', `Stage: ${selectedStage}`);
+      }
+    }
 
     // Helper to update the scoreboard and health bars.  Values are read
     // directly from the imported game state.  You can customise which
@@ -232,6 +248,42 @@ window.addEventListener('load', () => {
         applyAllTalentEffects();
         gameState.lastCoreUse = -Infinity;
         gameOverShown = false;
+        statusText.setAttribute('value', '');
+        updateUI();
+      });
+    }
+
+    if (stageSelectToggle && stageSelectPanel) {
+      stageSelectToggle.addEventListener('click', () => {
+        if (stageSelectPanel.getAttribute('visible') === true || stageSelectPanel.getAttribute('visible') === 'true') {
+          stageSelectPanel.setAttribute('visible', 'false');
+        } else {
+          selectedStage = state.currentStage;
+          updateStageSelectDisplay();
+          stageSelectPanel.setAttribute('visible', 'true');
+        }
+      });
+    }
+    if (prevStageBtn) {
+      prevStageBtn.addEventListener('click', () => {
+        selectedStage = Math.max(1, selectedStage - 1);
+        updateStageSelectDisplay();
+      });
+    }
+    if (nextStageBtn) {
+      nextStageBtn.addEventListener('click', () => {
+        selectedStage = Math.min(maxStage, selectedStage + 1);
+        updateStageSelectDisplay();
+      });
+    }
+    if (startStageBtn) {
+      startStageBtn.addEventListener('click', () => {
+        state.currentStage = selectedStage;
+        resetGame(false);
+        applyAllTalentEffects();
+        gameState.lastCoreUse = -Infinity;
+        gameOverShown = false;
+        stageSelectPanel.setAttribute('visible', 'false');
         statusText.setAttribute('value', '');
         updateUI();
       });


### PR DESCRIPTION
## Summary
- add a VR stage selection panel in *index.html*
- load stage configuration and handle panel interactions in *script.js*

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885a211235083319e1319d242c615bb