### PR TITLE
Introduce status effect panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ development.
   remaining hit points so you can track the encounter without leaving VR.
 * **Quick restart button** — A reset button on the table immediately
   restarts the run, mirroring the original game’s "retry" functionality.
+* **Status effect icons** — Active buffs and debuffs appear as emojis on a
+  panel so you can quickly see what affects your character.
 
 ## Running the Prototype
 

--- a/index.html
+++ b/index.html
@@ -88,11 +88,18 @@
              position="1.6 1.2 -0.3" rotation="0 -30 0">
       <a-text id="offPowerText" value="" align="center" width="0.3" color="#eaf2ff"></a-text>
     </a-plane>
-    <a-plane id="defPowerPanel" width="0.3" height="0.3"
-             material="color: #141428; opacity: 0.9"
-             position="1.6 1.2 -0.8" rotation="0 -30 0">
-      <a-text id="defPowerText" value="" align="center" width="0.3" color="#eaf2ff"></a-text>
-    </a-plane>
+      <a-plane id="defPowerPanel" width="0.3" height="0.3"
+               material="color: #141428; opacity: 0.9"
+               position="1.6 1.2 -0.8" rotation="0 -30 0">
+        <a-text id="defPowerText" value="" align="center" width="0.3" color="#eaf2ff"></a-text>
+      </a-plane>
+
+      <!-- Active status effects are shown on a panel opposite the score. -->
+      <a-plane id="statusEffectsPanel" width="1.2" height="0.3"
+               material="color: #141428; opacity: 0.9"
+               position="-2 1.2 -0.5" rotation="0 30 0">
+        <a-text id="statusEffectsText" value="" align="center" width="1.1" color="#eaf2ff"></a-text>
+      </a-plane>
 
     <!-- Aberration core representation.  A glowing sphere slowly spins and
          emits a continuous tone using positional audio.  When the core’s

--- a/script.js
+++ b/script.js
@@ -115,6 +115,7 @@ window.addEventListener('load', () => {
     const stageText = document.getElementById('stageText');
     const cooldownText = document.getElementById('cooldownText');
     const statusText = document.getElementById('statusText');
+    const statusEffectsText = document.getElementById('statusEffectsText');
     const offPowerText = document.getElementById('offPowerText');
     const defPowerText = document.getElementById('defPowerText');
     const bossPanel = document.getElementById('bossPanel');
@@ -195,6 +196,11 @@ window.addEventListener('load', () => {
         } else {
           bossPanel.setAttribute('visible', 'false');
         }
+      }
+
+      if (statusEffectsText) {
+        const emojis = state.player.statusEffects.map(e => e.emoji).join(' ');
+        statusEffectsText.setAttribute('value', emojis);
       }
     }
 


### PR DESCRIPTION
## Summary
- render active status effects in VR via a new panel
- display emojis for each status effect in the update loop
- document new feature in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885aadff8a883318e88791708e9f9af