### PR TITLE
Fix VR camera height

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ the neon look cohesive.
    open `index.html` in a WebXR‑capable desktop browser for a
    non‑VR preview.
 3. Aim your controller at the large screen and click to move your character. Click the red aberration core to trigger its cooldown.
+4. If the menus appear far below or above you, recenter your headset. The VR camera rig starts at the world origin so your real head height determines the in‑game eye level.
 
 ## Integrating the Full Game
 

--- a/index.html
+++ b/index.html
@@ -69,10 +69,11 @@
     <a-sky src="#spaceBackground" rotation="0 -90 0"></a-sky>
 
     <!-- Camera rig.  It contains the camera and both controllers.  The rig is positioned
-         so that the player's eyes start at 1.6 m above the platform.  Movement
-        controls are disabled because this game uses a stationary platform; users
-         move their on-screen avatar by grabbing and dragging the small marker on the table. -->
-    <a-entity id="rig" position="0 1.6 0">
+         at the origin so your real-world head height sets the in-game eye level.
+         Movement controls are disabled because this game uses a stationary platform;
+         players move their on-screen avatar by grabbing and dragging the small marker
+         on the table. -->
+    <a-entity id="rig" position="0 0 0">
       <a-camera id="camera" wasd-controls-enabled="false">
         <!-- Vignette ring fades in as health gets low -->
         <a-ring id="vignette" radius-inner="0.8" radius-outer="1.3"


### PR DESCRIPTION
## Summary
- set camera rig position to origin so player's real height matches VR eye level
- clarify VR height in README instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688649c1a6188331b6be03dc02dda4d6