### PR TITLE
Refine VR UI layout and menu panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,9 @@
                animation__press="property: position; startEvents: mousedown; dir: alternate; dur: 100; to: 0 -0.02 0"
                animation__release="property: position; startEvents: mouseup; dir: alternate; dur: 100; to: 0 0 0"
                animation__hover="property: material.emissiveIntensity; startEvents: mouseenter; dir: alternate; dur: 200; to: 1.5"></a-mixin>
+      <a-mixin id="console-panel"
+               geometry="primitive: plane; width:1; height:0.6"
+               material="color:#141428; opacity:0.9; transparent:true; emissive:#00ffff; emissiveIntensity:0.25"></a-mixin>
       <!-- Basic UI sounds -->
       <audio id="uiHoverSound" class="game-audio" src="assets/uiHoverSound.mp3" preload="auto"></audio>
       <audio id="uiClickSound" class="game-audio" src="assets/uiClickSound.mp3" preload="auto"></audio>
@@ -181,6 +184,37 @@
       <a-text id="bossInfoPanelTitle" value="" align="center" width="1.8" color="#eaf2ff" position="0 0.45 0.01"></a-text>
       <a-text id="bossInfoPanelContent" value="" align="center" width="1.8" wrap-count="38" color="#eaf2ff" position="0 -0.05 0.01"></a-text>
       <a-entity id="closeBossInfoBtn3D" mixin="console-button" class="interactive" position="0 -0.45 0.02">
+        <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
+    </a-plane>
+    <!-- Floating panels for in-game menus -->
+    <a-plane id="ascensionGridPanel" mixin="console-panel" width="2.4" height="1.4" position="0 1.6 -1" visible="false">
+      <a-text value="ASCENSION GRID" align="center" width="2" color="#eaf2ff" position="0 0.5 0.01"></a-text>
+      <a-entity id="closeAscensionGridBtn" mixin="console-button" class="interactive" position="0 -0.5 0.02">
+        <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
+    </a-plane>
+    <a-plane id="aberrationCorePanel" mixin="console-panel" width="2.4" height="1.4" position="0 1.6 -1" visible="false">
+      <a-text value="ABERRATION CORES" align="center" width="2" color="#eaf2ff" position="0 0.5 0.01"></a-text>
+      <a-entity id="closeAberrationCoreBtn" mixin="console-button" class="interactive" position="0 -0.5 0.02">
+        <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
+    </a-plane>
+    <a-plane id="loreCodexPanel" mixin="console-panel" width="2.4" height="1.4" position="0 1.6 -1" visible="false">
+      <a-text value="LORE CODEX" align="center" width="2" color="#eaf2ff" position="0 0.5 0.01"></a-text>
+      <a-entity id="closeLoreCodexBtn" mixin="console-button" class="interactive" position="0 -0.5 0.02">
+        <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
+    </a-plane>
+    <a-plane id="orreryPanel" mixin="console-panel" width="2.4" height="1.4" position="0 1.6 -1" visible="false">
+      <a-text value="WEAVER'S ORRERY" align="center" width="2" color="#eaf2ff" position="0 0.5 0.01"></a-text>
+      <a-entity id="closeOrreryBtn" mixin="console-button" class="interactive" position="0 -0.5 0.02">
+        <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
+    </a-plane>
+    <a-plane id="soundOptionsPanel" mixin="console-panel" width="1.6" height="1.0" position="0 1.6 -1" visible="false">
+      <a-text value="SOUND OPTIONS" align="center" width="1.2" color="#eaf2ff" position="0 0.3 0.01"></a-text>
+      <a-entity id="closeSoundOptionsBtn" mixin="console-button" class="interactive" position="0 -0.3 0.02">
         <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
       </a-entity>
     </a-plane>

--- a/script.js
+++ b/script.js
@@ -178,6 +178,16 @@ window.addEventListener('load', () => {
     if (commandDeckEnv)  commandDeckEnv.object3D.position.y = headY - 1.6;
   }
 
+  function showPanel(panelEl) {
+    if (!panelEl) return;
+    const cam = cameraEl.object3D;
+    const offset = new THREE.Vector3(0, 0, -1.2);
+    offset.applyQuaternion(cam.quaternion);
+    panelEl.object3D.position.copy(cam.position).add(offset);
+    panelEl.object3D.quaternion.copy(cam.quaternion);
+    panelEl.setAttribute('visible', 'true');
+  }
+
   // Start the selected stage by resetting and spawning enemies/bosses.
   function restartCurrentStage() {
     resetGame(false);
@@ -276,24 +286,19 @@ window.addEventListener('load', () => {
   // panels defined in the DOM.  They mirror the behaviour of the 2D
   // interface but are adapted for VR.
   const coreMenuToggle     = document.getElementById('coreMenuToggle');
-  const aberrationCoreModal = document.getElementById('aberrationCoreModal');
   const aberrationCorePanel = document.getElementById('aberrationCorePanel');
   const closeAberrationCoreBtn = document.getElementById('closeAberrationCoreBtn');
   const unequipCoreBtn     = document.getElementById('unequipCoreBtn');
   const ascensionToggle    = document.getElementById('ascensionToggle');
-  const ascensionGridModal = document.getElementById('ascensionGridModal');
   const ascensionGridPanel = document.getElementById('ascensionGridPanel');
   const closeAscensionGridBtn = document.getElementById('closeAscensionGridBtn');
   const codexToggle        = document.getElementById('codexToggle');
-  const loreCodexModal     = document.getElementById('loreCodexModal');
   const loreCodexPanel     = document.getElementById('loreCodexPanel');
   const closeLoreCodexBtn  = document.getElementById('closeLoreCodexBtn');
   const orreryToggle       = document.getElementById('orreryToggle');
-  const orreryModal        = document.getElementById('orreryModal');
   const orreryPanel        = document.getElementById('orreryPanel');
   const closeOrreryBtn     = document.getElementById('closeOrreryBtn');
   const soundOptionsToggle = document.getElementById('soundOptionsToggle');
-  const soundOptionsModal  = document.getElementById('soundOptionsModal');
   const soundOptionsPanel  = document.getElementById('soundOptionsPanel');
   const closeSoundOptionsBtn = document.getElementById('closeSoundOptionsBtn');
   const musicVolume        = document.getElementById('musicVolume');
@@ -356,13 +361,11 @@ window.addEventListener('load', () => {
       populateAberrationCoreMenu(() => {});
       updateUI();
     });
-    aberrationCoreModal.style.display = 'flex';
-    aberrationCorePanel.setAttribute('visible', 'true');
+    showPanel(aberrationCorePanel);
     AudioManager.playSfx('uiModalOpen');
   });
   if (closeAberrationCoreBtn) closeAberrationCoreBtn.addEventListener('click', () => {
     aberrationCorePanel.setAttribute('visible', 'false');
-    aberrationCoreModal.style.display = 'none';
     AudioManager.playSfx('uiModalClose');
   });
   if (unequipCoreBtn) unequipCoreBtn.addEventListener('click', () => {
@@ -371,30 +374,25 @@ window.addEventListener('load', () => {
     applyAllTalentEffects();
     populateAberrationCoreMenu(() => {});
     aberrationCorePanel.setAttribute('visible', 'false');
-    aberrationCoreModal.style.display = 'none';
     AudioManager.playSfx('uiModalClose');
     updateUI();
   });
   if (ascensionToggle) ascensionToggle.addEventListener('click', () => {
     renderAscensionGrid();
-    ascensionGridModal.style.display = 'block';
-    ascensionGridPanel.setAttribute('visible', 'true');
+    showPanel(ascensionGridPanel);
     AudioManager.playSfx('uiModalOpen');
   });
   if (closeAscensionGridBtn) closeAscensionGridBtn.addEventListener('click', () => {
     ascensionGridPanel.setAttribute('visible', 'false');
-    ascensionGridModal.style.display = 'none';
     AudioManager.playSfx('uiModalClose');
   });
   if (codexToggle) codexToggle.addEventListener('click', () => {
     populateLoreCodex();
-    loreCodexModal.style.display = 'block';
-    loreCodexPanel.setAttribute('visible', 'true');
+    showPanel(loreCodexPanel);
     AudioManager.playSfx('uiModalOpen');
   });
   if (closeLoreCodexBtn) closeLoreCodexBtn.addEventListener('click', () => {
     loreCodexPanel.setAttribute('visible', 'false');
-    loreCodexModal.style.display = 'none';
     AudioManager.playSfx('uiModalClose');
   });
   if (orreryToggle) orreryToggle.addEventListener('click', () => {
@@ -408,29 +406,24 @@ window.addEventListener('load', () => {
       const uv0 = spherePosToUv(avatarPos);
       state.player.x = uv0.u * canvas.width;
       state.player.y = uv0.v * canvas.height;
-      orreryModal.style.display = 'none';
       updateUI();
     });
-    orreryModal.style.display = 'block';
-    orreryPanel.setAttribute('visible', 'true');
+    showPanel(orreryPanel);
     AudioManager.playSfx('uiModalOpen');
   });
   if (closeOrreryBtn) closeOrreryBtn.addEventListener('click', () => {
     orreryPanel.setAttribute('visible', 'false');
-    orreryModal.style.display = 'none';
     AudioManager.playSfx('uiModalClose');
   });
   if (soundOptionsToggle) soundOptionsToggle.addEventListener('click', () => {
     musicVolume.value = AudioManager.musicVolume;
     sfxVolume.value   = AudioManager.sfxVolume;
     muteToggle.innerText = AudioManager.userMuted ? 'Unmute' : 'Mute';
-    soundOptionsModal.style.display = 'block';
-    soundOptionsPanel.setAttribute('visible', 'true');
+    showPanel(soundOptionsPanel);
     AudioManager.playSfx('uiModalOpen');
   });
   if (closeSoundOptionsBtn) closeSoundOptionsBtn.addEventListener('click', () => {
     soundOptionsPanel.setAttribute('visible', 'false');
-    soundOptionsModal.style.display = 'none';
     AudioManager.playSfx('uiModalClose');
   });
   if (muteToggle) muteToggle.addEventListener('click', () => {
@@ -453,7 +446,7 @@ window.addEventListener('load', () => {
   if (stageSelectToggle) stageSelectToggle.addEventListener('click', () => {
     selectedStage = state.currentStage;
     updateStageSelectDisplay();
-    stageSelectPanel.setAttribute('visible', 'true');
+    showPanel(stageSelectPanel);
   });
 
   if (restartStageBtn) restartStageBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add `console-panel` mixin
- add holographic 3D panels for menus and close buttons
- remove unused DOM menu handling and show panels in front of the camera
- utility to position panels at the player's view

## Testing
- `node -c script.js`
- `for f in modules/*.js; do node -c "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_6886a43646188331805e8ee708e1f242