### PR TITLE
Implement basic telemetry and update agent tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Adherence to these constraints is crucial for a successful implementation.
 - Expand boss attack patterns to use full 3D positioning and effects.
 - Replace DOM-based UI dependencies in `modules/ui.js` with A-Frame components for health, shield, ascension and ability slots.
 - Integrate telegraph system with other boss abilities like shrinking boxes and shaper runes.
-- Add VR performance telemetry logging and analytics hooks.
+- Integrate remote analytics upload for performance telemetry.
 
 ## NEED
 - High-contrast emoji textures for improved readability.
@@ -79,3 +79,4 @@ Adherence to these constraints is crucial for a successful implementation.
 - QA across varied room-scale setups to verify recenter functionality.
 - Voice actor for in-game tutorial narration.
 - Playtesting pathfinding on complex stage layouts.
+- Analytics endpoint credentials for telemetry upload.

--- a/modules/telemetry.js
+++ b/modules/telemetry.js
@@ -1,0 +1,44 @@
+// modules/telemetry.js
+//
+// Lightweight performance telemetry for Eternal Momentum VR. This module
+// tracks average frames per second and exposes a hook for sending metrics
+// to external analytics services.
+
+export const Telemetry = {
+  frames: 0,
+  lastTime: 0,
+  reportCallback: null,
+  interval: null,
+
+  /**
+   * Begin capturing frame data.
+   * @param {Function} [reportFn] Optional callback that receives {fps, ts}.
+   */
+  start(reportFn) {
+    this.reportCallback = reportFn;
+    this.frames = 0;
+    this.lastTime = performance.now();
+    this.interval = setInterval(() => {
+      const now = performance.now();
+      const fps = (this.frames / (now - this.lastTime)) * 1000;
+      const payload = { fps: Math.round(fps * 10) / 10, ts: Date.now() };
+      console.log('[Telemetry]', payload);
+      if (typeof this.reportCallback === 'function') {
+        try { this.reportCallback(payload); } catch(e) {}
+      }
+      this.frames = 0;
+      this.lastTime = now;
+    }, 5000);
+  },
+
+  /** Record a rendered frame. Call once per RAF tick. */
+  recordFrame() {
+    this.frames++;
+  },
+
+  /** Stop telemetry collection. */
+  stop() {
+    if (this.interval) clearInterval(this.interval);
+    this.interval = null;
+  }
+};

--- a/script.js
+++ b/script.js
@@ -21,6 +21,7 @@ import { updateEnemies3d } from './modules/enemyAI3d.js';
 import { updateProjectiles3d } from './modules/projectilePhysics3d.js';
 import { AudioManager } from './modules/audio.js';
 import { STAGE_CONFIG } from './modules/config.js';
+import { Telemetry } from './modules/telemetry.js';
 
 // -----------------------------------------------------------------------------
 // A‑Frame helper: apply a live canvas as a texture to any mesh.
@@ -709,6 +710,7 @@ window.addEventListener('load', () => {
   // ---------------------------------------------------------------------------
   function animate(){
     requestAnimationFrame(animate);
+    Telemetry.recordFrame();
     if(!vrState.isGameRunning||state.isPaused) return;
 
     // Map VR cursor to legacy (u,v) for gameLoop
@@ -1026,5 +1028,6 @@ window.addEventListener('load', () => {
     if(e.key === 'r' || e.key === 'R') recenterCommandDeck();
   });
 
+  Telemetry.start();
   animate();
 });


### PR DESCRIPTION
## Summary
- add a lightweight performance telemetry module
- hook telemetry start and frame recording into the main runtime
- update `AGENTS.md` TODO/NEED lists with next steps

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887678fcdec8331added5801b4db0c5