### PR TITLE
Clarify VR vision and replace game screen with cylinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,20 @@ three‑dimensional VR environment using modern WebXR technologies.  It is not
 a complete game, but rather a polished starting point for further
 development.
 
+## VR Philosophy
+
+Eternal Momentum VR aims to preserve the feel of the original 2D game while
+placing the player inside a spacious arena.  Instead of running around in VR,
+you stand on a platform and project a laser pointer from your controller
+onto a huge **180° curved screen** that surrounds you.  The on‑screen avatar
+follows this pointer just like a mouse cursor on a monitor.  All familiar UI
+elements appear on the surrounding table so you can play entirely from this
+balcony‑like viewpoint.  A full 3D version may come later, but the current
+focus is making every original mechanic comfortable to use in VR.
+
 ## Features
 
-* **Large game screen** — The 2D game canvas appears on a floating panel in front of you. Point at the screen with your controller to move your character.
+* **Large curved screen** — The 2D game canvas is mapped onto a 180° cylinder around you. Point at the screen with your controller to steer your character.
 * **Waist‑height UI table** — A circular table surrounds the player at
   waist level.  Score, health and aberration core cooldown indicators are
   presented on panels placed on the table so they are easy to glance at
@@ -19,7 +30,8 @@ development.
   triggers together activates the core’s ability and starts its cooldown
   timer.  The sphere is interactive and can be extended with more mechanics
   (e.g. grabbing or swapping cores).
-* **Pointer-based movement** — Aim at the game screen with your controller and click to set your position.
+* **Pointer-based movement** — Raise your hand to project a cursor on the curved screen. Your on-screen avatar follows the pointer automatically.
+* **Cursor marker** — A small draggable sphere on the table lets you reposition your on-screen avatar if pointing is inconvenient.
 * **Directional audio** — The aberration core emits a continuous tone
   (`assets/core_sound.wav`) which gets quieter as you move away or turn
   your head, giving a sense of spatial presence.

--- a/index.html
+++ b/index.html
@@ -62,8 +62,8 @@
 
     <!-- Camera rig.  It contains the camera and both controllers.  The rig is positioned
          so that the player's eyes start at 1.6 m above the platform.  Movement
-         controls are disabled because this game uses a stationary platform; users
-         move their avatar by grabbing and dragging the box. -->
+        controls are disabled because this game uses a stationary platform; users
+         move their on-screen avatar by grabbing and dragging the small marker on the table. -->
     <a-entity id="rig" position="0 1.6 0">
       <a-camera id="camera" wasd-controls-enabled="false"></a-camera>
       <!-- Left hand controller with laser pointer and interaction components -->
@@ -122,6 +122,11 @@
                position="-2 1.2 -0.5" rotation="0 30 0">
         <a-text id="statusEffectsText" value="" align="center" width="1.1" color="#eaf2ff"></a-text>
       </a-plane>
+
+      <!-- Draggable marker showing where the on-screen avatar is positioned -->
+      <a-sphere id="cursorMarker" radius="0.15"
+                material="color: #00aaff; emissive: #00aaff; emissiveIntensity: 0.6"
+                position="0 1 0" class="interactive grabbable draggable"></a-sphere>
 
     <!-- Aberration core representation.  A glowing sphere slowly spins and
          emits a continuous tone using positional audio.  When the core’s
@@ -217,8 +222,13 @@
         <a-text value="Start" align="center" width="0.7" color="#eaf2ff"></a-text>
       </a-plane>
     </a-plane>
-    <!-- Large screen showing the 2D game canvas -->
-    <a-plane id="gameScreen" width="4" height="2" position="0 1.6 -3" material="color: #21213c" canvas-texture="#gameCanvas" class="interactive"></a-plane>
+    <!-- Large cylindrical screen showing the 2D game canvas
+         The canvas wraps 180° around the player so pointing the controller
+         feels like using a giant curved monitor. -->
+    <a-cylinder id="gameScreen" radius="4" height="2" theta-length="180"
+                position="0 1.6 0" rotation="0 -90 0"
+                material="color: #21213c; side:double"
+                canvas-texture="#gameCanvas" class="interactive"></a-cylinder>
     
     <!-- script.js contains game logic and canvas updates.  Load it as an ES module so it can import the game's modules and call into them. -->
     <a-plane id="aberrationCorePanel" width="2.2" height="1.3" position="0 1.6 -1.5" material="shader: html; target: #aberrationCoreModal; transparent: true" visible="false" class="interactive"></a-plane>


### PR DESCRIPTION
## Summary
- explain the curved-screen philosophy in README
- update features to mention pointer movement and curved screen
- implement the game screen as a 180° cylinder in `index.html`

## Testing
- `node --check script.js`
- `node --check modules/gameLoop.js`


------
https://chatgpt.com/codex/tasks/task_e_6886257c7a2c833183deaad8a9831adc