### PR TITLE
Player stays in command deck

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ The repository contains an early VR prototype and the complete 2D browser game s
 
 The Eternal‑Momentum‑OLD GAME/ directory houses the definitive 2D game logic. Treat this directory as read‑only and do not modify its contents. Use it only as a source of truth.
 
-The VR prototype uses the A‑Frame WebXR framework. The key entry point for VR logic is the top‑level script.js file.
+The VR prototype uses the A‑Frame WebXR framework. The key entry point for VR logic is the top‑level script.js file. Gameplay is viewed from a floating command deck with a transparent neon grid floor so the battlefield below remains visible and interactive.
 
 Core Directives for AI‑generated code
 Bridge, don’t rewrite – Do not modify files under Eternal‑Momentum‑OLD GAME/. Instead, import the necessary functions and the state object (from modules/state.js, modules/gameLoop.js and other modules) into script.js or other new VR modules. Run the gameTick loop and iterate through the state object each frame to update 3D objects’ positions, rotations and visibility

--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@
 
 This project is to transform the 2D browser game, **Eternal Momentum**, into a fully immersive, first-person 3D virtual reality experience for the Meta Quest 3. The current repository contains an early prototype and the complete, functional source code of the original 2D game. The primary directive for all future development is to evolve the prototype into the vision detailed below, using the original game's logic as the foundational engine.
 
-The core fantasy is that the player **is the Conduit**, physically situated within a high-tech command center. From a balcony-like platform, they look down upon a vast, 3D battlefield where the game's events unfold.
+The core fantasy is that the player **is the Conduit**, operating from a floating command deck high above an enormous battlefield. The floor of this deck is a luminous neon grid, allowing the player to look straight down and project a cursor through the gaps to direct the Conduit below.
 
 ---
 ## The Core Experience: Inside the Conduit
 
 ### 1. The Command Deck (Player Environment)
 
-The player does not stand on a simple platform; they are inside the Conduit's command deck. This is a sleek, futuristic environment that must be styled to match the aesthetic of the original game (dark backgrounds, neon glows, and the color palette defined in `style.css`).
+The Conduit remains on the battlefield while the player's viewpoint is anchored in the command deck above. UI panels float around the deck, styled with the familiar dark and neon aesthetic from `style.css`.
 
-* **Balcony View:** The player stands on a raised platform, giving them a commanding, top-down tactical view of the massive 3D game screen below. This creates a powerful sense of scale and strategic oversight.
-* **Wrap-Around Console:** In front of the player is a wrap-around desk or console. This console is a hybrid of screens and tactile controls, featuring **physical, 3D buttons** that glow and provide satisfying feedback when pressed.
+* **Overhead View:** Looking through the grid floor, the player can see the battlefield far below. The VR pointer passes through the grid so clicks register on the ground plane beneath.
+* **Floating Console Panels:** Status readouts and buttons surround the player, glowing and depressing when interacted with.
 
 ---
 ### 2. The 3D Gameplay Arena (The Timeline Projection)
 
-The current prototype's method of projecting the 2D canvas onto a cylinder is to be **completely replaced**. The gameplay will take place in a fully realized 3D space below the player's command deck.
+The battlefield has been expanded twentyfold compared to the early prototype. The neon grid is now merely the command deck's floor, hovering high above this massive arena. The Conduit avatar, enemies and projectiles move on the plane far below, all driven by the original game state.
 
 * **Full 3D Conversion:** All gameplay elements—the player's avatar (the Nexus), enemies, bosses (Aberrations), and projectiles—must be rendered as 3D objects.
 * **State-Driven Rendering:** The positions, animations, and behaviors of these 3D objects will be directly driven by the original game's state object (`state` from `modules/state.js`). The `gameTick` function will read the `x`, `y` coordinates from the 2D logic and translate them into `x`, `y`, `z` positions in the 3D A-Frame scene.

--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@
     battlefield.  Keep the canvas hidden in the DOM.
   -->
   <canvas id="gameCanvas" width="2048" height="1024" style="display:none;"></canvas>
+  <!-- Canvas used to generate the neon grid texture for the battlefield floor -->
+  <canvas id="gridCanvas" width="512" height="512" style="display:none;"></canvas>
 
   <!-- Simple home screen overlay inspired by the original layout -->
   <div id="home-screen" class="visible">
@@ -88,24 +90,8 @@
       <a-entity id="rightHand" laser-controls="hand: right" raycaster="objects: .interactive" super-hands></a-entity>
     </a-entity>
 
-    <!-- Circular platform on which the player stands.  The platform is slightly
-         raised above ground and large enough that the UI table sits outside
-         its edge. -->
-    <!-- Platform uses a dark color inspired by the original game’s UI. -->
-    <a-cylinder id="platform" radius="3.5" height="0.2" color="#1e1e2f" position="0 0 0"
-                material="color: #1e1e2f; emissive: #00ffff; emissiveIntensity: 0.15"></a-cylinder>
-
-    <!-- Waist‑high table encircling the player.  This is where status panels,
-         cooldown timers and other UI widgets live.  A ring is used instead of
-         multiple boxes to create a continuous table surface without seams. -->
-    <!-- Waist‑high table encircling the player.  Use a semi‑transparent dark
-         colour to match the original UI background. -->
+    <!-- Container for UI panels that float around the player -->
     <a-entity id="commandDeck">
-      <a-cylinder id="commandWalls" radius="4.5" height="2.5" open-ended="true"
-                  material="color: #0a0a14; opacity: 0.6; side: back"></a-cylinder>
-      <a-ring id="commandConsole" radius-inner="3.3" radius-outer="3.5" theta-length="360"
-              rotation="-90 0 0" position="0 1 0"
-              material="color: var(--dark-bg); opacity: 0.95; emissive: var(--primary-glow); emissiveIntensity: 0.3"></a-ring>
 
     <!-- Score and health panel.  Placed slightly forward and to the right of the
          player so it is easily visible when glancing down at the table.  Two
@@ -225,11 +211,18 @@
       </a-entity>
     </a-plane>
     </a-entity>
-    <!-- 3D arena where the game action unfolds. The floor is a large plane below the command deck. Simple placeholders for the player avatar and enemies are added here and positioned each frame by script.js. -->
-    <a-plane id="arenaFloor" width="12" height="6" rotation="-90 0 0" position="0 -2 -4" material="color:#21213c; emissive:#00ffff; emissiveIntensity:0.1" class="interactive"></a-plane>
+    <!-- 3D arena where the game action unfolds. The command deck hovers above a
+         massive battlefield. A transparent neon grid serves as the deck floor
+         so the action below remains visible and clickable. -->
+    <a-plane id="neonGrid" width="240" height="120" rotation="-90 0 0"
+             position="0 -0.01 0" canvas-texture="#gridCanvas"
+             material="transparent:true; opacity:0.8"></a-plane>
+    <a-plane id="battlefieldPlane" width="240" height="120" rotation="-90 0 0"
+             position="0 -2 0" material="color:#21213c; emissive:#00ffff; emissiveIntensity:0.05"
+             class="interactive"></a-plane>
     <a-entity id="enemyContainer"></a-entity>
     <a-entity id="projectileContainer"></a-entity>
-    <a-sphere id="playerAvatar" radius="0.25" color="#00ff80" position="0 -1.9 -4"></a-sphere>
+    <a-sphere id="playerAvatar" radius="0.25" color="#00ff80" position="0 0.1 0"></a-sphere>
     <a-ring id="screenCursor" radius-inner="0.03" radius-outer="0.05" color="#00ffff" visible="false"></a-ring>
     
     <!-- script.js contains game logic and canvas updates.  Load it as an ES module so it can import the game's modules and call into them. -->


### PR DESCRIPTION
## Summary
- clarify game setting: the command deck floats above a huge arena
- make the grid deck floor transparent and enlarge the battlefield twentyfold
- keep the Conduit on the battlefield while the player remains above
- document the design direction in README and AGENTS guidance

## Testing
- `npx -y http-server -p 8080`


------
https://chatgpt.com/codex/tasks/task_e_6886636fc5bc8331b20831e72f7aff26