### PR TITLE
Implement holographic menu buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,8 @@ Adherence to these constraints is crucial for a successful implementation.
 
 ## TODO
 - Build proper 3D models and textures for all console buttons.
-- Implement remaining UI panels as holographic canvases (Ascension, Cores, Orrery). Boss info panel added.
+- Implement remaining UI panels as holographic canvases (Ascension, Cores, Orrery). Boss info panel added. ✅
+- Add tooltip labels to console buttons for clarity.
 - Expand entity spawner to cover projectile effects. ✅
 - Add null checks before attaching UI event listeners. ✅
 - Correct asset paths in legacy style sheet to prevent 404 errors. ✅


### PR DESCRIPTION
## Summary
- render Ascension, Core and Orrery menus as holographic panels
- hook console buttons to open these panels
- include core equip and orrery start logic
- update AGENTS TODO list with completed item

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6886d6811fbc8331843a7c1744b9c721