### PR TITLE
Add boss info buttons in VR stage select

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,12 @@
       <a-entity id="startStageBtn" mixin="console-button" class="interactive" position="0 -0.35 0.02">
         <a-text value="Start" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
       </a-entity>
+      <a-entity id="stageMechanicsBtn" mixin="console-button" class="interactive" position="-0.45 -0.35 0.02">
+        <a-text value="❔" align="center" width="0.4" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
+      <a-entity id="stageLoreBtn" mixin="console-button" class="interactive" position="0.45 -0.35 0.02">
+        <a-text value="ℹ️" align="center" width="0.4" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
     </a-plane>
     <!-- Game over panel -->
     <a-plane id="gameOverPanel" width="2.0" height="1.0"

--- a/script.js
+++ b/script.js
@@ -16,7 +16,7 @@ import { state, resetGame, savePlayerState } from './modules/state.js';
 import { activateCorePower } from './modules/cores.js';
 import { powers, usePower } from './modules/powers.js';
 import { applyAllTalentEffects, renderAscensionGrid } from './modules/ascension.js';
-import { populateAberrationCoreMenu, populateOrreryMenu, populateLoreCodex } from './modules/ui.js';
+import { populateAberrationCoreMenu, populateOrreryMenu, populateLoreCodex, showBossInfo } from './modules/ui.js';
 import { STAGE_CONFIG } from './modules/config.js';
 import { AudioManager } from './modules/audio.js';
 import { uvToSpherePos, spherePosToUv } from './modules/utils.js';
@@ -309,6 +309,8 @@ window.addEventListener('load', () => {
   const prevStageBtn       = document.getElementById('prevStageBtn');
   const nextStageBtn       = document.getElementById('nextStageBtn');
   const startStageBtn      = document.getElementById('startStageBtn');
+  const stageMechanicsBtn  = document.getElementById('stageMechanicsBtn');
+  const stageLoreBtn       = document.getElementById('stageLoreBtn');
   const restartStageBtn    = document.getElementById('restartStageBtn');
   const gameOverPanel      = document.getElementById('gameOverPanel');
   const levelSelectMenuBtn = document.getElementById('levelSelectMenuBtn');
@@ -335,6 +337,14 @@ window.addEventListener('load', () => {
     state.currentStage = selectedStage;
     restartCurrentStage();
     stageSelectPanel.setAttribute('visible', 'false');
+  });
+  if (stageMechanicsBtn) stageMechanicsBtn.addEventListener('click', () => {
+    const cfg = STAGE_CONFIG.find(s => s.stage === selectedStage);
+    if (cfg) showBossInfo(cfg.bosses, 'mechanics');
+  });
+  if (stageLoreBtn) stageLoreBtn.addEventListener('click', () => {
+    const cfg = STAGE_CONFIG.find(s => s.stage === selectedStage);
+    if (cfg) showBossInfo(cfg.bosses, 'lore');
   });
 
   // Menu toggles


### PR DESCRIPTION
## Summary
- add new stage info buttons in index.html
- hook up buttons to open boss lore and mechanics info panels

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6886a2c67b0083318e59d3240e55e02a