### PR TITLE
Implement initial fixes for VR layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,10 @@ This section lists the current known issues with the prototype. Your immediate p
     * **Issue:** Clicking the menu buttons (e.g., "Ascension," "Cores") does not open the corresponding menus.
     * **Required Fix:** Implement the functionality so that clicking a menu button opens the correct UI panel from the original `index.html` as a large, interactive holographic screen in front of the player.
 
+5.  **Broken VR Layout and Gameplay:**
+    * **Issue:** Upon entering VR, all UI elements and command deck pieces appear high above the player's head with scattered blue cylinders. The Aberration Core sphere is visible before any cores are unlocked, the player cannot move across the battlefield, and the stage never begins.
+    * **Required Fix:** Anchor the command deck and UI relative to the player's camera so they sit at waist level, hide the Aberration Core model until a core is unlocked, automatically start a valid stage when VR begins, and ensure the battle sphere registers pointer input for movement.
+
 ---
 
 ## Core Directives for AI-Generated Code

--- a/script.js
+++ b/script.js
@@ -218,6 +218,9 @@ window.addEventListener('load', () => {
     const bossInfoModal = document.getElementById("bossInfoModal");
     const closeBossInfoModalBtn = document.getElementById("closeBossInfoModalBtn");    const homeScreen = document.getElementById('home-screen');
     const startVrBtn = document.getElementById('start-vr-btn');
+    const commandDeck = document.getElementById('commandDeck');
+    const commandDeckEnv = document.getElementById('commandDeckEnv');
+    const camera = document.getElementById('camera');
     const coreCooldownRing = document.getElementById('coreCooldownRing');
     const maxStage = STAGE_CONFIG.length;
     const audioEls = Array.from(document.querySelectorAll(".game-audio"));
@@ -260,9 +263,18 @@ window.addEventListener('load', () => {
     }
     arrangeUiPanels();
 
+    function alignCommandDeck() {
+      if (!camera) return;
+      const headY = camera.object3D.position.y || 1.6;
+      if (commandDeck) commandDeck.object3D.position.y = headY - 0.5;
+      if (commandDeckEnv) commandDeckEnv.object3D.position.y = headY - 1.6;
+    }
+    alignCommandDeck();
+
     if (sceneEl) {
-      sceneEl.addEventListener('enter-vr', arrangeUiPanels);
-      sceneEl.addEventListener('exit-vr', arrangeUiPanels);
+      const reposition = () => { alignCommandDeck(); arrangeUiPanels(); };
+      sceneEl.addEventListener('enter-vr', reposition);
+      sceneEl.addEventListener('exit-vr', reposition);
     }
 
     // Hide the aberration core model when no cores are unlocked
@@ -563,6 +575,7 @@ window.addEventListener('load', () => {
       startVrBtn.addEventListener('click', () => {
         AudioManager.unlockAudio();
         homeScreen.style.display = 'none';
+        restartCurrentStage();
       });
     }
 


### PR DESCRIPTION
## Summary
- document new beta feedback
- align the command deck with player height
- reposition UI panels and command deck on entering VR
- start a stage automatically when clicking the BEGIN button

## Testing
- `node --check script.js`
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_68867f5f75608331b40129c6336af0cc