### PR TITLE
Fix menu freeze and add 3D boss spawns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Adherence to these constraints is crucial for a successful implementation.
 - Expand boss attack patterns to use full 3D positioning and effects.
 - Improve 3D projectile physics for enemy attacks.
 - Replace DOM-based UI dependencies in `modules/ui.js` with A-Frame components for health, shield, ascension and ability slots.
-- Investigate and fix VR menu freeze when clicking buttons.
+- Implement navmesh-based enemy pathfinding on the sphere.
 
 ## NEED
 - High-contrast emoji textures for improved readability.

--- a/modules/bosses.js
+++ b/modules/bosses.js
@@ -2,6 +2,9 @@
 import { STAGE_CONFIG } from './config.js';
 import * as utils from './utils.js';
 
+const CANVAS_W = 2048;
+const CANVAS_H = 1024;
+
 export const bossData = [{
     id: "splitter",
     name: "Splitter Sentinel",
@@ -17,20 +20,28 @@ export const bossData = [{
     onDeath: (b, state, spawnEnemy, spawnParticles, play) => {
         play('splitterOnDeath');
         spawnParticles(state.particles, b.x, b.y, "#ff4500", 100, 6, 40, 5);
-        const spawnInCircle = (count, radius, center) => {
+        const spawnInOrbit = (count, radiusPx, center) => {
+            const cu = center.x / CANVAS_W;
+            const cv = center.y / CANVAS_H;
+            const centerVec = utils.uvToSpherePos(cu, cv, 1);
+            const basisA = new THREE.Vector3(centerVec.z, 0, -centerVec.x).normalize();
+            const basisB = new THREE.Vector3().crossVectors(centerVec, basisA).normalize();
+            const angRadius = (radiusPx / CANVAS_W) * 2 * Math.PI;
             for (let i = 0; i < count; i++) {
-                const angle = (i / count) * 2 * Math.PI + Math.random() * 0.5;
-                const spawnX = center.x + Math.cos(angle) * radius;
-                const spawnY = center.y + Math.sin(angle) * radius;
+                const ang = (i / count) * 2 * Math.PI + Math.random() * 0.5;
+                const offset = basisA.clone().multiplyScalar(Math.cos(ang) * angRadius)
+                               .add(basisB.clone().multiplyScalar(Math.sin(ang) * angRadius));
+                const pos = centerVec.clone().add(offset).normalize();
+                const uv = utils.spherePosToUv(pos, 1);
                 const newEnemy = spawnEnemy(false, null, {
-                    x: spawnX,
-                    y: spawnY
+                    x: uv.u * CANVAS_W,
+                    y: uv.v * CANVAS_H
                 });
                 if (state.arenaMode && newEnemy) newEnemy.targetBosses = true;
             }
         };
-        spawnInCircle(6, 60, b);
-        setTimeout(() => spawnInCircle(6, 120, b), 1000);
+        spawnInOrbit(6, 60, b);
+        setTimeout(() => spawnInOrbit(6, 120, b), 1000);
     }
 }, {
     id: "reflector",

--- a/script.js
+++ b/script.js
@@ -603,8 +603,12 @@ window.addEventListener('load', () => {
       await html2canvas(modal,{backgroundColor:null,canvas:target,width:1280,height:960,scale:1});
       modal.classList.remove('is-rendering');
       panelCache.set(modalSel,target);
+    } else {
+      target = panelCache.get(modalSel);
     }
-    holographicPanel.setAttribute('canvas-texture',canvasSel);
+    // Yield to ensure texture upload does not stall the frame
+    await new Promise(r=>setTimeout(r,0));
+    holographicPanel.setAttribute('canvas-texture',`#${target.id}`);
     holographicPanel.setAttribute('visible',true);
     vrState.holographicPanelVisible=true;
     AudioManager.playSfx('uiModalOpen');
@@ -618,7 +622,8 @@ window.addEventListener('load', () => {
       ['#ascensionGridModal','#ascensionGridCanvas'],
       ['#aberrationCoreModal','#aberrationCanvas'],
       ['#orreryModal','#orreryCanvas'],
-      ['#settingsModal','#settingsCanvas']
+      ['#settingsModal','#settingsCanvas'],
+      ['#levelSelectModal','#levelSelectCanvas']
     ];
     for(const [modalSel,canvasSel] of panels){
       const modal = document.querySelector(modalSel);


### PR DESCRIPTION
## Summary
- pre-render all menus including stage select
- show holographic panels without blocking the frame
- expand Splitter Sentinel death spawns to a 3D orbit
- update agent TODO list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68875f461ec0833193b47a535a305271