### PR TITLE
Improve VR feature controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ development.
 * **Power queue cycling** — Use the grip buttons on your VR controllers to
   rotate through your offensive and defensive power queues. Upcoming powers are
   shown beneath the main icons so you always know what will trigger next.
+* **Controller shortcuts** — Face buttons open common menus (A: stage select,
+  B: pause, X: core menu, Y: ascension grid). Press the left thumbstick for the
+  lore codex and the right thumbstick for the orrery menu.
 
 ## Running the Prototype
 

--- a/script.js
+++ b/script.js
@@ -38,8 +38,8 @@
   import { state, resetGame, savePlayerState } from './modules/state.js';
   import { activateCorePower } from './modules/cores.js';
   import { usePower, powers } from './modules/powers.js';
-  import { applyAllTalentEffects } from './modules/ascension.js';
-  import { populateAberrationCoreMenu, populateOrreryMenu } from './modules/ui.js';
+import { applyAllTalentEffects, renderAscensionGrid } from './modules/ascension.js';
+import { populateAberrationCoreMenu, populateOrreryMenu, populateLoreCodex } from './modules/ui.js';
   import { STAGE_CONFIG } from './modules/config.js';
 import { AudioManager } from "./modules/audio.js";
 // Register a component that applies a 2D canvas as a live texture
@@ -504,6 +504,14 @@ window.addEventListener('load', () => {
       });
       leftHand.addEventListener('ybuttondown', () => {
         if (ascensionToggle) ascensionToggle.emit('click');
+      });
+
+      // Thumbstick presses for additional menus
+      leftHand.addEventListener('thumbstickdown', () => {
+        if (codexToggle) codexToggle.emit('click');
+      });
+      rightHand.addEventListener('thumbstickdown', () => {
+        if (orreryToggle) orreryToggle.emit('click');
       });
     }
 


### PR DESCRIPTION
## Summary
- fix missing imports for `renderAscensionGrid` and `populateLoreCodex`
- add thumbstick shortcuts for codex and orrery menus
- document controller shortcuts in the README

## Testing
- `node --check script.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6885b929e5ec8331951bd53fa3fc7074