### PR TITLE
Ensure VR UI styling and wording match original game

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,11 +42,11 @@
       <source src="assets/home.mp4" type="video/mp4">
     </video>
     <div id="homeOverlay">
-      <h1 id="gameTitle">ETERNAL MOMENTUM VR</h1>
+      <h1 id="gameTitle">ETERNAL MOMENTUM</h1>
       <div id="homeActions">
-        <button id="startVrBtn" class="home-btn">BEGIN</button>
-        <button id="continueVrBtn" class="home-btn" style="display:none;">CONTINUE</button>
-        <button id="eraseVrBtn" class="home-btn erase" style="display:none;">ERASE TIMELINE</button>
+        <button id="startVrBtn" class="home-btn">AWAKEN</button>
+        <button id="continueVrBtn" class="home-btn" style="display:none;">CONTINUE MOMENTUM</button>
+        <button id="eraseVrBtn" class="home-btn erase" style="display:none;">SEVER TIMELINE</button>
       </div>
     </div>
   </div>
@@ -157,19 +157,19 @@
       <a-text value="TIMELINE COLLAPSED" align="center" width="2.2" color="#ff8080" position="0 0.4 0.02"></a-text>
       <a-entity mixin="console-button" id="retryBtn"
                 position="0 0.1 0.02" class="interactive">
-        <a-text value="Restart" align="center" width="1" color="#eaf2ff" position="0 0 0.06"></a-text>
+        <a-text value="Restart Stage" align="center" width="1" color="#eaf2ff" position="0 0 0.06"></a-text>
       </a-entity>
       <a-entity mixin="console-button" id="gameOverAscBtn"
                 position="-0.8 -0.3 0.02" class="interactive">
-        <a-text value="Ascension" align="center" width="1" color="#eaf2ff" position="0 0 0.06"></a-text>
+        <a-text value="Ascension Conduit" align="center" width="1.8" color="#eaf2ff" position="0 0 0.06"></a-text>
       </a-entity>
       <a-entity mixin="console-button" id="gameOverCoreBtn"
                 position="0 -0.3 0.02" class="interactive">
-        <a-text value="Cores" align="center" width="1" color="#eaf2ff" position="0 0 0.06"></a-text>
+        <a-text value="Aberration Cores" align="center" width="1.8" color="#eaf2ff" position="0 0 0.06"></a-text>
       </a-entity>
       <a-entity mixin="console-button" id="gameOverStageBtn"
                 position="0.8 -0.3 0.02" class="interactive">
-        <a-text value="Stages" align="center" width="1" color="#eaf2ff" position="0 0 0.06"></a-text>
+        <a-text value="Stage Select" align="center" width="1.5" color="#eaf2ff" position="0 0 0.06"></a-text>
       </a-entity>
     </a-plane>
 

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,20 @@
 /* Basic stylesheet for Eternal Momentum VR prototype. */
 
 :root {
+  /* Match color variables from the 2‑D game for a consistent theme */
   --primary-glow: #00ffff;
-  --secondary-glow: #ff00ff;
-  --nexus-glow: #00ff00;
-  --dark-bg: #000;
-  --ui-bg: rgba(20,20,40,0.85);
+  --secondary-glow: #f000ff;
+  --dark-bg: #1e1e2f;
+  --ui-bg: rgba(20, 20, 40, 0.85);
+  --border-color: rgba(0, 255, 255, 0.4);
   --font-color: #eaf2ff;
+  --health-high: #3498db;
+  --health-medium: #f1c40f;
+  --health-low: #e74c3c;
+  --health-bar-bg: #444;
+  --disabled-color: rgba(255, 255, 255, 0.2);
+  --shield-color: rgba(241, 196, 15, 0.7);
+  --nexus-glow: #00ff00;
 }
 
 html, body {
@@ -16,7 +24,8 @@ html, body {
   padding: 0;
   background: var(--dark-bg);
   overflow: hidden;
-  font-family: sans-serif;
+  /* Use the same font stack as the original game */
+  font-family: 'Segoe UI', 'Roboto', sans-serif;
   color: var(--font-color);
 }
 


### PR DESCRIPTION
## Summary
- sync color variables in `styles.css` with original game's palette
- use original font stack for consistent typography
- update home screen labels and game over panel texts to match the 2‑D version

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887e1253830833193c54b794c0af649