### PR TITLE
Fix VR startup logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,19 @@
   -->
   <canvas id="gameCanvas" width="2048" height="1024" style="display:none;"></canvas>
 
+  <!-- Simple home screen overlay inspired by the original layout -->
+  <div id="home-screen" class="visible">
+    <video autoplay muted loop playsinline id="home-video-bg" preload="none">
+      <source src="assets/home.mp4" type="video/mp4">
+    </video>
+    <div id="home-overlay">
+      <h1 id="game-title">ETERNAL MOMENTUM VR</h1>
+      <div id="home-actions">
+        <button id="start-vr-btn" class="home-btn">BEGIN</button>
+      </div>
+    </div>
+  </div>
+
   <a-scene embedded background="color: #000">
     <!-- Asset management for the scene.  The original VR prototype loaded a looping
          core sound here, but that audio has been removed at the user’s

--- a/script.js
+++ b/script.js
@@ -158,6 +158,8 @@ window.addEventListener('load', () => {
     const bossInfoModal = document.getElementById("bossInfoModal");
     const closeBossInfoModalBtn = document.getElementById("closeBossInfoModalBtn");
     const playerAvatar = document.getElementById('playerAvatar');
+    const homeScreen = document.getElementById('home-screen');
+    const startVrBtn = document.getElementById('start-vr-btn');
     const maxStage = STAGE_CONFIG.length;
     const audioEls = Array.from(document.querySelectorAll(".game-audio"));
     AudioManager.setup(audioEls, muteToggle);
@@ -358,6 +360,12 @@ window.addEventListener('load', () => {
           gameState.playerPos.z = -2;
         }
         updateUI();
+      });
+    }
+
+    if (startVrBtn && homeScreen) {
+      startVrBtn.addEventListener('click', () => {
+        homeScreen.style.display = 'none';
       });
     }
 
@@ -588,7 +596,9 @@ window.addEventListener('load', () => {
       // Advance the game if possible
       if (typeof gameTick === 'function') {
         try {
-          gameTick();
+          // Pass the player's current coordinates as both the cursor
+          // and player position so the game logic remains stable.
+          gameTick(state.player.x, state.player.y);
         } catch (e) {
           console.warn('gameTick threw an error', e);
           drawGameCanvasFallback();


### PR DESCRIPTION
## Summary
- add a simple home screen overlay
- hide the overlay when clicking "BEGIN"
- call `gameTick` with player coordinates so the game loop runs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6885bf6a5bcc8331a034b06c8b08f42d