### PR TITLE
Fix command deck rotation in VR

### DIFF
--- a/script.js
+++ b/script.js
@@ -93,8 +93,8 @@ window.addEventListener('load', () => {
       cameraEl.appendChild(commandDeck);
       commandDeck.object3D.position.set(0, -0.6, 0); // waist level
     }
-    const yaw = cameraEl.object3D.rotation.y;
-    commandDeck.object3D.rotation.set(0, yaw, 0);
+    const rot = cameraEl.object3D.rotation;
+    commandDeck.object3D.rotation.set(-rot.x, 0, -rot.z);
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- adjust command deck anchoring logic to avoid inheriting head pitch/roll

## Testing
- `node -c script.js`
- `node -c main.js`
- `for f in modules/*.js; do node -c "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_6886cd3e7bf883319cc3f81f850fbdfd