### PR TITLE
Implement telemetry panel and audio sliders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,9 @@ Adherence to these constraints is crucial for a successful implementation.
 
 ## TODO
 - Expand boss attack patterns to use full 3D positioning and effects.
-- Build a telemetry panel in VR to review performance metrics.
-- Add volume sliders for music and SFX in the settings panel.
 - Implement localization framework starting with the privacy notice text.
+- Optimize holographic menu rendering to eliminate button click freezes.
+- Implement colorblind accessibility options for the VR HUD.
 
 ## NEED
 - High-contrast emoji textures for improved readability.
@@ -99,6 +99,6 @@ Adherence to these constraints is crucial for a successful implementation.
 - QA across varied room-scale setups to verify recenter functionality.
 - Voice actor for in-game tutorial narration.
 - Playtesting pathfinding on complex stage layouts.
-- Interface for viewing saved telemetry metrics in-game.
 - Localization support for the telemetry privacy notice.
 - VR accessibility options for colorblind users.
+- Performance optimization of draw calls and memory usage.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The battlefield is the entire inner surface of a **massive, hollow sphere** that
 * **Holographic Menus:** Complex menus like the Ascension Grid appear as large, interactive holographic panels.
 * **Physical Buttons:** Common actions are mapped to large, physical 3D buttons on the floating panels.
 * **Holographic Status Display:** A projector displays floating, 3D icons of your equipped powers and a detailed hologram of your attuned **Aberration Core**.
+* **Audio Controls:** The settings panel provides sliders for music and SFX volume.
 
 ### 4. Core Gameplay Loop & VR Control Scheme
 * **Targeting on the Sphere:** Your hand controller projects a **cursor** onto the **inner surface of the gameplay sphere**.
@@ -144,7 +145,7 @@ The battlefield is the entire inner surface of a **massive, hollow sphere** that
 
 ---
 ## Telemetry & Privacy
-Eternal Momentum VR can optionally record anonymous performance data such as average frame rate. Data is stored **only** in the browser's localStorage for local troubleshooting. Telemetry is **disabled by default** and can be enabled in the in‑game settings panel. No personal information is collected or transmitted anywhere.
+Eternal Momentum VR can optionally record anonymous performance data such as average frame rate. Data is stored **only** in the browser's localStorage for local troubleshooting. Telemetry is **disabled by default** and can be enabled in the in‑game settings panel. A dedicated **Telemetry** panel on the command deck lists recent frame‑rate samples. No personal information is collected or transmitted anywhere.
 
 ---
 ### User Feedback from Testing

--- a/index.html
+++ b/index.html
@@ -166,6 +166,19 @@
       </a-entity>
     </a-plane>
 
+    <!-- Telemetry panel -->
+    <a-plane id="telemetryPanel" class="interactive"
+             width="2.5" height="1.6"
+             position="0 1.8 -2.3"
+             visible="false">
+      <a-entity mixin="console-button" id="closeTelemetryBtn"
+                position="0 -0.6 0.02" class="interactive">
+        <a-text value="Close" align="center" width="1" color="#eaf2ff" position="0 0 0.06"></a-text>
+      </a-entity>
+      <a-text id="telemetryTitle" value="Performance Logs" align="center" width="2.2" color="#eaf2ff" position="0 0.4 0.02"></a-text>
+      <a-text id="telemetryContent" align="left" width="2.2" wrap-count="40" color="#eaf2ff" position="-1.1 0 0.02"></a-text>
+    </a-plane>
+
     <!-- Gameplay battleground -->
     <a-sphere id="battleSphere" radius="8"
               segments-height="60" segments-width="60"
@@ -303,6 +316,12 @@
         </label>
         <label>Crosshair Size
           <input id="crosshairSizeRange" type="range" min="0.5" max="1.5" step="0.05">
+        </label>
+        <label>Music Volume
+          <input id="musicVolumeRange" type="range" min="0" max="1" step="0.05">
+        </label>
+        <label>SFX Volume
+          <input id="sfxVolumeRange" type="range" min="0" max="1" step="0.05">
         </label>
         <label>Turn Style
           <select id="turnStyleSelect">


### PR DESCRIPTION
## Summary
- add telemetry panel markup and logic
- add music and SFX volume sliders to settings
- wire up new telemetry button on command deck
- store new audio settings and apply volumes
- update project docs and task lists

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6887797aa0d483318469187705cbf880