### PR TITLE
Fix VR startup and menu layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -281,7 +281,13 @@ window.addEventListener('load', () => {
 
     if (sceneEl) {
       const reposition = () => { alignCommandDeck(); arrangeUiPanels(); };
-      sceneEl.addEventListener('enter-vr', reposition);
+      sceneEl.addEventListener('enter-vr', () => {
+        reposition();
+        if (homeScreen && homeScreen.style.display !== 'none') {
+          homeScreen.style.display = 'none';
+          restartCurrentStage();
+        }
+      });
       sceneEl.addEventListener('exit-vr', reposition);
     }
 
@@ -582,6 +588,7 @@ window.addEventListener('load', () => {
       startVrBtn.addEventListener('click', () => {
         AudioManager.unlockAudio();
         homeScreen.style.display = 'none';
+        if (sceneEl && sceneEl.enterVR) sceneEl.enterVR();
         restartCurrentStage();
       });
     }


### PR DESCRIPTION
## Summary
- ensure the command deck recenters when VR mode activates
- hide the home screen and restart the stage when entering VR
- trigger VR mode on the `BEGIN` button

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6886845938d88331bf4fd4e803b5be14