### PR TITLE
Implement functional Game Over modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ The following task list is a **mandatory patch and refactoring directive**. You 
 | 2025-07-30 | FP-03 | PlayerController.js | Added laser pointer and cursor rendering |
 | 2025-07-30 | FP-04 | UIManager.js | Implemented loading bar and holographic UI materials |
 | 2025-07-30 | FP-05 | SplitterAI.js | Reimplemented Splitter Sentinel boss mechanics |
+| 2025-07-31 | FP-04 | ModalManager.js | Game Over modal buttons restart or open other menus |
+| 2025-07-31 | FP-04 | ModalManager.js | Game Over modal buttons restart or open other menus |
 | **FP-02** | **Player Avatar** | The player avatar is the wrong color, is not movable, and is positioned incorrectly. | 1. **Color:** In `PlayerController.js`, the avatar `THREE.SphereGeometry` MUST use a blue material. The correct hex color is **`#3498db`**. 2. **Position:** The avatar's initial position MUST be on the inner surface of the arena sphere. 3. **Movement:** The `PlayerController`'s `update` loop MUST be fixed to correctly move the avatar's position along the sphere's surface toward the laser pointer's target point. | The player avatar is **blue**, is always on the sphere's surface, and smoothly follows the laser pointer's target. |
 | 2025-07-30 | FP-03 | PlayerController.js | Added laser pointer and cursor rendering |
 | 2025-07-30 | FP-04 | UIManager.js | Implemented loading bar and holographic UI materials |
@@ -85,6 +87,7 @@ The following task list is a **mandatory patch and refactoring directive**. You 
 | 2025-07-30 | FP-03 | PlayerController.js | Added laser pointer and cursor rendering |
 | 2025-07-30 | FP-04 | UIManager.js | Implemented loading bar and holographic UI materials |
 | 2025-07-30 | FP-05 | SplitterAI.js | Reimplemented Splitter Sentinel boss mechanics |
+| 2025-07-31 | FP-04 | ModalManager.js | Game Over modal buttons restart or open other menus |
 
 | 2025-07-31 | CI-02 | navmesh.js, utils.js | Removed global THREE dependency |
 | 2025-07-31 | CI-03 | vrCommandCluster.js | Removed obsolete A-Frame HUD module |

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -1,5 +1,6 @@
 import * as THREE from '../vendor/three.module.js';
 import { getCamera } from './scene.js';
+import { resetGame, state } from './state.js';
 
 let modalGroup;
 const modals = {};
@@ -78,20 +79,26 @@ function createModal(id, title, buttons) {
   return modal;
 }
 
+function restartStage() {
+  resetGame(false);
+  state.isPaused = false;
+  Object.values(modals).forEach(m => m.visible = false);
+}
+
 export function initModals() {
   const group = ensureGroup();
   if (!group || modals.gameOver) return;
 
   modals.gameOver = createModal('gameOver', 'TIMELINE COLLAPSED', [
-    { label: 'Restart Stage', onSelect: () => console.log('Retry') },
-    { label: 'Ascension', onSelect: () => console.log('Ascension') },
-    { label: 'Cores', onSelect: () => console.log('Cores') },
-    { label: 'Stage Select', onSelect: () => console.log('Stages') }
+    { label: 'Restart Stage', onSelect: restartStage },
+    { label: 'Ascension', onSelect: () => showModal('ascension') },
+    { label: 'Cores', onSelect: () => showModal('cores') },
+    { label: 'Stage Select', onSelect: () => showModal('levelSelect') }
   ]);
   group.add(modals.gameOver);
 
   modals.levelSelect = createModal('levelSelect', 'SELECT STAGE', [
-    { label: 'Start', onSelect: () => console.log('Start Stage') },
+    { label: 'Start', onSelect: restartStage },
     { label: 'Close', onSelect: () => hideModal('levelSelect') }
   ]);
   group.add(modals.levelSelect);


### PR DESCRIPTION
## Summary
- add restart functionality and wiring for VR modals
- log FP-04 progress in AGENTS documentation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68898cb9a6248331b3ec38a73cc11936