### PR TITLE
Fix VR controller references

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,14 @@
       <!-- Intentionally left empty to avoid unwanted sounds. -->
       <audio id="bgMusic1" class="game-audio" src="assets/bgMusic_01.mp3" preload="auto" loop></audio>
       <audio id="bgMusic2" class="game-audio" src="assets/bgMusic_02.mp3" preload="auto" loop></audio>
+      <audio id="uiHoverSound" class="game-audio" src="assets/uiHoverSound.mp3" preload="auto"></audio>
+      <audio id="uiClickSound" class="game-audio" src="assets/uiClickSound.mp3" preload="auto"></audio>
+      <audio id="uiModalOpen" class="game-audio" src="assets/uiModalOpen.mp3" preload="auto"></audio>
+      <audio id="uiModalClose" class="game-audio" src="assets/uiModalClose.mp3" preload="auto"></audio>
+      <audio id="talentPurchase" class="game-audio" src="assets/talentPurchase.mp3" preload="auto"></audio>
+      <audio id="talentError" class="game-audio" src="assets/talentError.mp3" preload="auto"></audio>
+      <audio id="bossSpawnSound" class="game-audio" src="assets/bossSpawnSound.mp3" preload="auto"></audio>
+      <audio id="bossDefeatSound" class="game-audio" src="assets/bossDefeatSound.mp3" preload="auto"></audio>
       <!-- Cosmic background used for the skybox so the scene matches the original game's vibe -->
       <img id="spaceBackground" src="assets/bg.png">
     </a-assets>

--- a/script.js
+++ b/script.js
@@ -165,6 +165,8 @@ window.addEventListener('load', () => {
     const maxStage = STAGE_CONFIG.length;
     const audioEls = Array.from(document.querySelectorAll(".game-audio"));
     const gameScreen = document.getElementById("gameScreen");
+    const leftHand = document.getElementById("leftHand");
+    const rightHand = document.getElementById("rightHand");
     AudioManager.setup(audioEls, muteToggle);
     document.addEventListener("visibilitychange", () => AudioManager.handleVisibilityChange());
     let selectedStage = state.currentStage;
@@ -349,6 +351,7 @@ window.addEventListener('load', () => {
 
     if (startVrBtn && homeScreen) {
       startVrBtn.addEventListener('click', () => {
+        AudioManager.unlockAudio();
         homeScreen.style.display = 'none';
       });
     }


### PR DESCRIPTION
## Summary
- attach `leftHand` and `rightHand` DOM references in `script.js`
- add SFX audio tags so original sounds work in VR
- unlock audio when starting VR

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_6886306aa4e4833191dcf30e5798f85f