### PR TITLE
Add localization and colorblind settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,9 @@ Adherence to these constraints is crucial for a successful implementation.
 
 ## TODO
 - Expand boss attack patterns to use full 3D positioning and effects.
-- Implement localization framework starting with the privacy notice text.
 - Optimize holographic menu rendering to eliminate button click freezes.
-- Implement colorblind accessibility options for the VR HUD.
+- Add in-game language selection in settings.
+- Create high contrast theme toggle for the entire HUD.
 
 ## NEED
 - High-contrast emoji textures for improved readability.
@@ -99,6 +99,6 @@ Adherence to these constraints is crucial for a successful implementation.
 - QA across varied room-scale setups to verify recenter functionality.
 - Voice actor for in-game tutorial narration.
 - Playtesting pathfinding on complex stage layouts.
-- Localization support for the telemetry privacy notice.
-- VR accessibility options for colorblind users.
 - Performance optimization of draw calls and memory usage.
+- Add Spanish language translations for core UI.
+- Custom colorblind-friendly emoji textures.

--- a/index.html
+++ b/index.html
@@ -317,6 +317,9 @@
         <label>Crosshair Size
           <input id="crosshairSizeRange" type="range" min="0.5" max="1.5" step="0.05">
         </label>
+        <label>Colorblind Mode
+          <input id="colorblindToggle" type="checkbox">
+        </label>
         <label>Music Volume
           <input id="musicVolumeRange" type="range" min="0" max="1" step="0.05">
         </label>
@@ -331,6 +334,12 @@
         </label>
         <label>Enable Telemetry
           <input id="telemetryToggle" type="checkbox">
+        </label>
+        <label>Language
+          <select id="languageSelect">
+            <option value="en">English</option>
+            <option value="es">Español</option>
+          </select>
         </label>
         <p id="privacyNote" style="font-size:0.8em; opacity:0.8;">Enabling records anonymous performance data locally only.</p>
       </div>

--- a/modules/localization.js
+++ b/modules/localization.js
@@ -1,0 +1,28 @@
+export const translations = {
+  en: {
+    privacyNote: 'Enabling records anonymous performance data locally only.'
+  },
+  es: {
+    privacyNote: 'Al habilitar, se guardan datos de rendimiento anonimos solo localmente.'
+  }
+};
+
+export function getCurrentLanguage() {
+  return localStorage.getItem('language') || 'en';
+}
+
+export function setLanguage(lang) {
+  localStorage.setItem('language', lang);
+  applyTranslations();
+}
+
+export function t(key) {
+  const lang = getCurrentLanguage();
+  if (translations[lang] && translations[lang][key]) return translations[lang][key];
+  return translations['en'][key] || key;
+}
+
+export function applyTranslations() {
+  const note = document.getElementById('privacyNote');
+  if (note) note.innerText = t('privacyNote');
+}

--- a/script.js
+++ b/script.js
@@ -22,6 +22,7 @@ import { updateProjectiles3d } from './modules/projectilePhysics3d.js';
 import { AudioManager } from './modules/audio.js';
 import { STAGE_CONFIG } from './modules/config.js';
 import { Telemetry, storeTelemetry } from './modules/telemetry.js';
+import { applyTranslations, setLanguage, getCurrentLanguage } from './modules/localization.js';
 
 // -----------------------------------------------------------------------------
 // A‑Frame helper: apply a live canvas as a texture to any mesh.
@@ -131,6 +132,7 @@ window.addEventListener('load', () => {
     vignetteIntensity: 0.4,
     crosshairColor: '#00ffff',
     crosshairSize: 1.0,
+    colorblindMode: false,
     turnStyle: 'smooth',
     telemetryEnabled: false,
     musicVolume: 0.35,
@@ -142,6 +144,7 @@ window.addEventListener('load', () => {
     vignetteIntensity: parseFloat(localStorage.getItem('vignetteIntensity')) || DEFAULT_SETTINGS.vignetteIntensity,
     crosshairColor: localStorage.getItem('crosshairColor') || DEFAULT_SETTINGS.crosshairColor,
     crosshairSize: parseFloat(localStorage.getItem('crosshairSize')) || DEFAULT_SETTINGS.crosshairSize,
+    colorblindMode: localStorage.getItem('colorblindMode') === 'true',
     turnStyle: localStorage.getItem('turnStyle') || DEFAULT_SETTINGS.turnStyle,
     telemetryEnabled: localStorage.getItem('telemetryEnabled') === 'true',
     musicVolume: parseFloat(localStorage.getItem('musicVolume')) || DEFAULT_SETTINGS.musicVolume,
@@ -183,6 +186,7 @@ window.addEventListener('load', () => {
     localStorage.setItem('vignetteIntensity', userSettings.vignetteIntensity);
     localStorage.setItem('crosshairColor', userSettings.crosshairColor);
     localStorage.setItem('crosshairSize', userSettings.crosshairSize);
+    localStorage.setItem('colorblindMode', userSettings.colorblindMode);
     localStorage.setItem('turnStyle', userSettings.turnStyle);
     localStorage.setItem('telemetryEnabled', userSettings.telemetryEnabled);
     localStorage.setItem('musicVolume', userSettings.musicVolume);
@@ -203,6 +207,16 @@ window.addEventListener('load', () => {
     }
     AudioManager.setMusicVolume(userSettings.musicVolume);
     AudioManager.setSfxVolume(userSettings.sfxVolume);
+    applyColorblindMode();
+  }
+
+  function applyColorblindMode(){
+    const hbFill = document.getElementById('vrHealthFill');
+    if(userSettings.colorblindMode){
+      hbFill && hbFill.setAttribute('material','color:#ffd700; emissive:#ffd700; emissiveIntensity:0.6');
+    }else{
+      hbFill && hbFill.setAttribute('material','color:#ff5555; emissive:#ff5555; emissiveIntensity:0.6');
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -348,6 +362,8 @@ window.addEventListener('load', () => {
     const sfx  = document.getElementById('sfxVolumeRange');
     const styleSel = document.getElementById('turnStyleSelect');
     const tele = document.getElementById('telemetryToggle');
+    const langSel = document.getElementById('languageSelect');
+    const cbToggle = document.getElementById('colorblindToggle');
     if(turn){ turn.value = userSettings.turnSpeed; }
     if(vig){ vig.value = userSettings.vignetteIntensity; }
     if(color){ color.value = userSettings.crosshairColor; }
@@ -356,6 +372,8 @@ window.addEventListener('load', () => {
     if(sfx){ sfx.value = userSettings.sfxVolume; }
     if(styleSel){ styleSel.value = userSettings.turnStyle; }
     if(tele){ tele.checked = userSettings.telemetryEnabled; }
+    if(langSel){ langSel.value = getCurrentLanguage(); }
+    if(cbToggle){ cbToggle.checked = userSettings.colorblindMode; }
     await showHolographicPanel('#settingsModal','#settingsCanvas');
   }
 
@@ -962,6 +980,7 @@ window.addEventListener('load', () => {
   // One‑time start‑up: set up deck, light, controllers, events, etc.
   // ---------------------------------------------------------------------------
   loadPlayerState();
+  applyTranslations();
   drawGrid(document.getElementById('gridCanvas'));
   drawButtonTexture(document.getElementById('buttonCanvas'));
   applySettings();
@@ -974,6 +993,8 @@ window.addEventListener('load', () => {
   const sfxVolumeRange     = document.getElementById('sfxVolumeRange');
   const turnStyleSelect   = document.getElementById('turnStyleSelect');
   const telemetryToggle   = document.getElementById('telemetryToggle');
+  const languageSelect    = document.getElementById('languageSelect');
+  const colorblindToggle  = document.getElementById('colorblindToggle');
 
   safeAddEventListener(turnSpeedRange,'input',e=>{ userSettings.turnSpeed = parseFloat(e.target.value); saveSettings(); });
   safeAddEventListener(vignetteRange,'input',e=>{ userSettings.vignetteIntensity = parseFloat(e.target.value); applySettings(); saveSettings(); });
@@ -987,6 +1008,15 @@ window.addEventListener('load', () => {
     saveSettings();
     if(userSettings.telemetryEnabled) Telemetry.start(storeTelemetry);
     else Telemetry.stop();
+  });
+  safeAddEventListener(languageSelect,'input',e=>{
+    setLanguage(e.target.value);
+    saveSettings();
+  });
+  safeAddEventListener(colorblindToggle,'input',e=>{
+    userSettings.colorblindMode = e.target.checked;
+    applySettings();
+    saveSettings();
   });
 
   if(battleSphere){


### PR DESCRIPTION
## Summary
- implement simple localization module and apply it to privacy note
- add language and colorblind toggles in settings
- support colorblind mode for VR HUD
- update TODO and NEED lists in `AGENTS.md`

## Testing
- `node --check modules/localization.js`
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_688781b21468833198cc6dd07b01a8db