### PR TITLE
Tune projectile speed & style VR buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,11 +87,11 @@ Adherence to these constraints is crucial for a successful implementation.
 
 ## TODO
 - Expand boss attack patterns to use full 3D positioning and effects.
-- Style physical buttons for VR UI.
+- Implement holographic menus for in-game panels.
 
 ## NEED
 - Additional sound effects and background music loops.
-- Calibrate enemy projectile speed for VR.
+- Tune boss health values for VR balance.
 
 ## Workflow for Agents
 1. Review `README.md` and this `AGENTS.md` before starting work.

--- a/index.html
+++ b/index.html
@@ -61,12 +61,12 @@
     <!-- Reusable mix‑ins & audio assets -->
     <a-assets>
       <a-mixin id="console-button"
-               geometry="primitive: cylinder; radius:0.12; height:0.06"
-               material="color:#0b1020; opacity:0.95; transparent:true;
-                        emissive:#00ffff; emissiveIntensity:0.7; metalness:0.2; roughness:0.4"
+               geometry="primitive: cylinder; radius:0.13; height:0.05"
+               material="shader: standard; color:#0b1020; opacity:0.95; transparent:true;
+                        emissive:#00ffff; emissiveIntensity:0.8; metalness:0.3; roughness:0.5"
                animation__press="property: position; startEvents: mousedown; dir: alternate; dur: 100; to: 0 -0.02 0"
                animation__release="property: position; startEvents: mouseup; dir: alternate; dur: 100; to: 0 0 0"
-               animation__hover="property: material.emissiveIntensity; startEvents: mouseenter; dir: alternate; dur: 200; to: 1.5">
+               animation__hover="property: material.emissiveIntensity; startEvents: mouseenter; dir: alternate; dur: 200; to: 1.6">
       </a-mixin>
 
       <a-mixin id="console-panel"

--- a/modules/config.js
+++ b/modules/config.js
@@ -92,3 +92,8 @@ export const STAGE_CONFIG = [
     { stage: 29, displayName: 'The Shaper of Fate',   bosses: ['shaper_of_fate'] },
     { stage: 30, displayName: 'The Pantheon',         bosses: ['pantheon'] }
 ];
+
+// Global tuning values for the VR prototype
+// Scale factor applied to all enemy projectile velocities. Can be tweaked for
+// comfort as the VR movement speed is refined.
+export const VR_PROJECTILE_SPEED_SCALE = 0.85;

--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { state } from './state.js';
 import { uvToSpherePos, spherePosToUv } from './utils.js';
+import { VR_PROJECTILE_SPEED_SCALE } from './config.js';
 
 const dataMap = new WeakMap();
 const projectileTypes = new Set([
@@ -17,10 +18,17 @@ export function updateProjectiles3d(radius, width, height){
     let d = dataMap.get(p);
     if(!d){
       const pos = uvToSpherePos(p.x/width, p.y/height, radius);
+      // Apply VR speed scale once when the projectile is first seen
+      p.dx *= VR_PROJECTILE_SPEED_SCALE;
+      p.dy *= VR_PROJECTILE_SPEED_SCALE;
       d = { pos };
       dataMap.set(p,d);
     }
-    const nextPos = uvToSpherePos((p.x + p.dx)/width, (p.y + p.dy)/height, radius);
+    const nextPos = uvToSpherePos(
+      (p.x + p.dx) / width,
+      (p.y + p.dy) / height,
+      radius
+    );
     const vel = nextPos.clone().sub(d.pos);
     d.pos.add(vel).normalize().multiplyScalar(radius);
     const uv = spherePosToUv(d.pos, radius);

--- a/script.js
+++ b/script.js
@@ -549,15 +549,15 @@ window.addEventListener('load', () => {
       wrapper.object3D.lookAt(new THREE.Vector3(0,cfg.y,0));
 
       const ring=document.createElement('a-torus');
-      ring.setAttribute('geometry','primitive: torus; radius:0.17; radiusTubular:0.01; segmentsTubular:12');
-      ring.setAttribute('material','color:#00ffff; emissive:#00ffff; emissiveIntensity:0.5; opacity:0.5; transparent:true');
+      ring.setAttribute('geometry','primitive: torus; radius:0.17; radiusTubular:0.01; segmentsTubular:20');
+      ring.setAttribute('material','color:#00ffff; emissive:#00ffff; emissiveIntensity:0.6; opacity:0.45; transparent:true');
       ring.object3D.position.set(0,-0.035,0);
       wrapper.appendChild(ring);
 
       const base=document.createElement('a-cylinder');
       base.setAttribute('radius',0.15);
       base.setAttribute('height',0.02);
-      base.setAttribute('material','color:#050510; emissive:#00ffff; emissiveIntensity:0.35; metalness:0.2; roughness:0.6');
+      base.setAttribute('material','shader: standard; color:#050510; emissive:#00ffff; emissiveIntensity:0.4; metalness:0.25; roughness:0.6');
       base.object3D.position.set(0,-0.03,0);
       wrapper.appendChild(base);
 


### PR DESCRIPTION
## Summary
- retune enemy projectiles for VR using `VR_PROJECTILE_SPEED_SCALE`
- restyle console buttons with emissive glow and better materials
- adjust ring and base on generated buttons
- update TODO/NEED roadmap in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887c7d308288331bd1d1a70ca9d27b2