### PR TITLE
Add VR power cycling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ development.
   restarts the run, mirroring the original game’s "retry" functionality.
 * **Status effect icons** — Active buffs and debuffs appear as emojis on a
   panel so you can quickly see what affects your character.
+* **Power queue cycling** — Use the grip buttons on your VR controllers to
+  rotate through your offensive and defensive power queues. Upcoming powers are
+  shown beneath the main icons so you always know what will trigger next.
 
 ## Running the Prototype
 

--- a/index.html
+++ b/index.html
@@ -87,11 +87,13 @@
              material="color: #141428; opacity: 0.9"
              position="1.6 1.2 -0.3" rotation="0 -30 0">
       <a-text id="offPowerText" value="" align="center" width="0.3" color="#eaf2ff"></a-text>
+      <a-text id="offPowerQueueText" value="" align="center" width="0.3" color="#eaf2ff" position="0 -0.22 0.01"></a-text>
     </a-plane>
       <a-plane id="defPowerPanel" width="0.3" height="0.3"
                material="color: #141428; opacity: 0.9"
                position="1.6 1.2 -0.8" rotation="0 -30 0">
         <a-text id="defPowerText" value="" align="center" width="0.3" color="#eaf2ff"></a-text>
+        <a-text id="defPowerQueueText" value="" align="center" width="0.3" color="#eaf2ff" position="0 -0.22 0.01"></a-text>
       </a-plane>
 
       <!-- Active status effects are shown on a panel opposite the score. -->

--- a/script.js
+++ b/script.js
@@ -118,7 +118,9 @@ window.addEventListener('load', () => {
     const statusText = document.getElementById('statusText');
     const statusEffectsText = document.getElementById('statusEffectsText');
     const offPowerText = document.getElementById('offPowerText');
+    const offPowerQueueText = document.getElementById('offPowerQueueText');
     const defPowerText = document.getElementById('defPowerText');
+    const defPowerQueueText = document.getElementById('defPowerQueueText');
     const bossPanel = document.getElementById('bossPanel');
     const bossNameText = document.getElementById('bossNameText');
     const bossHpText = document.getElementById('bossHpText');
@@ -183,6 +185,12 @@ window.addEventListener('load', () => {
         const defKey = state.defensiveInventory[0];
         offPowerText.setAttribute('value', offKey ? powers[offKey].emoji : '');
         defPowerText.setAttribute('value', defKey ? powers[defKey].emoji : '');
+      }
+      if (offPowerQueueText && defPowerQueueText) {
+        const offNext = state.offensiveInventory.slice(1).filter(Boolean).map(k => powers[k].emoji).join(' ');
+        const defNext = state.defensiveInventory.slice(1).filter(Boolean).map(k => powers[k].emoji).join(' ');
+        offPowerQueueText.setAttribute('value', offNext);
+        defPowerQueueText.setAttribute('value', defNext);
       }
       const now = performance.now();
       const elapsed = (now - gameState.lastCoreUse) / 1000;
@@ -445,6 +453,21 @@ window.addEventListener('load', () => {
       rightHand.addEventListener('triggerdown', () => {
         const key = state.defensiveInventory[0];
         if (key) usePower(key);
+      });
+      // Cycle powers with the grip buttons
+      leftHand.addEventListener('gripdown', () => {
+        if (state.offensiveInventory.filter(Boolean).length > 1) {
+          state.offensiveInventory.push(state.offensiveInventory.shift());
+          AudioManager.playSfx('uiHoverSound');
+          updateUI();
+        }
+      });
+      rightHand.addEventListener('gripdown', () => {
+        if (state.defensiveInventory.filter(Boolean).length > 1) {
+          state.defensiveInventory.push(state.defensiveInventory.shift());
+          AudioManager.playSfx('uiHoverSound');
+          updateUI();
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- show upcoming powers in VR UI panels
- cycle offensive and defensive power queues with controller grip buttons
- document new functionality in README

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6885b3c9eac083318081494223788071