### PR TITLE
Implement new telegraph warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,8 @@ Adherence to these constraints is crucial for a successful implementation.
 ## TODO
 - Expand boss attack patterns to use full 3D positioning and effects.
 - Replace DOM-based UI dependencies in `modules/ui.js` with A-Frame components for health, shield, ascension and ability slots.
-- Integrate telegraph system with other boss abilities like shrinking boxes and shaper runes.
 - Implement command cluster layout around the player using A-Frame.
+- Refine haptic feedback and controller vibrations for key actions.
 
 ## NEED
 - High-contrast emoji textures for improved readability.
@@ -101,3 +101,4 @@ Adherence to these constraints is crucial for a successful implementation.
 - Playtesting pathfinding on complex stage layouts.
 - Interface for viewing saved telemetry metrics in-game.
 - Localization support for the telemetry privacy notice.
+- VR accessibility options for colorblind users.

--- a/modules/bosses.js
+++ b/modules/bosses.js
@@ -1417,16 +1417,27 @@ export const bossData = [{
             b.lastWallSummon = Date.now();
             gameHelpers.play('wallSummon');
             const boxSize = Math.min(ctx.canvas.width, ctx.canvas.height) * 0.8;
-            state.effects.push({
-                type: 'shrinking_box',
+            const warn = {
+                type: 'shrinking_box_warning',
                 startTime: Date.now(),
-                duration: 6000,
+                duration: 1500,
                 x: state.player.x,
                 y: state.player.y,
-                initialSize: boxSize,
-                gapSide: Math.floor(Math.random() * 4),
-                gapPosition: Math.random()
-            });
+                size: boxSize
+            };
+            state.effects.push(warn);
+            setTimeout(() => {
+                state.effects.push({
+                    type: 'shrinking_box',
+                    startTime: Date.now(),
+                    duration: 6000,
+                    x: warn.x,
+                    y: warn.y,
+                    initialSize: boxSize,
+                    gapSide: Math.floor(Math.random() * 4),
+                    gapPosition: Math.random()
+                });
+            }, 1500);
         }
     },
     onDeath: (b, state, sE, sP, play, stopLoopingSfx) => {
@@ -1947,19 +1958,32 @@ export const bossData = [{
             ].sort(() => Math.random() - 0.5);
 
             for (let i = 0; i < 3; i++) {
-                const rune = {
-                    type: 'shaper_rune',
+                const warn = {
+                    type: 'shaper_rune_warning',
                     runeType: shuffledRunes[i],
                     x: positions[i].x,
                     y: positions[i].y,
                     r: 60,
-                    endTime: now + 4000,
+                    startTime: now,
+                    duration: 1000,
                     sourceBoss: b
                 };
-                state.effects.push(rune);
-                b.activeRunes.push(rune);
+                state.effects.push(warn);
+                setTimeout(() => {
+                    const rune = {
+                        type: 'shaper_rune',
+                        runeType: warn.runeType,
+                        x: warn.x,
+                        y: warn.y,
+                        r: warn.r,
+                        endTime: Date.now() + 4000,
+                        sourceBoss: b
+                    };
+                    state.effects.push(rune);
+                    b.activeRunes.push(rune);
+                }, 1000);
             }
-            b.phaseTimer = now + 4000;
+            b.phaseTimer = now + 5000;
         }
         
         else if (b.phase === 'prophecy' && now > b.phaseTimer) {

--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -1504,6 +1504,21 @@ export function gameTick(mx, my) {
                 state.effects.splice(i, 1);
             }
         }
+        else if (effect.type === 'shrinking_box_warning') {
+            const progress = (Date.now() - effect.startTime) / effect.duration;
+            const size = effect.size;
+            const half = size / 2;
+            const left = effect.x - half, right = effect.x + half;
+            const top = effect.y - half, bottom = effect.y + half;
+            ctx.strokeStyle = 'rgba(211,84,0,' + (0.3 + 0.7 * progress) + ')';
+            ctx.lineWidth = 4;
+            ctx.strokeRect(left, top, size, size);
+            if (progress >= 1) {
+                state.effects.splice(i, 1);
+                i--;
+                continue;
+            }
+        }
         else if (effect.type === 'shrinking_box') {
             playLooping('wallShrink');
             const progress = (Date.now() - effect.startTime) / effect.duration;
@@ -1542,6 +1557,19 @@ export function gameTick(mx, my) {
                 ctx.fillRect(left, top, wallThickness, gapStart);
                 ctx.fillRect(left, top + gapStart + gapSize, wallThickness, currentSize - gapStart - gapSize);
             } else { ctx.fillRect(left, top, wallThickness, currentSize); }
+        }
+        else if (effect.type === 'shaper_rune_warning') {
+            const progress = (Date.now() - effect.startTime) / effect.duration;
+            ctx.strokeStyle = 'rgba(241,196,15,' + (0.3 + 0.7 * progress) + ')';
+            ctx.lineWidth = 3;
+            ctx.beginPath();
+            ctx.arc(effect.x, effect.y, effect.r, 0, Math.PI * 2);
+            ctx.stroke();
+            if (progress >= 1) {
+                state.effects.splice(i, 1);
+                i--;
+                continue;
+            }
         }
         else if (effect.type === 'shaper_rune') {
             const runeSymbols = { nova: '💫', shockwave: '💥', lasers: '☄️', heal: '❤️', speed_buff: '🚀' };


### PR DESCRIPTION
## Summary
- show telegraph box before Centurion's shrinking prison
- warn players of Shaper runes before they appear
- render new warning effects in the main loop
- update task lists in `AGENTS.md`

## Testing
- `node -c modules/bosses.js >/dev/null`
- `node -c modules/gameLoop.js >/dev/null`

------
https://chatgpt.com/codex/tasks/task_e_6887746ff73083319f0286f7fe98711e