### PR TITLE
Fix crosshair visibility on stage start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,8 @@ Adherence to these constraints is crucial for a successful implementation.
 - Begin port of enemy and boss AI logic to fully 3D components.
 - Expand entity spawner to cover projectile effects.
 - Implement a VR-native loading screen that displays progress before entering the command deck.
-- Fix crosshair cursor and Nexus avatar visibility when the stage starts.
 - Add a visual prompt reminding players to recenter if they move far from the command deck.
+- Implement distance-based scaling for the crosshair to improve depth perception.
 
 ## NEED
 - 3D art assets for enemies, pickups, and projectiles.

--- a/script.js
+++ b/script.js
@@ -322,6 +322,15 @@ window.addEventListener('load', () => {
     const uv = spherePosToUv(vrState.avatarPos, SPHERE_RADIUS);
     state.player.x = uv.u*canvas.width;
     state.player.y = uv.v*canvas.height;
+    // Ensure avatar and crosshair are visible at start
+    nexusAvatar.setAttribute('visible', true);
+    nexusAvatar.object3D.position.copy(vrState.avatarPos);
+    nexusAvatar.object3D.lookAt(0,0,0);
+    if(crosshair){
+      crosshair.setAttribute('visible', true);
+      crosshair.object3D.position.copy(vrState.avatarPos);
+      crosshair.object3D.lookAt(0,0,0);
+    }
     if(!state.currentStage||state.currentStage<1||state.currentStage>STAGE_CONFIG.length) state.currentStage=1;
     spawnBossesForStage(state.currentStage);
     vrState.isGameRunning = true;
@@ -344,12 +353,12 @@ window.addEventListener('load', () => {
     // Move Nexus avatar toward cursor (Momentum)
     if(vrState.cursorPoint.length()){
       moveTowards(vrState.avatarPos, vrState.cursorPoint, state.player.speed, SPHERE_RADIUS);
-      nexusAvatar.object3D.position.copy(vrState.avatarPos);
-      nexusAvatar.object3D.lookAt(0,0,0);
-      const uvNow = spherePosToUv(vrState.avatarPos,SPHERE_RADIUS);
-      state.player.x = uvNow.u*canvas.width;
-      state.player.y = uvNow.v*canvas.height;
     }
+    nexusAvatar.object3D.position.copy(vrState.avatarPos);
+    nexusAvatar.object3D.lookAt(0,0,0);
+    const uvNow = spherePosToUv(vrState.avatarPos,SPHERE_RADIUS);
+    state.player.x = uvNow.u*canvas.width;
+    state.player.y = uvNow.v*canvas.height;
 
     // Spawn / update 3‑D representations of all dynamic objects
     const activeIds=new Set();


### PR DESCRIPTION
## Summary
- ensure the crosshair and Nexus avatar appear when a stage starts
- keep the avatar updated every frame even when no cursor position is available
- replace the completed TODO item in `AGENTS.md` with a follow-up crosshair improvement

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6886e74d96108331843371e843c7e110