### PR TITLE
fix: load three.js without bundling

### DIFF
--- a/modules/vrCommandCluster.js
+++ b/modules/vrCommandCluster.js
@@ -1,4 +1,7 @@
-import * as THREE from 'three';
+// Use local three.js bundle so the browser can load the module without
+// a build step. Node-based unit tests still resolve the package name
+// "three" via node_modules.
+import * as THREE from '../node_modules/three/build/three.module.js';
 import { powers } from './powers.js';
 
 const PANEL_DEFS = [


### PR DESCRIPTION
## Summary
- reference three.js via relative path so browsers can load it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688828e2e1e0833183a449626bba3c74