### PR TITLE
Ensure VR stages start and player can move

### DIFF
--- a/script.js
+++ b/script.js
@@ -536,8 +536,22 @@ window.addEventListener('load', () => {
 
   // Animation loop: update game logic and 3D positions every frame.
   function animate() {
-    // Advance the core 2D game simulation
-    try { gameTick(); } catch (err) { console.error(err); }
+    // Determine the current cursor position on the 2D canvas.  When the
+    // raycaster is hitting the gameplay sphere we convert the UV back to
+    // pixel coordinates.  Otherwise fall back to the avatar's location so
+    // logic that relies on mx/my continues to work.
+    let mx, my;
+    if (gameState.cursorUV) {
+      mx = gameState.cursorUV.x * canvas.width;
+      my = gameState.cursorUV.y * canvas.height;
+    } else {
+      const uv = spherePosToUv(avatarPos);
+      mx = uv.u * canvas.width;
+      my = uv.v * canvas.height;
+    }
+
+    // Advance the core 2D game simulation with the mapped coordinates
+    try { gameTick(mx, my); } catch (err) { console.error(err); }
     // Move the avatar gradually toward the cursor using the 3D momentum formula
     if (gameState.cursorPoint) {
       const targetPos = gameState.cursorPoint.clone().normalize().multiplyScalar(SPHERE_RADIUS);


### PR DESCRIPTION
## Summary
- map VR cursor UVs to canvas coordinates
- pass cursor coordinates to `gameTick`

## Testing
- `node --check script.js`
- `node --check modules/gameLoop.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68869cbef1bc8331beed69ecf2b15533