### PR TITLE
Fix VR controller references

### DIFF
--- a/script.js
+++ b/script.js
@@ -165,6 +165,8 @@ window.addEventListener('load', () => {
     const maxStage = STAGE_CONFIG.length;
     const audioEls = Array.from(document.querySelectorAll(".game-audio"));
     const gameScreen = document.getElementById("gameScreen");
+    const leftHand = document.getElementById("leftHand");
+    const rightHand = document.getElementById("rightHand");
     AudioManager.setup(audioEls, muteToggle);
     document.addEventListener("visibilitychange", () => AudioManager.handleVisibilityChange());
     let selectedStage = state.currentStage;


### PR DESCRIPTION
## Summary
- attach `leftHand` and `rightHand` DOM references in `script.js`

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6886306aa4e4833191dcf30e5798f85f