### PR TITLE
Add additional VR UI elements and fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,13 +72,14 @@
          player so it is easily visible when glancing down at the table.  Two
          text elements display the current score and health; they are updated
          dynamically by script.js every frame. -->
-    <a-plane id="scorePanel" width="1.2" height="0.9"
+    <a-plane id="scorePanel" width="1.2" height="1.1"
              material="color: #141428; opacity: 0.9" position="2 1.2 -0.5" rotation="0 -30 0">
       <!-- Score and health text adopt the original game’s pale font colour. -->
       <a-text id="scoreText" value="Essence: 0" position="0 0.28 0.01" align="center" width="1.0" color="#eaf2ff"></a-text>
       <a-text id="healthText" value="Health: 100" position="0 0.05 0.01" align="center" width="1.0" color="#eaf2ff"></a-text>
       <a-text id="levelText" value="Level: 1" position="0 -0.18 0.01" align="center" width="1.0" color="#eaf2ff"></a-text>
       <a-text id="stageText" value="Stage: 1" position="0 -0.41 0.01" align="center" width="1.0" color="#eaf2ff"></a-text>
+      <a-text id="apText" value="AP: 0" position="0 -0.64 0.01" align="center" width="1.0" color="#eaf2ff"></a-text>
     </a-plane>
     <!-- Panels showing the currently equipped offensive and defensive powers.
          The emojis update each frame and the triggers on the VR controllers
@@ -288,6 +289,18 @@
       <label>SFX <input type="range" id="sfxVolume" min="0" max="1" step="0.01"></label>
       <button id="muteToggle">Mute</button>
       <button id="closeSoundOptionsBtn" class="btn-modal-close">Close</button>
+    </div>
+  </div>
+  <div id="bossBanner"></div>
+  <div id="unlock-notification"></div>
+  <div id="custom-confirm" style="display:none;">
+    <div id="custom-confirm-box">
+      <div id="custom-confirm-title"></div>
+      <div id="custom-confirm-text"></div>
+      <div id="custom-confirm-actions">
+        <button id="confirm-yes">Yes</button>
+        <button id="confirm-no">No</button>
+      </div>
     </div>
   </div>
 </body>

--- a/script.js
+++ b/script.js
@@ -117,6 +117,7 @@ window.addEventListener('load', () => {
     const cooldownText = document.getElementById('cooldownText');
     const statusText = document.getElementById('statusText');
     const statusEffectsText = document.getElementById('statusEffectsText');
+    const apText = document.getElementById('apText');
     const offPowerText = document.getElementById('offPowerText');
     const offPowerQueueText = document.getElementById('offPowerQueueText');
     const defPowerText = document.getElementById('defPowerText');
@@ -156,6 +157,7 @@ window.addEventListener('load', () => {
     const muteToggle = document.getElementById("muteToggle");
     const bossInfoModal = document.getElementById("bossInfoModal");
     const closeBossInfoModalBtn = document.getElementById("closeBossInfoModalBtn");
+    const playerAvatar = document.getElementById('playerAvatar');
     const maxStage = STAGE_CONFIG.length;
     const audioEls = Array.from(document.querySelectorAll(".game-audio"));
     AudioManager.setup(audioEls, muteToggle);
@@ -180,6 +182,9 @@ window.addEventListener('load', () => {
       healthText.setAttribute('value', `Health: ${Math.floor(health)}`);
       levelText.setAttribute('value', `Level: ${state.player.level}`);
       stageText.setAttribute('value', `Stage: ${state.currentStage}`);
+      if (apText) {
+        apText.setAttribute('value', `AP: ${state.player.ascensionPoints}`);
+      }
       if (offPowerText && defPowerText) {
         const offKey = state.offensiveInventory[0];
         const defKey = state.defensiveInventory[0];
@@ -292,6 +297,11 @@ window.addEventListener('load', () => {
         gameState.lastCoreUse = -Infinity;
         gameOverShown = false;
         statusText.setAttribute('value', '');
+        if (playerAvatar) {
+          playerAvatar.object3D.position.set(0, 1.0, -2);
+          gameState.playerPos.x = 0;
+          gameState.playerPos.z = -2;
+        }
         updateUI();
       });
     }
@@ -312,7 +322,7 @@ window.addEventListener('load', () => {
 
     if (stageSelectToggle && stageSelectPanel) {
       stageSelectToggle.addEventListener('click', () => {
-        if (stageSelectPanel.getAttribute('visible') === true || stageSelectPanel.getAttribute('visible') === 'true') {
+        if (stageSelectPanel.getAttribute('visible') === 'true') {
           stageSelectPanel.setAttribute('visible', 'false');
         } else {
           selectedStage = state.currentStage;
@@ -342,6 +352,11 @@ window.addEventListener('load', () => {
         gameOverShown = false;
         stageSelectPanel.setAttribute('visible', 'false');
         statusText.setAttribute('value', '');
+        if (playerAvatar) {
+          playerAvatar.object3D.position.set(0, 1.0, -2);
+          gameState.playerPos.x = 0;
+          gameState.playerPos.z = -2;
+        }
         updateUI();
       });
     }
@@ -354,6 +369,11 @@ window.addEventListener('load', () => {
       gameOverShown = false;
       orreryModal.style.display = 'none';
       statusText.setAttribute('value', '');
+      if (playerAvatar) {
+        playerAvatar.object3D.position.set(0, 1.0, -2);
+        gameState.playerPos.x = 0;
+        gameState.playerPos.z = -2;
+      }
       updateUI();
     }
 
@@ -493,7 +513,6 @@ window.addEventListener('load', () => {
     // into 2D canvas coordinates and assign them to `state.player.x` and
     // `state.player.y`.  Feel free to adjust this mapping to better fit
     // the gameplay surface.
-    const playerAvatar = document.getElementById('playerAvatar');
     playerAvatar.addEventListener('dragend', evt => {
       const pos3D = evt.detail.target.object3D.position;
       // Clamp to the platform radius so the avatar cannot be dragged off


### PR DESCRIPTION
## Summary
- show Ascension Points on VR scoreboard
- include additional DOM overlays from original UI
- fix stage select toggle logic
- reset player avatar position when restarting or starting new encounters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885b762720483319f2f62562265fc26