### PR TITLE
Add VR boss info panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,16 @@
         <a-text value="Stage Select" align="center" width="0.8" color="#eaf2ff" position="0 0 0.06"></a-text>
       </a-entity>
     </a-plane>
+    <!-- Boss info panel -->
+    <a-plane id="bossInfoPanel" width="2.0" height="1.2"
+             material="color: #141428; opacity: 0.95; emissive: #00ffff; emissiveIntensity: 0.25"
+             position="0 1.6 -1.2" visible="false">
+      <a-text id="bossInfoPanelTitle" value="" align="center" width="1.8" color="#eaf2ff" position="0 0.45 0.01"></a-text>
+      <a-text id="bossInfoPanelContent" value="" align="center" width="1.8" wrap-count="38" color="#eaf2ff" position="0 -0.05 0.01"></a-text>
+      <a-entity id="closeBossInfoBtn3D" mixin="console-button" class="interactive" position="0 -0.45 0.02">
+        <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
+    </a-plane>
     <!-- The spherical battlefield that surrounds the deck -->
     <a-sphere id="battleSphere" radius="8" segments-height="60" segments-width="60"
               material="color: #080c18; side: back; opacity: 0.0; transparent: true"

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -31,6 +31,9 @@ const bossInfoTitle = document.getElementById('bossInfoModalTitle');
 const bossInfoContent = document.getElementById('bossInfoModalContent');
 const closeBossInfoBtn = document.getElementById('closeBossInfoModalBtn');
 const bossInfoPanel = document.getElementById('bossInfoPanel');
+const bossInfoPanelTitle = document.getElementById('bossInfoPanelTitle');
+const bossInfoPanelContent = document.getElementById('bossInfoPanelContent');
+const closeBossInfoBtn3D = document.getElementById('closeBossInfoBtn3D');
 
 const aberrationCoreSocket = document.getElementById('aberration-core-socket');
 const aberrationCoreIcon = document.getElementById('aberration-core-icon');
@@ -319,12 +322,23 @@ export function showBossInfo(bossIds, type) {
 
     bossInfoTitle.innerHTML = title;
     bossInfoContent.innerHTML = content;
+    if (bossInfoPanelTitle) bossInfoPanelTitle.setAttribute('value', title.replace(/<[^>]+>/g, ''));
+    if (bossInfoPanelContent) {
+        const plain = bosses.map(b => type === 'lore' ? b.lore : b.mechanics_desc).join('\n\n');
+        bossInfoPanelContent.setAttribute('value', plain);
+    }
     bossInfoModal.style.display = 'flex';
     if (bossInfoPanel) bossInfoPanel.setAttribute('visible', 'true');
     AudioManager.playSfx('uiModalOpen');
 }
 
 closeBossInfoBtn.addEventListener('click', () => {
+    bossInfoModal.style.display = 'none';
+    if (bossInfoPanel) bossInfoPanel.setAttribute('visible', 'false');
+    AudioManager.playSfx('uiModalClose');
+});
+
+if (closeBossInfoBtn3D) closeBossInfoBtn3D.addEventListener('click', () => {
     bossInfoModal.style.display = 'none';
     if (bossInfoPanel) bossInfoPanel.setAttribute('visible', 'false');
     AudioManager.playSfx('uiModalClose');


### PR DESCRIPTION
## Summary
- add a 3D boss info panel to the scene
- show boss info text in VR and allow closing it with a new button

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6886984b07188331a688b0adfe9c67fa