### PR TITLE
Add Orrery menu to VR

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,9 +158,14 @@
              position="2 1.8 -1.2" rotation="0 -30 0" class="interactive">
       <a-text value="Codex" align="center" width="0.7" color="#eaf2ff"></a-text>
     </a-plane>
-    <a-plane id="soundOptionsToggle" width="0.8" height="0.2"
+    <a-plane id="orreryToggle" width="0.8" height="0.2"
              material="color: #141428; opacity: 0.9"
              position="2 2.05 -1.2" rotation="0 -30 0" class="interactive">
+      <a-text value="Orrery" align="center" width="0.7" color="#eaf2ff"></a-text>
+    </a-plane>
+    <a-plane id="soundOptionsToggle" width="0.8" height="0.2"
+             material="color: #141428; opacity: 0.9"
+             position="2 2.3 -1.2" rotation="0 -30 0" class="interactive">
       <a-text value="Sound" align="center" width="0.7" color="#eaf2ff"></a-text>
     </a-plane>
 
@@ -249,6 +254,24 @@
       <div id="bossInfoModalTitle"></div>
       <div id="bossInfoModalContent"></div>
       <div id="bossInfoModalActions"><button id="closeBossInfoModalBtn" class="btn-modal-close">Close</button></div>
+    </div>
+  </div>
+  <div id="orreryModal" style="display:none;">
+    <div id="orrery-modal-content">
+      <h1 style="margin-top:0;margin-bottom:10px;color:var(--secondary-glow);">Weaver's Orrery</h1>
+      <div id="orrery-main-content">
+        <div id="orrery-boss-list-container"></div>
+        <div id="orrery-selection-container">
+          <h3>Selected</h3>
+          <div id="orrery-selection-display"></div>
+          <div id="orrery-cost-display">Cost: <span id="orrery-current-cost">0</span>/<span id="orrery-points-total">0</span></div>
+        </div>
+      </div>
+      <div style="display:flex;justify-content:flex-end;gap:10px;">
+        <button id="orrery-reset-btn">Reset</button>
+        <button id="closeOrreryBtn" class="btn-modal-close">Close</button>
+        <button id="orrery-start-btn" class="btn-modal-close disabled">Start</button>
+      </div>
     </div>
   </div>
   <div id="soundOptionsModal" style="display:none;">

--- a/script.js
+++ b/script.js
@@ -39,7 +39,7 @@
   import { activateCorePower } from './modules/cores.js';
   import { usePower, powers } from './modules/powers.js';
   import { applyAllTalentEffects } from './modules/ascension.js';
-  import { populateAberrationCoreMenu } from './modules/ui.js';
+  import { populateAberrationCoreMenu, populateOrreryMenu } from './modules/ui.js';
   import { STAGE_CONFIG } from './modules/config.js';
 // Register a component that applies a 2D canvas as a live texture
   // on an entity.  When attached to the cylinder in index.html it
@@ -140,6 +140,9 @@ window.addEventListener('load', () => {
     const codexToggle = document.getElementById("codexToggle");
     const loreCodexModal = document.getElementById("loreCodexModal");
     const closeLoreCodexBtn = document.getElementById("closeLoreCodexBtn");
+    const orreryToggle = document.getElementById("orreryToggle");
+    const orreryModal = document.getElementById("orreryModal");
+    const closeOrreryBtn = document.getElementById("closeOrreryBtn");
     const soundOptionsToggle = document.getElementById("soundOptionsToggle");
     const soundOptionsModal = document.getElementById("soundOptionsModal");
     const closeSoundOptionsBtn = document.getElementById("closeSoundOptionsBtn");
@@ -318,6 +321,17 @@ window.addEventListener('load', () => {
       });
     }
 
+    function startOrreryEncounter(bossList) {
+      resetGame(true);
+      state.customOrreryBosses = bossList;
+      state.currentStage = 999;
+      gameState.lastCoreUse = -Infinity;
+      gameOverShown = false;
+      orreryModal.style.display = 'none';
+      statusText.setAttribute('value', '');
+      updateUI();
+    }
+
     function equipCore(coreId) {
       state.player.equippedAberrationCore = coreId;
       savePlayerState();
@@ -359,6 +373,17 @@ window.addEventListener('load', () => {
         codexToggle.addEventListener("click", () => {
           populateLoreCodex();
           loreCodexModal.style.display = "flex";
+        });
+      }
+      if (orreryToggle && orreryModal) {
+        orreryToggle.addEventListener("click", () => {
+          populateOrreryMenu(startOrreryEncounter);
+          orreryModal.style.display = "flex";
+        });
+      }
+      if (closeOrreryBtn) {
+        closeOrreryBtn.addEventListener("click", () => {
+          orreryModal.style.display = "none";
         });
       }
       if (closeLoreCodexBtn) {


### PR DESCRIPTION
## Summary
- add an Orrery button to the VR UI table
- implement Weaver's Orrery modal overlay
- wire up new menu via populateOrreryMenu in script.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885abc326c083319727b467d8574f9a