### PR TITLE
Fix global THREE usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,9 +88,11 @@ The following task list is a **mandatory patch and refactoring directive**. You 
 
 | 2025-07-31 | CI-02 | navmesh.js, utils.js | Removed global THREE dependency |
 | 2025-07-31 | CI-03 | vrCommandCluster.js | Removed obsolete A-Frame HUD module |
+| 2025-07-31 | CI-04 | BaseAgent.js, AssetManager.js, projectilePhysics3d.js | Replaced global THREE with module imports |
 ### Next Steps
 1.  **Execute Fidelity Patch 1.0 sequentially and with absolute adherence to the fidelity requirements.**
-2.  **Halt for user verification and playtest after all FP tasks are complete.**
+2.  Continue removing legacy global dependencies and wiring UI interactions.
+3.  **Halt for user verification and playtest after all FP tasks are complete.**
 
 ## Code Audit & Bug Report (2025-07-30)
 The current repository contains both the original 2D game (under `Eternal-Momentum-OLD GAME/`) and a partial VR rewrite. Key modules and their interactions are:

--- a/modules/AssetManager.js
+++ b/modules/AssetManager.js
@@ -1,3 +1,5 @@
+import * as THREE from '../vendor/three.module.js';
+
 const modelCache = new Map();
 const textureCache = new Map();
 const audioCache = new Map();
@@ -7,7 +9,6 @@ let gltfLoader;
 let textureLoader;
 
 async function ensureLoaders() {
-  if (!globalThis.THREE) throw new Error('THREE global missing');
   if (!gltfLoader) {
     try {
       const { GLTFLoader } = await import('three/addons/loaders/GLTFLoader.js');
@@ -18,8 +19,7 @@ async function ensureLoaders() {
     }
   }
   if (!textureLoader) {
-    const { TextureLoader } = globalThis.THREE;
-    textureLoader = new TextureLoader();
+    textureLoader = new THREE.TextureLoader();
   }
 }
 

--- a/modules/BaseAgent.js
+++ b/modules/BaseAgent.js
@@ -1,5 +1,6 @@
 // BaseAgent.js - foundational 3D agent class
-// Relies on global THREE namespace (provided by A-Frame or tests)
+// Import a local copy of three.js instead of relying on a global THREE
+import * as THREE from '../vendor/three.module.js';
 
 export class BaseAgent extends THREE.Group {
   constructor(options = {}) {

--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -1,6 +1,6 @@
-// Access the global THREE instance supplied by A-Frame at runtime. Tests expose
-// the same namespace via the "three" npm package so we avoid importing it here
-// to keep the browser build working without a bundler.
+// Projectile physics helpers for the VR build.
+// Import three.js directly rather than relying on a global THREE namespace.
+import * as THREE from '../vendor/three.module.js';
 import { state } from './state.js';
 import { uvToSpherePos, spherePosToUv } from './utils.js';
 import { VR_PROJECTILE_SPEED_SCALE } from './config.js';


### PR DESCRIPTION
## Summary
- import three.js instead of relying on global THREE
- update AssetManager loaders to use module imports
- document progress in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68898b4396f88331b44a3ffc4b25eeb0