### PR TITLE
Add basic 3D enemy colliders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Adherence to these constraints is crucial for a successful implementation.
 
 ## TODO
 - Expand boss attack patterns to use full 3D positioning and effects.
-- Refine enemy hit detection using proper 3D colliders.
+- Improve 3D projectile physics for enemy attacks.
 
 ## NEED
 - High-contrast emoji textures for improved readability.


### PR DESCRIPTION
## Summary
- add `enemy-hitbox` A-Frame component for proximity checks
- apply hitboxes to spawned enemies and handle damage when colliding
- update AGENTS TODO list

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6886fde7df808331b4b792fc2eda9141