### PR TITLE
Remove visible 2D canvas, add offscreen fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This README serves as the primary brief for AI development tools. Your core task
     * `modules/bosses.js` and `modules/powers.js`: Define the required behaviors for enemies and abilities.
     * `modules/state.js` and `modules/talents.js`: Define the necessary data structures and progression systems.
     * `style.css`: Contains the color variables and aesthetic style to be recreated in 3D materials.
+    * _Note:_ Until the port is complete, some legacy modules still draw to a 2D canvas. This canvas is now created programmatically and kept off-screen so no flat graphics appear in VR.
 
 2.  **Build a Native VR Engine:** You have the freedom to write and structure new JavaScript files (`script.js`, new modules, etc.) as needed to build a robust, 3D-native game. You are not merely bridging the old engine; you are building a new one based on its specifications.
     * Create a 3D-aware state management system.

--- a/index.html
+++ b/index.html
@@ -15,21 +15,6 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <!--
-    Hidden 2D canvas.  The original Eternal Momentum game renders into this
-    off‑screen canvas.  In this VR port the canvas content is wrapped
-    around the player on a cylinder so you can glance up and see the
-    familiar 2D battlefield in all directions.  Because the canvas is
-    hidden in the DOM, it does not interfere with VR rendering but its
-    contents are still updated every frame by script.js.
-  -->
-  <!--
-    Off‑screen canvas used by the original Eternal Momentum game.  Its ID is
-    "gameCanvas" to satisfy references inside the game code.  The cylinder
-    around the player uses this canvas as a texture to project the 2D
-    battlefield.  Keep the canvas hidden in the DOM.
-  -->
-  <canvas id="gameCanvas" width="2048" height="1024" style="display:none;"></canvas>
   <!-- Canvas used to generate the neon grid texture for the battlefield floor -->
   <canvas id="gridCanvas" width="512" height="512" style="display:none;"></canvas>
 

--- a/modules/cores.js
+++ b/modules/cores.js
@@ -145,7 +145,13 @@ export function activateCorePower(mx, my, gameHelpers) {
 export function applyCoreTickEffects(gameHelpers) {
   const now = Date.now();
   const { play } = gameHelpers;
-  const ctx = document.getElementById('gameCanvas').getContext('2d');
+  let canvas = document.getElementById('gameCanvas');
+  if (!canvas) {
+    canvas = document.createElement('canvas');
+    canvas.width = 2048;
+    canvas.height = 1024;
+  }
+  const ctx = canvas.getContext('2d');
   // --- Pantheon rotation ---
   if (state.player.equippedAberrationCore === 'pantheon') {
     const pantheonState = state.player.talent_states.core_states.pantheon;

--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -8,7 +8,13 @@ import * as utils from './utils.js';
 import { AudioManager } from './audio.js';
 import * as Cores from './cores.js';
 
-const canvas = document.getElementById("gameCanvas");
+let canvas = document.getElementById("gameCanvas");
+if (!canvas) {
+  canvas = document.createElement('canvas');
+  canvas.id = 'gameCanvas';
+  canvas.width = 2048;
+  canvas.height = 1024;
+}
 const ctx = canvas.getContext("2d");
 
 // --- Helper Function ---

--- a/modules/state.js
+++ b/modules/state.js
@@ -203,7 +203,13 @@ export function loadPlayerState() {
  * stage 1 regardless of the highest stage beaten.
  */
 export function resetGame(isArena = false) {
-  const canvas = document.getElementById('gameCanvas');
+  let canvas = document.getElementById('gameCanvas');
+  if (!canvas) {
+    canvas = document.createElement('canvas');
+    canvas.id = 'gameCanvas';
+    canvas.width = 2048;
+    canvas.height = 1024;
+  }
   // Place the player at the centre of the screen and fully heal them.
   state.player.x = canvas.width / 2;
   state.player.y = canvas.height / 2;

--- a/script.js
+++ b/script.js
@@ -85,9 +85,15 @@ import { AudioManager } from "./modules/audio.js";
   });
 // Once the DOM is fully loaded, set up the game state and event listeners
 window.addEventListener('load', () => {
-    // The hidden 2D canvas has the id "gameCanvas" in index.html.  Grab it here
-    // rather than the old "game2dCanvas" id to ensure the texture updates correctly.
-    const canvas = document.getElementById('gameCanvas');
+    // Create an offscreen canvas for legacy modules that still expect one.
+    // This canvas is not added to the DOM so no 2D elements are visible.
+    let canvas = document.getElementById('gameCanvas');
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      canvas.id = 'gameCanvas';
+      canvas.width = 2048;
+      canvas.height = 1024;
+    }
     const ctx = canvas.getContext('2d');
     const gridCanvas = document.getElementById('gridCanvas');
     if (gridCanvas) {


### PR DESCRIPTION
## Summary
- remove hidden gameCanvas from index.html
- create offscreen canvas in script.js and modules when none exists
- note offscreen canvas in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68866da296d4833198b381840c0c682b