### PR TITLE
Enable automatic stage start and hide core model until unlocked

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,14 +79,14 @@
       <!-- Aberration core and cooldown ring -->
       <a-sphere id="coreModel" radius="0.3"
                 material="color: #f000ff; emissive: #f000ff; emissiveIntensity: 0.5"
-                position="-2 1.5 -1" class="interactive">
+                position="-2 1.5 -1" class="interactive" visible="false">
         <a-animation attribute="rotation" dur="8000" to="360 360 0" repeat="indefinite" easing="linear"></a-animation>
       </a-sphere>
       <a-ring id="coreCooldownRing" radius-inner="0.32" radius-outer="0.36"
               position="-2 1.5 -1" material="color:#f000ff; opacity:0.4" rotation="0 0 0" visible="false"></a-ring>
       <a-plane id="coreCooldownPanel" width="0.6" height="0.3"
                material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-               position="-2 1.0 -1">
+               position="-2 1.0 -1" visible="false">
         <a-text id="cooldownText" value="Core cooldown: Ready" align="center" width="0.5" color="#eaf2ff"></a-text>
       </a-plane>
       <!-- Status message panel -->

--- a/script.js
+++ b/script.js
@@ -97,6 +97,8 @@ window.addEventListener('load', () => {
     cursorPoint: null
   };
 
+  restartCurrentStage();
+
   // Cache important elements for quick access.
   const scoreText       = document.getElementById('scoreText');
   const healthText      = document.getElementById('healthText');
@@ -126,6 +128,9 @@ window.addEventListener('load', () => {
   const pickupContainer    = document.getElementById('pickupContainer');
   const leftHand        = document.getElementById('leftHand');
   const rightHand       = document.getElementById('rightHand');
+  const coreModel       = document.getElementById('coreModel');
+  const coreCooldownRing = document.getElementById('coreCooldownRing');
+  const coreCooldownPanel = document.getElementById('coreCooldownPanel');
 
   const projectileMap = new Map();
   const pickupMap = new Map();
@@ -256,6 +261,14 @@ window.addEventListener('load', () => {
         bossPanel.setAttribute('visible', 'false');
       }
     }
+    updateCoreModelVisibility();
+  }
+
+  function updateCoreModelVisibility() {
+    const hasCore = state.player.unlockedAberrationCores.size > 0;
+    if (coreModel) coreModel.setAttribute('visible', hasCore);
+    if (coreCooldownRing) coreCooldownRing.setAttribute('visible', hasCore);
+    if (coreCooldownPanel) coreCooldownPanel.setAttribute('visible', hasCore);
   }
 
   // Event handlers for menu buttons.  These open the respective modals and


### PR DESCRIPTION
## Summary
- start the first stage automatically when the VR scene loads
- control visibility of the aberration core model and cooldown UI based on unlocked cores
- default hidden state for core model and cooldown panel

## Testing
- `node -c script.js`
- `node -c main.js`
- `node -c modules/utils.js`
- `node -c modules/gameLoop.js`


------
https://chatgpt.com/codex/tasks/task_e_68869a1a04b48331a1ab9a4f357151dc