### PR TITLE
Fix deck floor shading

### DIFF
--- a/script.js
+++ b/script.js
@@ -579,7 +579,7 @@ window.addEventListener('load', () => {
     deckFloor.setAttribute('id','deckFloor');
     deckFloor.setAttribute('radius',3);
     deckFloor.setAttribute('rotation','-90 0 0');
-    deckFloor.setAttribute('material','transparent:true; opacity:0.6; side:double');
+    deckFloor.setAttribute('material','shader:flat; transparent:true; opacity:0.6; side:double');
     deckFloor.setAttribute('canvas-texture','#gridCanvas');
     commandDeck.appendChild(deckFloor);
 


### PR DESCRIPTION
## Summary
- ensure the command deck floor uses a flat shader so the neon grid is visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68881409019c833199deed3e01b95ee6