### PR TITLE
Fix UI layout and spawn positions for VR beta issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,11 @@
          <a-assets> block as needed. -->
     <a-assets>
       <!-- Intentionally left empty to avoid unwanted sounds. -->
-      <a-mixin id="console-button" geometry="primitive: box; width:0.6; height:0.2; depth:0.1" material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"></a-mixin>
+      <a-mixin id="console-button"
+               geometry="primitive: cylinder; radius:0.3; height:0.1"
+               material="color:#141428; opacity:0.95; emissive:#00ffff; emissiveIntensity:0.6"
+               animation__press="property: scale; startEvents: mousedown; dir: alternate; dur: 100; to: 0.9 0.9 0.9"
+               animation__release="property: scale; startEvents: mouseup; dir: alternate; dur: 100; to: 1 1 1"></a-mixin>
       <audio id="bgMusic1" class="game-audio" src="assets/bgMusic_01.mp3" preload="auto" loop></audio>
       <audio id="bgMusic2" class="game-audio" src="assets/bgMusic_02.mp3" preload="auto" loop></audio>
       <audio id="uiHoverSound" class="game-audio" src="assets/uiHoverSound.mp3" preload="auto"></audio>
@@ -83,7 +87,8 @@
          text elements display the current score and health; they are updated
          dynamically by script.js every frame. -->
     <a-plane id="scorePanel" width="1.2" height="1.1"
-             material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25" position="2 1.2 -0.5" rotation="0 -30 0">
+             material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
+             position="1.6 1.2 -1.2" rotation="0 -20 0">
       <!-- Score and health text adopt the original game’s pale font colour. -->
       <a-text id="scoreText" value="Essence: 0" position="0 0.28 0.01" align="center" width="1.0" color="#eaf2ff"></a-text>
       <a-text id="healthText" value="Health: 100" position="0 0.05 0.01" align="center" width="1.0" color="#eaf2ff"></a-text>
@@ -96,13 +101,13 @@
          activate these powers. -->
     <a-plane id="offPowerPanel" width="0.3" height="0.3"
              material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-             position="1.6 1.2 -0.3" rotation="0 -30 0">
+             position="0.8 1.2 -1.6" rotation="0 -10 0">
       <a-text id="offPowerText" value="" align="center" width="0.3" color="#eaf2ff"></a-text>
       <a-text id="offPowerQueueText" value="" align="center" width="0.3" color="#eaf2ff" position="0 -0.22 0.01"></a-text>
     </a-plane>
       <a-plane id="defPowerPanel" width="0.3" height="0.3"
                material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-               position="1.6 1.2 -0.8" rotation="0 -30 0">
+               position="-0.8 1.2 -1.6" rotation="0 10 0">
         <a-text id="defPowerText" value="" align="center" width="0.3" color="#eaf2ff"></a-text>
         <a-text id="defPowerQueueText" value="" align="center" width="0.3" color="#eaf2ff" position="0 -0.22 0.01"></a-text>
       </a-plane>
@@ -110,7 +115,7 @@
       <!-- Active status effects are shown on a panel opposite the score. -->
       <a-plane id="statusEffectsPanel" width="1.2" height="0.3"
                material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-               position="-2 1.2 -0.5" rotation="0 30 0">
+               position="-1.6 1.2 -1.2" rotation="0 20 0">
         <a-text id="statusEffectsText" value="" align="center" width="1.1" color="#eaf2ff"></a-text>
       </a-plane>
 
@@ -153,30 +158,30 @@
       <a-text id="bossHpText" value="" align="center" width="1.2" position="0 -0.17 0.01" color="#eaf2ff"></a-text>
     </a-plane>
 
-    <a-entity id="resetButton" mixin="console-button" position="2 0.8 -1.2" rotation="0 -30 0" class="interactive">
+    <a-entity id="resetButton" mixin="console-button" position="1.4 0.8 -2" rotation="0 -40 0" class="interactive">
       <a-text value="Reset" align="center" width="0.5" color="#eaf2ff" position="0 0 0.06"></a-text>
     </a-entity>
-    <a-entity id="pauseToggle" mixin="console-button" position="2 0.95 -1.2" rotation="0 -30 0" class="interactive">
+    <a-entity id="pauseToggle" mixin="console-button" position="1.4 0.95 -2.2" rotation="0 -40 0" class="interactive">
       <a-text id="pauseText" value="Pause" align="center" width="0.5" color="#eaf2ff" position="0 0 0.06"></a-text>
     </a-entity>
 
-    <a-entity id="stageSelectToggle" mixin="console-button" position="2 1.05 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+    <a-entity id="stageSelectToggle" mixin="console-button" position="1.4 1.05 -2.4" rotation="0 -40 0" class="interactive" geometry="width:0.8">
       <a-text value="Stage Select" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
     </a-entity>
 
-    <a-entity id="coreMenuToggle" mixin="console-button" position="2 1.3 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+    <a-entity id="coreMenuToggle" mixin="console-button" position="0.9 1.3 -2.3" rotation="0 -30 0" class="interactive" geometry="width:0.8">
       <a-text value="Core Menu" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
     </a-entity>
-    <a-entity id="ascensionToggle" mixin="console-button" position="2 1.55 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+    <a-entity id="ascensionToggle" mixin="console-button" position="-0.9 1.55 -2.3" rotation="0 30 0" class="interactive" geometry="width:0.8">
       <a-text value="Ascension" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
     </a-entity>
-    <a-entity id="codexToggle" mixin="console-button" position="2 1.8 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+    <a-entity id="codexToggle" mixin="console-button" position="-1.4 1.8 -2.2" rotation="0 40 0" class="interactive" geometry="width:0.8">
       <a-text value="Codex" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
     </a-entity>
-    <a-entity id="orreryToggle" mixin="console-button" position="2 2.05 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+    <a-entity id="orreryToggle" mixin="console-button" position="-1.4 2.05 -2.4" rotation="0 40 0" class="interactive" geometry="width:0.8">
       <a-text value="Orrery" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
     </a-entity>
-    <a-entity id="soundOptionsToggle" mixin="console-button" position="2 2.3 -1.2" rotation="0 -30 0" class="interactive" geometry="width:0.8">
+    <a-entity id="soundOptionsToggle" mixin="console-button" position="-1.4 2.3 -2" rotation="0 40 0" class="interactive" geometry="width:0.8">
       <a-text value="Sound" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
     </a-entity>
 
@@ -208,7 +213,7 @@
               class="interactive"></a-sphere>
     <a-entity id="enemyContainer"></a-entity>
     <a-entity id="projectileContainer"></a-entity>
-    <a-sphere id="nexusAvatar" radius="0.25" color="#00ff80" position="0 0.1 0"></a-sphere>
+    <a-sphere id="nexusAvatar" radius="0.25" color="#00ff80" position="0 0 -8" rotation="0 0 0"></a-sphere>
     <a-ring id="screenCursor" radius-inner="0.03" radius-outer="0.05" color="#00ffff" visible="false"></a-ring>
     
     <!-- script.js contains game logic and canvas updates.  Load it as an ES module so it can import the game's modules and call into them. -->

--- a/script.js
+++ b/script.js
@@ -136,6 +136,9 @@ window.addEventListener('load', () => {
     const startUv = spherePosToUv(avatarPos);
     state.player.x = startUv.u * canvas.width;
     state.player.y = startUv.v * canvas.height;
+    if (nexusAvatar) {
+      nexusAvatar.object3D.position.copy(avatarPos);
+    }
 
     const CORE_COOLDOWNS = {
       juggernaut: 8000,
@@ -545,52 +548,61 @@ window.addEventListener('load', () => {
     if (coreMenuToggle && aberrationCorePanel) {
       coreMenuToggle.addEventListener('click', () => {
         populateAberrationCoreMenu(equipCore);
+        aberrationCoreModal.style.display = 'flex';
         aberrationCorePanel.setAttribute('visible', 'true');
       });
     }
     if (closeAberrationCoreBtn) {
       closeAberrationCoreBtn.addEventListener('click', () => {
         aberrationCorePanel.setAttribute('visible', 'false');
+        aberrationCoreModal.style.display = 'none';
       });
     }
     if (unequipCoreBtn) {
       unequipCoreBtn.addEventListener('click', () => {
         equipCore(null);
         aberrationCorePanel.setAttribute('visible', 'false');
+        aberrationCoreModal.style.display = 'none';
       });
     }
     if (ascensionToggle && ascensionGridPanel) {
       ascensionToggle.addEventListener('click', () => {
         apTotalAscGrid.innerText = state.player.ascensionPoints;
         renderAscensionGrid();
+        ascensionGridModal.style.display = 'block';
         ascensionGridPanel.setAttribute('visible', 'true');
       });
     }
     if (closeAscensionGridBtn) {
       closeAscensionGridBtn.addEventListener('click', () => {
         ascensionGridPanel.setAttribute('visible', 'false');
+        ascensionGridModal.style.display = 'none';
       });
     }
     if (codexToggle && loreCodexPanel) {
       codexToggle.addEventListener('click', () => {
         populateLoreCodex();
+        loreCodexModal.style.display = 'block';
         loreCodexPanel.setAttribute('visible', 'true');
       });
     }
     if (closeLoreCodexBtn) {
       closeLoreCodexBtn.addEventListener('click', () => {
         loreCodexPanel.setAttribute('visible', 'false');
+        loreCodexModal.style.display = 'none';
       });
     }
     if (orreryToggle && orreryPanel) {
       orreryToggle.addEventListener('click', () => {
         populateOrreryMenu(startOrreryEncounter);
+        orreryModal.style.display = 'block';
         orreryPanel.setAttribute('visible', 'true');
       });
     }
     if (closeOrreryBtn) {
       closeOrreryBtn.addEventListener('click', () => {
         orreryPanel.setAttribute('visible', 'false');
+        orreryModal.style.display = 'none';
       });
     }
     if (soundOptionsToggle && soundOptionsPanel) {
@@ -598,12 +610,14 @@ window.addEventListener('load', () => {
         musicVolume.value = AudioManager.musicVolume;
         sfxVolume.value = AudioManager.sfxVolume;
         muteToggle.innerText = AudioManager.userMuted ? 'Unmute' : 'Mute';
+        soundOptionsModal.style.display = 'block';
         soundOptionsPanel.setAttribute('visible', 'true');
       });
     }
     if (closeSoundOptionsBtn) {
       closeSoundOptionsBtn.addEventListener('click', () => {
         soundOptionsPanel.setAttribute('visible', 'false');
+        soundOptionsModal.style.display = 'none';
       });
     }
     if (muteToggle) {
@@ -841,6 +855,7 @@ window.addEventListener('load', () => {
           const id = e.instanceId;
           existing.add(id);
           let el = enemyContainer.querySelector(`[data-eid="${id}"]`);
+          const pos = uvToSpherePos(e.x / canvas.width, e.y / canvas.height, SPHERE_RADIUS);
           if (!el) {
             el = document.createElement('a-box');
             el.setAttribute('depth', 0.4);
@@ -848,9 +863,9 @@ window.addEventListener('load', () => {
             el.setAttribute('width', 0.4);
             el.setAttribute('color', '#ff4040');
             el.dataset.eid = id;
+            el.setAttribute('position', `${pos.x} ${pos.y} ${pos.z}`);
             enemyContainer.appendChild(el);
           }
-          const pos = uvToSpherePos(e.x / canvas.width, e.y / canvas.height, SPHERE_RADIUS);
           el.object3D.position.copy(pos);
           el.object3D.lookAt(0, 0, 0);
         });
@@ -868,18 +883,19 @@ window.addEventListener('load', () => {
           if (!projTypes.includes(effect.type)) return;
           let el = projectileEls.get(effect);
           active.add(effect);
+          const pos = uvToSpherePos(effect.x / canvas.width, effect.y / canvas.height, SPHERE_RADIUS);
           if (!el) {
             el = document.createElement('a-sphere');
             el.setAttribute('radius', 0.05);
             el.setAttribute('segments-height', 6);
             el.setAttribute('segments-width', 6);
             el.setAttribute('color', effect.color || '#ffd400');
+            el.setAttribute('position', `${pos.x} ${pos.y} ${pos.z}`);
             projectileContainer.appendChild(el);
             projectileEls.set(effect, el);
           } else if (effect.color) {
             el.setAttribute('color', effect.color);
           }
-          const pos = uvToSpherePos(effect.x / canvas.width, effect.y / canvas.height, SPHERE_RADIUS);
           el.object3D.position.copy(pos);
         });
         projectileEls.forEach((el, eff) => {


### PR DESCRIPTION
## Summary
- arrange main HUD panels and console buttons in a semicircle around the player
- style console buttons as glowing cylinders with press animations
- spawn the Nexus avatar and all new objects on the gameplay sphere
- toggle DOM modal display when opening or closing VR menu panels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688676be1f008331bb6752dcb46c3568