### PR TITLE
Fix THREE module import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,9 @@ Adherence to these constraints is crucial for a successful implementation.
 
 ## TODO
 - Expand boss attack patterns to use full 3D positioning and effects.
-- Implement holographic menus for in-game panels.
 - preform significant debugging until the game is stable.
 - invesegate render issues and focus on compatiblity with meta quest 3 web browser.
+- create unit tests for navmesh pathfinding to ensure 3D movement reliability.
 
 ## NEED
 - Additional sound effects and background music loops.

--- a/README.md
+++ b/README.md
@@ -154,5 +154,5 @@ Eternal Momentum VR can optionally record anonymous performance data such as ave
 Recent playtesting revealed several issues that need to be addressed:
 
 * loading screen hangs on 0% and VR option comes up but we are not at the home screen, we never see the home screen.
-* Console error - Eternal-Momentum-VR/:1 Uncaught TypeError: Failed to resolve module specifier "three". Relative references must start with either "/", "./", or "../".
+* Console error - Eternal-Momentum-VR/:1 Uncaught TypeError: Failed to resolve module specifier "three". Relative references must start with either "/", "./", or "../". ✅ Fixed by removing direct imports of the "three" module and relying on the global THREE namespace provided by A-Frame.
 * when we enter VR we only see some kind of green ball under us, everything else is black and does not show up.

--- a/modules/navmesh.js
+++ b/modules/navmesh.js
@@ -1,4 +1,6 @@
-import * as THREE from 'three';
+// Use global THREE provided by A-Frame in the browser. Tests provide it via node
+// "three" package, so no import is required here to avoid an unresolved module
+// specifier error in browsers.
 import { state } from './state.js';
 import { uvToSpherePos, spherePosToUv } from './utils.js';
 

--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -1,4 +1,6 @@
-import * as THREE from 'three';
+// Access the global THREE instance supplied by A-Frame at runtime. Tests expose
+// the same namespace via the "three" npm package so we avoid importing it here
+// to keep the browser build working without a bundler.
 import { state } from './state.js';
 import { uvToSpherePos, spherePosToUv } from './utils.js';
 import { VR_PROJECTILE_SPEED_SCALE } from './config.js';


### PR DESCRIPTION
## Summary
- rely on global `THREE` instead of importing the package so the browser build loads
- document the fix in README feedback section
- remove the completed holographic menu item from `AGENTS.md` and add a new follow-up task

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887cebdee6c8331bf4a697276fb1f4a