### PR TITLE
Rework VR command deck

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
          <a-assets> block as needed. -->
     <a-assets>
       <!-- Intentionally left empty to avoid unwanted sounds. -->
+      <a-mixin id="console-button" geometry="primitive: box; width:0.6; height:0.2; depth:0.1" material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"></a-mixin>
       <audio id="bgMusic1" class="game-audio" src="assets/bgMusic_01.mp3" preload="auto" loop></audio>
       <audio id="bgMusic2" class="game-audio" src="assets/bgMusic_02.mp3" preload="auto" loop></audio>
       <audio id="uiHoverSound" class="game-audio" src="assets/uiHoverSound.mp3" preload="auto"></audio>
@@ -99,9 +100,12 @@
          multiple boxes to create a continuous table surface without seams. -->
     <!-- Waist‑high table encircling the player.  Use a semi‑transparent dark
          colour to match the original UI background. -->
-    <a-ring id="uiTable" radius-inner="3.4" radius-outer="3.6" theta-length="360"
-            rotation="-90 0 0" position="0 1 0"
-            material="color: #141428; opacity: 0.85; emissive: #00ffff; emissiveIntensity: 0.3"></a-ring>
+    <a-entity id="commandDeck">
+      <a-cylinder id="commandWalls" radius="4.5" height="2.5" open-ended="true"
+                  material="color: #0a0a14; opacity: 0.6; side: back"></a-cylinder>
+      <a-ring id="commandConsole" radius-inner="3.3" radius-outer="3.5" theta-length="360"
+              rotation="-90 0 0" position="0 1 0"
+              material="color: var(--dark-bg); opacity: 0.95; emissive: var(--primary-glow); emissiveIntensity: 0.3"></a-ring>
 
     <!-- Score and health panel.  Placed slightly forward and to the right of the
          player so it is easily visible when glancing down at the table.  Two
@@ -178,70 +182,49 @@
       <a-text id="bossHpText" value="" align="center" width="1.2" position="0 -0.17 0.01" color="#eaf2ff"></a-text>
     </a-plane>
 
-    <a-plane id="resetButton" width="0.6" height="0.2"
-             material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-             position="2 0.8 -1.2" rotation="0 -30 0" class="interactive">
-      <a-text value="Reset" align="center" width="0.5" color="#eaf2ff"></a-text>
-    </a-plane>
-    <a-plane id="pauseToggle" width="0.6" height="0.2"
-             material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-             position="2 0.95 -1.2" rotation="0 -30 0" class="interactive">
-      <a-text id="pauseText" value="Pause" align="center" width="0.5" color="#eaf2ff"></a-text>
-    </a-plane>
+    <a-entity id="resetButton" mixin="console-button" position="2 0.8 -1.2" rotation="0 -30 0" class="interactive">
+      <a-text value="Reset" align="center" width="0.5" color="#eaf2ff" position="0 0 0.06"></a-text>
+    </a-entity>
+    <a-entity id="pauseToggle" mixin="console-button" position="2 0.95 -1.2" rotation="0 -30 0" class="interactive">
+      <a-text id="pauseText" value="Pause" align="center" width="0.5" color="#eaf2ff" position="0 0 0.06"></a-text>
+    </a-entity>
 
-    <a-plane id="stageSelectToggle" width="0.8" height="0.2"
-             material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-             position="2 1.05 -1.2" rotation="0 -30 0" class="interactive">
-      <a-text value="Stage Select" align="center" width="0.7" color="#eaf2ff"></a-text>
-    </a-plane>
+    <a-entity id="stageSelectToggle" mixin="console-button" position="2 1.05 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+      <a-text value="Stage Select" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+    </a-entity>
 
-    <a-plane id="coreMenuToggle" width="0.8" height="0.2"
-             material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-             position="2 1.3 -1.2" rotation="0 -30 0" class="interactive">
-      <a-text value="Core Menu" align="center" width="0.7" color="#eaf2ff"></a-text>
-    </a-plane>
-    <a-plane id="ascensionToggle" width="0.8" height="0.2"
-             material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-             position="2 1.55 -1.2" rotation="0 -30 0" class="interactive">
-      <a-text value="Ascension" align="center" width="0.7" color="#eaf2ff"></a-text>
-    </a-plane>
-    <a-plane id="codexToggle" width="0.8" height="0.2"
-             material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-             position="2 1.8 -1.2" rotation="0 -30 0" class="interactive">
-      <a-text value="Codex" align="center" width="0.7" color="#eaf2ff"></a-text>
-    </a-plane>
-    <a-plane id="orreryToggle" width="0.8" height="0.2"
-             material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-             position="2 2.05 -1.2" rotation="0 -30 0" class="interactive">
-      <a-text value="Orrery" align="center" width="0.7" color="#eaf2ff"></a-text>
-    </a-plane>
-    <a-plane id="soundOptionsToggle" width="0.8" height="0.2"
-             material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-             position="2 2.3 -1.2" rotation="0 -30 0" class="interactive">
-      <a-text value="Sound" align="center" width="0.7" color="#eaf2ff"></a-text>
-    </a-plane>
+    <a-entity id="coreMenuToggle" mixin="console-button" position="2 1.3 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+      <a-text value="Core Menu" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+    </a-entity>
+    <a-entity id="ascensionToggle" mixin="console-button" position="2 1.55 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+      <a-text value="Ascension" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+    </a-entity>
+    <a-entity id="codexToggle" mixin="console-button" position="2 1.8 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+      <a-text value="Codex" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+    </a-entity>
+    <a-entity id="orreryToggle" mixin="console-button" position="2 2.05 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+      <a-text value="Orrery" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+    </a-entity>
+    <a-entity id="soundOptionsToggle" mixin="console-button" position="2 2.3 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+      <a-text value="Sound" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+    </a-entity>
 
     <a-plane id="stageSelectPanel" width="1.4" height="0.8" visible="false"
              material="color: #141428; opacity: 0.95; emissive: #00ffff; emissiveIntensity: 0.25"
              position="0 1.6 -1.5" rotation="0 0 0">
       <a-text id="stageSelectLabel" value="Stage: 1" align="center" width="1.2"
               position="0 0.25 0.01" color="#eaf2ff"></a-text>
-      <a-plane id="prevStageBtn" width="0.4" height="0.2" class="interactive"
-               material="color: #333; emissive: #00ffff; emissiveIntensity: 0.2"
-               position="-0.45 -0.05 0.01">
-        <a-text value="Prev" align="center" width="0.4" color="#eaf2ff"></a-text>
-      </a-plane>
-      <a-plane id="nextStageBtn" width="0.4" height="0.2" class="interactive"
-               material="color: #333; emissive: #00ffff; emissiveIntensity: 0.2"
-               position="0.45 -0.05 0.01">
-        <a-text value="Next" align="center" width="0.4" color="#eaf2ff"></a-text>
-      </a-plane>
-      <a-plane id="startStageBtn" width="0.8" height="0.25" class="interactive"
-               material="color: #555; emissive: #00ffff; emissiveIntensity: 0.2"
-               position="0 -0.35 0.01">
-        <a-text value="Start" align="center" width="0.7" color="#eaf2ff"></a-text>
-      </a-plane>
+      <a-entity id="prevStageBtn" mixin="console-button" position="-0.45 -0.05 0.01" class="interactive" geometry="width:0.4">
+        <a-text value="Prev" align="center" width="0.4" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
+      <a-entity id="nextStageBtn" mixin="console-button" position="0.45 -0.05 0.01" class="interactive" geometry="width:0.4">
+        <a-text value="Next" align="center" width="0.4" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
+      <a-entity id="startStageBtn" mixin="console-button" position="0 -0.35 0.01" class="interactive" geometry="width:0.8">
+        <a-text value="Start" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
     </a-plane>
+    </a-entity>
     <!-- 3D arena where the game action unfolds. The floor is a large plane below the command deck. Simple placeholders for the player avatar and enemies are added here and positioned each frame by script.js. -->
     <a-plane id="arenaFloor" width="12" height="6" rotation="-90 0 0" position="0 -2 -4" material="color:#21213c; emissive:#00ffff; emissiveIntensity:0.1" class="interactive"></a-plane>
     <a-entity id="enemyContainer"></a-entity>


### PR DESCRIPTION
## Summary
- add reusable `console-button` mixin for 3D buttons
- wrap UI in new `commandDeck` entity with walls and a `commandConsole` ring
- replace flat plane menu toggles with physical console buttons

## Testing
- `htmlhint index.html`
- `http-server` *(manual smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_688660d85f488331a8e63ba385c405d4