### PR TITLE
Add core UI modals for VR

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,5 +182,99 @@
              material="color:#00ffff; emissive:#00ffff; emissiveIntensity:0.2; transparent:true; opacity:0.6"
              rotation="90 0 0"></a-torus>
   </a-scene>
+  <!-- VR modals and overlays ported from the original interface -->
+  <div id="ascensionGridModal" style="display:none;" class="modal flex-center">
+    <div id="ascension-grid-container" class="modal-background">
+      <div class="ascension-header">
+        <h1>ASCENSION CONDUIT</h1>
+        <div class="ap-display-header">
+          <span>ASCENSION POINTS</span>
+          <span id="ap-total-asc-grid">0</span>
+        </div>
+      </div>
+      <div class="ascension-content"></div>
+      <div class="ascension-footer">
+        <button id="clearSaveBtn">ERASE TIMELINE</button>
+        <button id="closeAscensionBtn" class="btn-modal-close">CLOSE</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="aberrationCoreModal" style="display:none;" class="modal flex-center">
+    <div id="aberration-core-container" class="modal-background">
+      <div class="ascension-header">
+        <h1>ABERRATION CORE ATTUNEMENT</h1>
+        <div id="aberration-core-equipped-display">
+          <span>CURRENTLY ATTUNED</span>
+          <span id="aberration-core-equipped-name">None</span>
+        </div>
+      </div>
+      <div id="aberration-core-list-container"></div>
+      <div class="ascension-footer">
+        <button id="unequipCoreBtn">UNEQUIP CORE</button>
+        <button id="closeAberrationCoreBtn" class="btn-modal-close">CLOSE</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="orreryModal" style="display:none;" class="modal flex-center">
+    <div id="orrery-modal-content" class="modal-background">
+      <div class="ascension-header">
+        <h1>THE WEAVER'S ORRERY</h1>
+        <div class="ap-display-header">
+          <span>ECHOES OF CREATION</span>
+          <span id="orrery-points-total">0</span>
+        </div>
+      </div>
+      <div id="orrery-main-content">
+        <div id="orrery-boss-list-container"></div>
+        <div id="orrery-selection-container">
+          <h3>TIMELINE ROSTER</h3>
+          <div id="orrery-selection-display"></div>
+          <div id="orrery-cost-display">
+            <span>ECHOES SPENT: </span>
+            <span id="orrery-current-cost">0</span>
+          </div>
+        </div>
+      </div>
+      <div class="ascension-footer">
+        <button id="orrery-reset-btn">CLEAR ROSTER</button>
+        <div style="display:flex;gap:15px;">
+          <button id="orrery-start-btn" class="disabled">FORGE TIMELINE</button>
+          <button id="closeOrreryBtn" class="btn-modal-close">CLOSE</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="loreCodexModal" style="display:none;" class="modal flex-center">
+    <div id="lore-codex-container" class="modal-background">
+      <h1 style="margin-top:0;">LORE CODEX</h1>
+      <div id="lore-codex-list" style="flex-grow:1;overflow-y:auto;"></div>
+      <div style="text-align:right;margin-top:15px;">
+        <button id="closeLoreCodexBtn" class="btn-modal-close">CLOSE</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="soundOptionsModal" style="display:none;" class="modal flex-center">
+    <div id="sound-options-container">
+      <h1>SOUND OPTIONS</h1>
+      <label>Music <input id="musicVolume" type="range" min="0" max="1" step="0.01"></label>
+      <label>SFX <input id="sfxVolume" type="range" min="0" max="1" step="0.01"></label>
+      <button id="muteToggle">Mute</button>
+      <button id="closeSoundOptionsBtn" class="btn-modal-close">Close</button>
+    </div>
+  </div>
+
+  <div id="bossInfoModal" style="display:none;" class="modal flex-center">
+    <div id="bossInfoModalBox" class="modal-background">
+      <h2 id="bossInfoModalTitle"></h2>
+      <div id="bossInfoModalContent"></div>
+      <div id="bossInfoModalActions">
+        <button id="closeBossInfoModalBtn" class="btn-modal-close">Close</button>
+      </div>
+    </div>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add DOM modals from the 2D game for Ascension Grid, Core attunement, Orrery, Lore Codex, Sound options and boss info
- these overlays let the existing UI scripts operate in VR

## Testing
- `node -v`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_6886969196ac8331ae1f10468cef28f7