### PR TITLE
Add health-based vignette effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,13 @@
         controls are disabled because this game uses a stationary platform; users
          move their on-screen avatar by grabbing and dragging the small marker on the table. -->
     <a-entity id="rig" position="0 1.6 0">
-      <a-camera id="camera" wasd-controls-enabled="false"></a-camera>
+      <a-camera id="camera" wasd-controls-enabled="false">
+        <!-- Vignette ring fades in as health gets low -->
+        <a-ring id="vignette" radius-inner="0.8" radius-outer="1.3"
+                position="0 0 -0.1"
+                material="color: #000; shader: flat; opacity: 0; transparent: true"
+                visible="false"></a-ring>
+      </a-camera>
       <!-- Left hand controller with laser pointer and interaction components -->
       <a-entity id="leftHand" laser-controls="hand: left" raycaster="objects: .interactive" super-hands></a-entity>
       <!-- Right hand controller -->

--- a/script.js
+++ b/script.js
@@ -187,6 +187,7 @@ window.addEventListener('load', () => {
     const screenCursor = document.getElementById("screenCursor");
     const leftHand = document.getElementById("leftHand");
     const rightHand = document.getElementById("rightHand");
+    const vignetteRing = document.getElementById("vignette");
     function triggerHaptic(el, intensity = 0.5, duration = 50) {
       const controller = el?.components["laser-controls"]?.controller ||
                         el?.components["tracked-controls"]?.controller;
@@ -222,6 +223,12 @@ window.addEventListener('load', () => {
       scoreText.setAttribute('value', `Essence: ${Math.floor(essence)}`);
       const health = state.player.health ?? 0;
       healthText.setAttribute('value', `Health: ${Math.floor(health)}`);
+      if (vignetteRing && state.player.maxHealth) {
+        const ratio = Math.max(0, Math.min(1, health / state.player.maxHealth));
+        const opacity = Math.min(0.6, (1 - ratio) * (1 - ratio) * 0.8);
+        vignetteRing.setAttribute('visible', opacity > 0.01);
+        vignetteRing.setAttribute('material', 'opacity', opacity);
+      }
       levelText.setAttribute('value', `Level: ${state.player.level}`);
       stageText.setAttribute('value', `Stage: ${state.currentStage}`);
       if (apText) {


### PR DESCRIPTION
## Summary
- add a dark vignette ring to the camera in `index.html`
- adjust `script.js` to fade the ring in as health drops

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688647de0c748331a789e9a19c1ecf57