### PR TITLE
Fix multiple bugs across VR codebase

### DIFF
--- a/modules/ascension.js
+++ b/modules/ascension.js
@@ -236,7 +236,7 @@ function purchaseTalent(talentId) {
 
     } else {
         AudioManager.playSfx('talentError');
-        console.log("Cannot purchase talent! Not enough AP or prerequisites not met.");
+        console.warn("Cannot purchase talent! Not enough AP or prerequisites not met.");
     }
 }
 

--- a/modules/audio.js
+++ b/modules/audio.js
@@ -145,6 +145,11 @@ export const AudioManager = {
     },
 
     _fade(audioElement, startVol, endVol, duration, onComplete) {
+        if (duration <= 0) {
+            audioElement.volume = endVol;
+            if(onComplete) onComplete();
+            return;
+        }
         this.isFading = true;
         let currentVol = startVol;
         audioElement.volume = currentVol;

--- a/modules/powers.js
+++ b/modules/powers.js
@@ -44,7 +44,7 @@ export const powers={
   shockwave:{emoji:"💥",desc:"Expanding wave damages enemies.",apply:(utils, game, mx, my, options = {})=>{
       const { damageModifier = 1.0, origin = state.player } = options;
       let speed = 800;
-      let radius = Math.max(innerWidth, innerHeight);
+      let radius = Math.max(window.innerWidth, window.innerHeight);
       let damage = (((state.player.berserkUntil > Date.now()) ? 30 : 15) * state.player.talent_modifiers.damage_multiplier) * damageModifier;
       state.effects.push({ type: 'shockwave', caster: origin, x: origin.x, y: origin.y, radius: 0, maxRadius: radius, speed: speed, startTime: Date.now(), hitEnemies: new Set(), damage: damage });
       game.play('shockwaveSound');
@@ -137,15 +137,15 @@ export const powers={
         game.play('gravitySound'); 
         state.gravityActive=true; 
         state.gravityEnd=Date.now()+1000; 
-        utils.spawnParticles(state.particles, innerWidth/2, innerHeight/2,"#9b59b6",100,4,40,5); 
+        utils.spawnParticles(state.particles, window.innerWidth/2, window.innerHeight/2,"#9b59b6",100,4,40,5);
         
         if (state.player.purchasedTalents.has('temporal-collapse')) {
             setTimeout(() => {
                 if(state.gameOver) return;
                 state.effects.push({ 
                     type: 'slow_zone', 
-                    x: innerWidth / 2, 
-                    y: innerHeight / 2, 
+                    x: window.innerWidth / 2,
+                    y: window.innerHeight / 2,
                     r: 250, 
                     endTime: Date.now() + 4000 
                 });
@@ -153,7 +153,18 @@ export const powers={
         }
     }
   },
-  speed:{emoji:"🚀",desc:"Speed Boost for 5s",apply:(utils, game)=>{ state.player.speed*=1.5; game.addStatusEffect('Speed Boost', '🚀', 5000); utils.spawnParticles(state.particles, state.player.x,state.player.y,"#00f5ff",40,3,30,5); setTimeout(()=>state.player.speed/=1.5,5000); }},
+  speed:{emoji:"🚀",desc:"Speed Boost for 5s",apply:(utils, game)=>{
+      if(!state.player.speedBoostActive){
+          state.player.speedBoostActive = true;
+          state.player.speed *= 1.5;
+      }
+      game.addStatusEffect('Speed Boost', '🚀', 5000);
+      utils.spawnParticles(state.particles, state.player.x,state.player.y,"#00f5ff",40,3,30,5);
+      setTimeout(()=>{
+          state.player.speedBoostActive = false;
+          state.player.speed /= 1.5;
+      },5000);
+  }},
   freeze:{emoji:"🧊",desc:"Freeze enemies for 4s",apply:(utils, game)=>{
       state.enemies.forEach(e=>{
           if (e.id === 'fractal_horror' || e.isFriendly) return;

--- a/modules/state.js
+++ b/modules/state.js
@@ -31,8 +31,10 @@ export const state = {
     maxHealth: 100,
     health: 100,
     shield: false,
+    shield_end_time: 0,
     stunnedUntil: 0,
     berserkUntil: 0,
+    speedBoostActive: false,
     controlsInverted: false,
     statusEffects: [],
     level: 1,
@@ -218,7 +220,9 @@ export function resetGame(isArena = false) {
   state.player.statusEffects = [];
   state.player.activePantheonBuffs = [];
   state.player.shield = false;
+  state.player.shield_end_time = 0;
   state.player.berserkUntil = 0;
+  state.player.speedBoostActive = false;
   state.player.talent_states.phaseMomentum.lastDamageTime = Date.now();
   state.player.talent_states.reactivePlating.cooldownUntil = 0;
   state.player.infected = false;

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -64,7 +64,7 @@ function updatePantheonUI() {
         const coreData = bossData.find(b => b.id === buff.coreId);
         if (!coreData) return;
 
-        const remaining = (buff.endTime - now) / 1000;
+        const remaining = Math.max(0, (buff.endTime - now) / 1000);
         
         const iconEl = document.createElement('div');
         iconEl.className = 'pantheon-buff-icon';
@@ -92,7 +92,7 @@ function updateStatusEffectsUI() {
 
     state.player.statusEffects.forEach(effect => {
         const remaining = effect.endTime - now;
-        const duration = effect.endTime - effect.startTime;
+        const duration = Math.max(1, effect.endTime - effect.startTime);
         const progress = Math.max(0, remaining) / duration;
         const iconEl = document.createElement('div');
         iconEl.className = 'status-icon';

--- a/script.js
+++ b/script.js
@@ -533,7 +533,6 @@ window.addEventListener('load', () => {
     if(styleSel){ styleSel.value = userSettings.turnStyle; }
     if(tele){ tele.checked = userSettings.telemetryEnabled; }
     if(hcToggle){ hcToggle.checked = userSettings.highContrast; }
-    if(hcToggle){ hcToggle.checked = userSettings.highContrast; }
     await showHolographicPanel('#settingsModal','#settingsCanvas');
   }
 


### PR DESCRIPTION
## Summary
- initialize missing `shield_end_time` and `speedBoostActive` fields
- clean up duplicated settings code
- fix innerWidth references and speed boost logic
- guard duration maths in UI helpers
- improve audio fade and warning message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888199e34dc83318a2aacebd21ab002