### PR TITLE
Add recenter option for command deck

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,12 +69,13 @@ Adherence to these constraints is crucial for a successful implementation.
 - Implement remaining UI panels as holographic canvases (Ascension, Cores, Orrery). Boss info panel added.
 - Begin port of enemy and boss AI logic to fully 3D components.
 - Expand entity spawner to cover projectile effects.
-- Add a recenter option so players can reposition the command deck if they drift too far from the origin.
 - Implement a VR-native loading screen that displays progress before entering the command deck.
 - Fix crosshair cursor and Nexus avatar visibility when the stage starts.
+- Add a visual prompt reminding players to recenter if they move far from the command deck.
 
 ## NEED
 - 3D art assets for enemies, pickups, and projectiles.
 - Additional sound effects and background music loops.
 - VR performance profiling on target hardware.
 - QA testers for cross-device VR compatibility.
+- QA across varied room-scale setups to verify recenter functionality.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The player is positioned on a circular, floating **Command Deck** at the absolut
 * **360° Omniscience:** From your central vantage point, you can see every part of the battlefield.
 * **Transparent Neon-Grid Floor:** The floor of your command deck is a transparent, luminous grid, styled to match the game's aesthetic.
 * **Floating Console:** Your UI is a series of floating holographic panels and physical controls that hover at waist-height around you.
+* **Recenter Option:** Press the new **Center** button or the `R` key to move the command deck back to your current position if you drift away.
 
 ### 2. The 3D Gameplay Arena (The Spherical Timeline)
 The battlefield is the entire inner surface of a **massive, hollow sphere** that surrounds your Command Deck.

--- a/script.js
+++ b/script.js
@@ -116,6 +116,20 @@ window.addEventListener('load', () => {
   }
 
   // ---------------------------------------------------------------------------
+  // Helper: move the command deck to the player's current position without
+  // attaching it to the headset.  Useful if the player drifts away from the
+  // origin in room‑scale play.
+  // ---------------------------------------------------------------------------
+  function recenterCommandDeck(){
+    if(!cameraEl||!commandDeck) return;
+    const camPos = new THREE.Vector3();
+    cameraEl.object3D.getWorldPosition(camPos);
+    commandDeck.object3D.position.set(camPos.x, camPos.y - 0.5, camPos.z);
+    commandDeck.object3D.rotation.set(0,0,0);
+  }
+  window.recenterCommandDeck = recenterCommandDeck;
+
+  // ---------------------------------------------------------------------------
   // Helper: draw the neon‑grid floor texture once at start‑up.
   // ---------------------------------------------------------------------------
   function drawGrid(c) {
@@ -216,7 +230,8 @@ window.addEventListener('load', () => {
       cores:    {angle:-10, r:1.25, y:0.25, emoji:"⭐", label:"Cores",     action:openCorePanel},
       orrery:   {angle: 20, r:1.25, y:0.20, emoji:"🪐", label:"Orrery",    action:openOrreryPanel},
       resume:   {angle: 50, r:1.30, y:0.15, emoji:"▶", label:"Resume",   action:()=>vrState.isGameRunning=true},
-      sound:    {angle: 80, r:1.30, y:0.10, emoji:"🔊", label:"Sound",    action:()=>AudioManager.toggleMute()}
+      sound:    {angle: 80, r:1.30, y:0.10, emoji:"🔊", label:"Sound",    action:()=>AudioManager.toggleMute()},
+      recenter: {angle:110, r:1.30, y:0.10, emoji:"📍", label:"Center",  action:recenterCommandDeck}
     };
 
     Object.entries(buttons).forEach(([id,cfg])=>{
@@ -443,6 +458,10 @@ window.addEventListener('load', () => {
   safeAddEventListener(sceneEl,'enter-vr',()=>{
     anchorCommandDeck();
     restartCurrentStage();
+  });
+
+  window.addEventListener('keydown', e => {
+    if(e.key === 'r' || e.key === 'R') recenterCommandDeck();
   });
 
   animate();


### PR DESCRIPTION
## Summary
- implement `recenterCommandDeck` utility and expose to window
- add new command deck button and keyboard shortcut to trigger recenter
- note recenter feature in README
- update AGENTS TODO/NEED lists

## Testing
- `node --check script.js`
- `for f in modules/*.js; do node --check "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_6886e61b71ac83318d506ade6d458ec5