### PR TITLE
Improve VR console layout and button behaviour

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,10 @@ This section lists the current known issues with the prototype. Your immediate p
     * **Issue:** Testers note the command deck still lacks the promised neon grid floor.
     * **Action:** Add a transparent grid floor beneath the command deck using the gridCanvas texture so players can see space below.
 
+11.  **Button Drift Feedback (July 2025):**
+    * **Issue:** Some testers report the console buttons are unlabeled and appear to jump toward the player when pressed instead of opening their menus.
+    * **Action:** Ensure each button has a clear emoji label, stays anchored to the command deck, and toggles its corresponding holographic panel without moving.
+
 ---
 
 ## Core Directives for AI-Generated Code

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
     <!-- Stage selection panel -->
     <a-plane id="stageSelectPanel" width="2.0" height="1.2"
              material="color: #141428; opacity: 0.95; emissive: #00ffff; emissiveIntensity: 0.25"
-             visible="false">
+             position="-0.9 1.6 -2.44" look-at="#commandDeck" visible="false">
       <a-text id="stageSelectLabel" value="Stage: 1" align="center" width="1.5" color="#eaf2ff" position="0 0.3 0.01"></a-text>
       <a-entity id="prevStageBtn" mixin="console-button" class="interactive" position="-0.6 -0.1 0.02">
         <a-text value="Prev" align="center" width="0.4" color="#eaf2ff" position="0 0 0.06"></a-text>
@@ -162,7 +162,7 @@
     <!-- Game over panel -->
     <a-plane id="gameOverPanel" width="2.0" height="1.0"
              material="color: #141428; opacity: 0.9; emissive: #00ffff; emissiveIntensity: 0.25"
-             visible="false">
+             position="0 1.6 -1" look-at="#commandDeck" visible="false">
       <a-text value="TIMELINE COLLAPSED" align="center" width="1.8" color="#e74c3c" position="0 0.3 0.01"></a-text>
       <a-entity id="restartStageBtn" mixin="console-button" class="interactive" position="-0.7 -0.1 0.02">
         <a-text value="Restart Stage" align="center" width="0.8" color="#eaf2ff" position="0 0 0.06"></a-text>
@@ -180,7 +180,7 @@
     <!-- Boss info panel -->
     <a-plane id="bossInfoPanel" width="2.0" height="1.2"
              material="color: #141428; opacity: 0.95; emissive: #00ffff; emissiveIntensity: 0.25"
-             position="0 1.6 -1.2" visible="false">
+             position="0 1.6 -1.2" look-at="#commandDeck" visible="false">
       <a-text id="bossInfoPanelTitle" value="" align="center" width="1.8" color="#eaf2ff" position="0 0.45 0.01"></a-text>
       <a-text id="bossInfoPanelContent" value="" align="center" width="1.8" wrap-count="38" color="#eaf2ff" position="0 -0.05 0.01"></a-text>
       <a-entity id="closeBossInfoBtn3D" mixin="console-button" class="interactive" position="0 -0.45 0.02">
@@ -188,31 +188,31 @@
       </a-entity>
     </a-plane>
     <!-- Floating panels for in-game menus -->
-    <a-plane id="ascensionGridPanel" mixin="console-panel" width="2.4" height="1.4" position="0 1.6 -1" visible="false">
+    <a-plane id="ascensionGridPanel" mixin="console-panel" width="2.4" height="1.4" position="0.89 1.6 -2.44" look-at="#commandDeck" visible="false">
       <a-text value="ASCENSION GRID" align="center" width="2" color="#eaf2ff" position="0 0.5 0.01"></a-text>
       <a-entity id="closeAscensionGridBtn" mixin="console-button" class="interactive" position="0 -0.5 0.02">
         <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
       </a-entity>
     </a-plane>
-    <a-plane id="aberrationCorePanel" mixin="console-panel" width="2.4" height="1.4" position="0 1.6 -1" visible="false">
+    <a-plane id="aberrationCorePanel" mixin="console-panel" width="2.4" height="1.4" position="-0.89 1.6 -2.44" look-at="#commandDeck" visible="false">
       <a-text value="ABERRATION CORES" align="center" width="2" color="#eaf2ff" position="0 0.5 0.01"></a-text>
       <a-entity id="closeAberrationCoreBtn" mixin="console-button" class="interactive" position="0 -0.5 0.02">
         <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
       </a-entity>
     </a-plane>
-    <a-plane id="loreCodexPanel" mixin="console-panel" width="2.4" height="1.4" position="0 1.6 -1" visible="false">
+    <a-plane id="loreCodexPanel" mixin="console-panel" width="2.4" height="1.4" position="2.25 1.6 -1.3" look-at="#commandDeck" visible="false">
       <a-text value="LORE CODEX" align="center" width="2" color="#eaf2ff" position="0 0.5 0.01"></a-text>
       <a-entity id="closeLoreCodexBtn" mixin="console-button" class="interactive" position="0 -0.5 0.02">
         <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
       </a-entity>
     </a-plane>
-    <a-plane id="orreryPanel" mixin="console-panel" width="2.4" height="1.4" position="0 1.6 -1" visible="false">
+    <a-plane id="orreryPanel" mixin="console-panel" width="2.4" height="1.4" position="-2.25 1.6 -1.3" look-at="#commandDeck" visible="false">
       <a-text value="WEAVER'S ORRERY" align="center" width="2" color="#eaf2ff" position="0 0.5 0.01"></a-text>
       <a-entity id="closeOrreryBtn" mixin="console-button" class="interactive" position="0 -0.5 0.02">
         <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>
       </a-entity>
     </a-plane>
-    <a-plane id="soundOptionsPanel" mixin="console-panel" width="1.6" height="1.0" position="0 1.6 -1" visible="false">
+    <a-plane id="soundOptionsPanel" mixin="console-panel" width="1.6" height="1.0" position="2.56 1.6 0.45" look-at="#commandDeck" visible="false">
       <a-text value="SOUND OPTIONS" align="center" width="1.2" color="#eaf2ff" position="0 0.3 0.01"></a-text>
       <a-entity id="closeSoundOptionsBtn" mixin="console-button" class="interactive" position="0 -0.3 0.02">
         <a-text value="Close" align="center" width="0.7" color="#eaf2ff" position="0 0 0.06"></a-text>

--- a/script.js
+++ b/script.js
@@ -177,15 +177,19 @@ window.addEventListener('load', () => {
     const headY = cameraEl.object3D.position.y || 1.6;
     if (commandDeck)     commandDeck.object3D.position.y    = headY - 0.5;
     if (commandDeckEnv)  commandDeckEnv.object3D.position.y = headY - 1.6;
+    const panelY = headY;
+    const panelIds = [
+      'stageSelectPanel','gameOverPanel','bossInfoPanel','ascensionGridPanel',
+      'aberrationCorePanel','loreCodexPanel','orreryPanel','soundOptionsPanel'
+    ];
+    panelIds.forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.object3D.position.y = panelY;
+    });
   }
 
   function showPanel(panelEl) {
     if (!panelEl) return;
-    const cam = cameraEl.object3D;
-    const offset = new THREE.Vector3(0, 0, -1.2);
-    offset.applyQuaternion(cam.quaternion);
-    panelEl.object3D.position.copy(cam.position).add(offset);
-    panelEl.object3D.quaternion.copy(cam.quaternion);
     panelEl.setAttribute('visible', 'true');
   }
 


### PR DESCRIPTION
## Summary
- arrange menu panels around the command deck instead of stacking them
- keep panels level with the player's head height
- stop buttons from warping panels to the camera
- document new beta feedback about drifting buttons

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6886a75e8e348331b561fb4bdcbfc965