### PR TITLE
Improve docs with new feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ The goal is to build a new, native 3D VR game based on the vision in `README.md`
 
 ---
 
-## Current Beta Test Feedback & Issues (Updated July 2025)
+## Current Beta Test Feedback & Issues (Updated August 2025)
 
 This section lists the current known issues with the prototype. Your immediate priority is to resolve these issues. **This section must be updated with any new user feedback received.**
 
@@ -57,6 +57,10 @@ This section lists the current known issues with the prototype. Your immediate p
 11.  **Button Drift Feedback (July 2025):**
     * **Issue:** Some testers report the console buttons are unlabeled and appear to jump toward the player when pressed instead of opening their menus.
     * **Action:** Ensure each button has a clear emoji label, stays anchored to the command deck, and toggles its corresponding holographic panel without moving.
+12.  **General Beta Feedback (August 2025):**
+    * **Issue:** A recent tester states the VR build is still unrecognizable and unplayable compared to the README vision and the original game.
+    * **Action:** Prioritize fixing critical bugs and failed implementations so the VR version matches the original design before adding new features.
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,3 +106,5 @@ For faster iteration, you can run a local web server.
     http-server
     ```
 3.  Open the provided local URL (e.g., `http://127.0.0.1:8080`) in a WebXR-compatible browser on your PC or headset.
+4.  If the VR scene fails to load or you see the old 2D layout, make sure you are opening `index.html` via an HTTP server. Module imports will fail if you open the file directly.
+5.  As an alternative to `http-server`, you can run `python3 -m http.server` from the project root and open the provided address in your headset browser.


### PR DESCRIPTION
## Summary
- add recent beta tester feedback about unplayable VR build
- clarify local development instructions for running index via an HTTP server

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6886acf2a7fc833199bd4b9339a56f19