### PR TITLE
Implement VR game over menu and multi-boss HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,11 +160,11 @@
       <a-text id="statusText" value="" align="center" width="1.2" color="#eaf2ff"></a-text>
     </a-plane>
 
-    <a-plane id="bossPanel" width="1.4" height="0.3"
+    <a-plane id="bossPanel" width="1.4" height="0.5"
              material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
              position="0 1.7 -1.5" rotation="0 0 0" visible="false">
-      <a-text id="bossNameText" value="" align="center" width="1.2" position="0 0.1 0.01" color="#ff5555"></a-text>
-      <a-text id="bossHpText" value="" align="center" width="1.2" position="0 -0.12 0.01" color="#eaf2ff"></a-text>
+      <a-text id="bossNameText" value="" align="center" width="1.2" position="0 0.17 0.01" color="#ff5555"></a-text>
+      <a-text id="bossHpText" value="" align="center" width="1.2" position="0 -0.17 0.01" color="#eaf2ff"></a-text>
     </a-plane>
 
     <a-plane id="resetButton" width="0.6" height="0.2"
@@ -247,6 +247,7 @@
     <a-plane id="bossInfoPanel" width="2.2" height="1.2" position="0 1.6 -1.5" material="shader: html; target: #bossInfoModal; transparent: true" visible="false" class="interactive"></a-plane>
     <a-plane id="orreryPanel" width="2.6" height="1.5" position="0 1.6 -1.6" material="shader: html; target: #orreryModal; transparent: true" visible="false" class="interactive"></a-plane>
     <a-plane id="soundOptionsPanel" width="1.6" height="1.2" position="0 1.6 -1.4" material="shader: html; target: #soundOptionsModal; transparent: true" visible="false" class="interactive"></a-plane>
+    <a-plane id="gameOverPanel" width="2" height="1.1" position="0 1.6 -1.5" material="shader: html; target: #gameOverMenu; transparent: true" visible="false" class="interactive"></a-plane>
   <script type="module" src="script.js"></script>
   </a-scene>
 
@@ -317,6 +318,15 @@
       <label>SFX <input type="range" id="sfxVolume" min="0" max="1" step="0.01"></label>
       <button id="muteToggle">Mute</button>
       <button id="closeSoundOptionsBtn" class="btn-modal-close">Close</button>
+    </div>
+  </div>
+  <div id="gameOverMenu" class="vr-source">
+    <h1>TIMELINE COLLAPSED</h1>
+    <div id="gameOverActions">
+      <button id="restartStageBtn">Restart Stage</button>
+      <button id="ascensionMenuBtn">Ascension Conduit</button>
+      <button id="aberrationCoreMenuBtn">Aberration Cores</button>
+      <button id="levelSelectMenuBtn">Stage Select</button>
     </div>
   </div>
   <div id="bossBanner"></div>

--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -346,8 +346,12 @@ export function gameTick(mx, my) {
         stopAllLoopingSounds();
         const gameOverMenu = document.getElementById('gameOverMenu');
         const aberrationBtn = document.getElementById('aberrationCoreMenuBtn');
-        aberrationBtn.style.display = state.player.level >= 10 ? 'block' : 'none';
-        if (gameOverMenu.style.display !== 'flex') gameOverMenu.style.display = 'flex';
+        if (aberrationBtn) {
+            aberrationBtn.style.display = state.player.level >= 10 ? 'block' : 'none';
+        }
+        if (gameOverMenu && gameOverMenu.style.display !== 'flex') {
+            gameOverMenu.style.display = 'flex';
+        }
         return false;
     }
 

--- a/script.js
+++ b/script.js
@@ -159,6 +159,11 @@ window.addEventListener('load', () => {
     const orreryPanel = document.getElementById("orreryPanel");
     const soundOptionsPanel = document.getElementById("soundOptionsPanel");
     const muteToggle = document.getElementById("muteToggle");
+    const gameOverPanel = document.getElementById("gameOverPanel");
+    const restartStageBtn = document.getElementById("restartStageBtn");
+    const levelSelectMenuBtn = document.getElementById("levelSelectMenuBtn");
+    const ascensionMenuBtn = document.getElementById("ascensionMenuBtn");
+    const aberrationCoreMenuBtn = document.getElementById("aberrationCoreMenuBtn");
     const bossInfoModal = document.getElementById("bossInfoModal");
     const closeBossInfoModalBtn = document.getElementById("closeBossInfoModalBtn");    const homeScreen = document.getElementById('home-screen');
     const startVrBtn = document.getElementById('start-vr-btn');
@@ -230,11 +235,13 @@ window.addEventListener('load', () => {
       }
 
       if (bossPanel && bossNameText && bossHpText) {
-        const boss = state.enemies.find(e => e.boss);
-        if (boss) {
+        const bosses = state.enemies.filter(e => e.boss);
+        if (bosses.length > 0) {
           bossPanel.setAttribute('visible', 'true');
-          bossNameText.setAttribute('value', boss.name || 'Boss');
-          bossHpText.setAttribute('value', `HP: ${Math.floor(boss.hp)} / ${boss.maxHP}`);
+          const names = bosses.map(b => b.name || 'Boss').join('\n');
+          const hpLines = bosses.map(b => `HP: ${Math.floor(b.hp)} / ${b.maxHP}`).join('\n');
+          bossNameText.setAttribute('value', names);
+          bossHpText.setAttribute('value', hpLines);
         } else {
           bossPanel.setAttribute('visible', 'false');
         }
@@ -369,6 +376,43 @@ window.addEventListener('load', () => {
         stageSelectPanel.setAttribute('visible', 'false');
         statusText.setAttribute('value', '');
         updateUI();
+      });
+    }
+
+    function restartCurrentStage() {
+      resetGame(false);
+      applyAllTalentEffects();
+      gameState.lastCoreUse = -Infinity;
+      gameOverShown = false;
+      if (gameOverPanel) gameOverPanel.setAttribute('visible', 'false');
+      statusText.setAttribute('value', '');
+      updateUI();
+    }
+
+    if (restartStageBtn) {
+      restartStageBtn.addEventListener('click', () => {
+        restartCurrentStage();
+      });
+    }
+
+    if (levelSelectMenuBtn && stageSelectToggle) {
+      levelSelectMenuBtn.addEventListener('click', () => {
+        if (gameOverPanel) gameOverPanel.setAttribute('visible', 'false');
+        stageSelectToggle.emit('click');
+      });
+    }
+
+    if (ascensionMenuBtn && ascensionToggle) {
+      ascensionMenuBtn.addEventListener('click', () => {
+        if (gameOverPanel) gameOverPanel.setAttribute('visible', 'false');
+        ascensionToggle.emit('click');
+      });
+    }
+
+    if (aberrationCoreMenuBtn && coreMenuToggle) {
+      aberrationCoreMenuBtn.addEventListener('click', () => {
+        if (gameOverPanel) gameOverPanel.setAttribute('visible', 'false');
+        coreMenuToggle.emit('click');
       });
     }
 
@@ -642,7 +686,11 @@ window.addEventListener('load', () => {
       if (state.gameOver && !gameOverShown) {
         if (statusTimeout) clearTimeout(statusTimeout);
         statusText.setAttribute('value', 'GAME OVER');
+        if (gameOverPanel) gameOverPanel.setAttribute('visible', 'true');
         gameOverShown = true;
+      } else if (!state.gameOver && gameOverShown) {
+        if (gameOverPanel) gameOverPanel.setAttribute('visible', 'false');
+        gameOverShown = false;
       }
 
       // Update UI panels


### PR DESCRIPTION
## Summary
- add a VR overlay for the game-over menu so stages can be restarted in-headset
- hook up buttons in the new menu to existing scene toggles
- display all active bosses in VR HUD instead of only the first
- avoid crashes when DOM game-over elements are missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886426704cc8331bc0b97f3440858a8