### PR TITLE
Implement ProjectileManager and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ This document serves two critical functions:
 | :--- | :--- | :--- | :--- |
 | **F-01** | Create `AssetManager.js` | Must handle loading/caching of assets. | **Done** |
 | **F-02**| Create `BaseAgent.js` | Must extend `THREE.Group`. Must include health, damage, death, and update methods. | **Done**|
-| **F-03** | Create `ProjectileManager.js` | Manages an object pool of projectiles, their movement, and collisions. | **To Do** |
+| **F-03** | Create `ProjectileManager.js` | Manages an object pool of projectiles, their movement, and collisions. | **Done** |
 
 ### Phase 2: Complete Boss Implementation Plan
 * **Detailed Implementation (B1-B10)**: Implement these bosses using the detailed guides below.
@@ -62,11 +62,10 @@ This document serves two critical functions:
 | Date | Task ID | Agent/System Implemented | Notes |
 | :--- | :--- | :--- | :--- |
 | 2025-07-29 | F-01/F-02 |`AssetManager.js`, `BaseAgent.js` | Initial foundational modules created. |
-| | | | |
+| 2025-07-29 | F-03 |`ProjectileManager.js` | Basic projectile pooling and update logic implemented. |
 
 ### Next Steps
-1.  **Implement Task F-03:** Create the `ProjectileManager.js` module.
-2.  **Begin Task B1:** Create `SplitterAI.js` and implement its state machine.
+1.  **Begin Task B1:** Create `SplitterAI.js` and implement its state machine.
 
 ---
 

--- a/modules/ProjectileManager.js
+++ b/modules/ProjectileManager.js
@@ -1,0 +1,34 @@
+const pool = [];
+const active = [];
+
+export function spawnProjectile(props = {}) {
+  const p = pool.pop() || {};
+  Object.assign(p, props);
+  p.alive = true;
+  active.push(p);
+  return p;
+}
+
+export function updateProjectiles(stepFn, collisionFn) {
+  for (let i = active.length - 1; i >= 0; i--) {
+    const p = active[i];
+    if (stepFn) stepFn(p);
+    if (collisionFn && collisionFn(p)) {
+      p.alive = false;
+    }
+    if (!p.alive) {
+      active.splice(i, 1);
+      pool.push(p);
+    }
+  }
+}
+
+export function resetProjectiles() {
+  while (active.length) {
+    pool.push(active.pop());
+  }
+}
+
+export function getActiveProjectiles() {
+  return active;
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs"
+    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs && node tests/projectileManager.test.mjs"
   },
   "keywords": [],
   "author": "",

--- a/tests/projectileManager.test.mjs
+++ b/tests/projectileManager.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'assert';
+import { spawnProjectile, updateProjectiles, getActiveProjectiles, resetProjectiles } from '../modules/ProjectileManager.js';
+
+const target = { x: 2, y: 0, r: 1, hp: 3 };
+
+const first = spawnProjectile({ x: 0, y: 0, dx: 1, dy: 0, r: 0.5, damage: 1 });
+
+function step(p) {
+  p.x += p.dx;
+  p.y += p.dy;
+}
+
+function collide(p) {
+  const dx = p.x - target.x;
+  const dy = p.y - target.y;
+  if (Math.hypot(dx, dy) < p.r + target.r) {
+    target.hp -= p.damage;
+    return true;
+  }
+  return false;
+}
+
+updateProjectiles(step, collide);
+updateProjectiles(step, collide);
+
+assert.strictEqual(getActiveProjectiles().length, 0, 'Projectile removed after collision');
+assert.strictEqual(target.hp, 2, 'Target took damage');
+
+const reused = spawnProjectile({ x: 0, y: 0, dx: 1, dy: 0, r: 0.5, damage: 1 });
+assert.strictEqual(reused, first, 'Reused pooled projectile');
+
+resetProjectiles();
+assert.strictEqual(getActiveProjectiles().length, 0, 'Manager reset clears active projectiles');
+
+console.log('projectileManager tests passed');


### PR DESCRIPTION
## Summary
- implement basic projectile pool in `ProjectileManager.js`
- add tests exercising projectile pooling and collision logic
- wire new tests into `npm test`
- mark F-03 task complete in AGENTS.md and log progress

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68891cb69a60833199948cb35f0d4cd7