### PR TITLE
Add pause/resume control for VR

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,11 @@
              position="2 0.8 -1.2" rotation="0 -30 0" class="interactive">
       <a-text value="Reset" align="center" width="0.5" color="#eaf2ff"></a-text>
     </a-plane>
+    <a-plane id="pauseToggle" width="0.6" height="0.2"
+             material="color: #141428; opacity: 0.9"
+             position="2 0.95 -1.2" rotation="0 -30 0" class="interactive">
+      <a-text id="pauseText" value="Pause" align="center" width="0.5" color="#eaf2ff"></a-text>
+    </a-plane>
 
     <a-plane id="stageSelectToggle" width="0.8" height="0.2"
              material="color: #141428; opacity: 0.9"

--- a/script.js
+++ b/script.js
@@ -41,6 +41,7 @@
   import { applyAllTalentEffects } from './modules/ascension.js';
   import { populateAberrationCoreMenu, populateOrreryMenu } from './modules/ui.js';
   import { STAGE_CONFIG } from './modules/config.js';
+import { AudioManager } from "./modules/audio.js";
 // Register a component that applies a 2D canvas as a live texture
   // on an entity.  When attached to the cylinder in index.html it
   // continuously copies the canvas contents into the material map.
@@ -124,6 +125,8 @@ window.addEventListener('load', () => {
     const resetButton = document.getElementById('resetButton');
     const stageSelectToggle = document.getElementById('stageSelectToggle');
     const stageSelectPanel = document.getElementById('stageSelectPanel');
+    const pauseToggle = document.getElementById("pauseToggle");
+    const pauseText = document.getElementById("pauseText");
     const stageSelectLabel = document.getElementById('stageSelectLabel');
     const prevStageBtn = document.getElementById('prevStageBtn');
     const nextStageBtn = document.getElementById('nextStageBtn');
@@ -282,6 +285,20 @@ window.addEventListener('load', () => {
         gameOverShown = false;
         statusText.setAttribute('value', '');
         updateUI();
+      });
+    }
+    if (pauseToggle) {
+      pauseToggle.addEventListener("click", () => {
+        state.isPaused = !state.isPaused;
+        if (state.isPaused) {
+          if (pauseText) pauseText.setAttribute("value", "Resume");
+          statusText.setAttribute("value", "PAUSED");
+          AudioManager.fadeOutMusic(500);
+        } else {
+          if (pauseText) pauseText.setAttribute("value", "Pause");
+          statusText.setAttribute("value", "");
+          AudioManager.playMusic();
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- add VR button to pause and resume gameplay
- hook up pause logic in `script.js`
- import `AudioManager` to control music fade

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6885b00e01c8833198a05f4014e76f45