### PR TITLE
Implement haptics and fix deck anchoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,9 @@ Adherence to these constraints is crucial for a successful implementation.
     |-- assets/       ← png / mp3 / mp4 used by both versions
 
 ## TODO
-- Prevent command deck buttons from following the player's headset; they must stay fixed relative to the world, as noted in README.
-- Implement haptic cues for damage taken and power activation.
+- Prevent command deck buttons from following the player's headset; they must stay fixed relative to the world, as noted in README. ✅
+- Implement haptic cues for damage taken and power activation. ✅
+- Add comfort settings menu for turning speed and vignette intensity.
 - Implement remaining UI panels as holographic canvases (Ascension, Cores, Orrery). Boss info panel added. ✅
 - Begin port of enemy and boss AI logic to fully 3D components.
 - Expand entity spawner to cover projectile effects. ✅

--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -806,7 +806,8 @@ export function gameTick(mx, my) {
                         } else {
                             state.player.health -= damage; 
                         }
-                        play('hitSound'); 
+                        play('hitSound');
+                        if(window.pulseControllers) window.pulseControllers(100,0.7);
                         if(e.onDamage) e.onDamage(e, damage, state.player, state, spawnParticlesCallback, play, stopLoopingSfx, gameHelpers);
                         if(state.player.health<=0) state.gameOver=true; 
                     } else if (state.player.shield && damage > 0) { 

--- a/modules/powers.js
+++ b/modules/powers.js
@@ -356,9 +356,11 @@ export function usePower(powerKey, isFreeCast = false, options = {}){
 
   // Apply the main power effect
   power.apply(...applyArgs);
+  if(window.pulseControllers) window.pulseControllers(60,0.6);
   
   if (stackedEffect && power.name !== 'Stack') {
       power.apply(...applyArgs);
+      if(window.pulseControllers) window.pulseControllers(60,0.6);
       if(state.stacked) {
           state.stacked = false;
           state.player.statusEffects = state.player.statusEffects.filter(e => e.name !== 'Stacked');
@@ -369,6 +371,7 @@ export function usePower(powerKey, isFreeCast = false, options = {}){
       setTimeout(() => {
            if (state.gameOver) return;
            power.apply(...applyArgs);
+           if(window.pulseControllers) window.pulseControllers(60,0.6);
            addStatusEffect('Duplicated', '✨', 2000);
            play('shaperAttune');
            utils.spawnParticles(state.particles, state.player.x, state.player.y, '#9b59b6', 40, 3, 30,5);

--- a/script.js
+++ b/script.js
@@ -95,6 +95,7 @@ window.addEventListener('load', () => {
       }
     }
   }
+  window.pulseControllers = pulseControllers;
 
   // ---------------------------------------------------------------------------
   // Helper: anchor the command deck to the camera at waist height and ensure
@@ -102,12 +103,14 @@ window.addEventListener('load', () => {
   // frame to keep orientation stable even if the player tilts their head.
   // ---------------------------------------------------------------------------
   function anchorCommandDeck() {
-    if (cameraEl && commandDeck.parentElement !== cameraEl) {
-      cameraEl.appendChild(commandDeck);
-      commandDeck.object3D.position.set(0, -0.6, 0); // waist level
+    if(!sceneEl||!cameraEl) return;
+    if(commandDeck.parentElement !== sceneEl){
+      sceneEl.appendChild(commandDeck);
     }
-    const rot = cameraEl.object3D.rotation;
-    commandDeck.object3D.rotation.set(-rot.x, 0, -rot.z);
+    const pos = new THREE.Vector3();
+    cameraEl.object3D.getWorldPosition(pos);
+    commandDeck.object3D.position.set(pos.x, pos.y - 0.6, pos.z);
+    commandDeck.object3D.rotation.set(0,0,0);
   }
 
   // ---------------------------------------------------------------------------
@@ -314,7 +317,6 @@ window.addEventListener('load', () => {
   // ---------------------------------------------------------------------------
   function animate(){
     requestAnimationFrame(animate);
-    anchorCommandDeck();
     if(!vrState.isGameRunning||state.isPaused) return;
 
     // Map VR cursor to legacy (u,v) for gameLoop


### PR DESCRIPTION
## Summary
- keep command deck fixed in world space
- expose `pulseControllers` globally and trigger on power use and player damage
- allow for comfort settings task in TODO

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6886ddb163c88331ac7ae59a0086b779