### PR TITLE
Fix missing THREE imports in AI modules

### DIFF
--- a/modules/agents/AethelUmbraAI.js
+++ b/modules/agents/AethelUmbraAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // Aethel & Umbra duo implementation (Boss B9)

--- a/modules/agents/AnnihilatorAI.js
+++ b/modules/agents/AnnihilatorAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // AnnihilatorAI - Implements boss B16: The Annihilator

--- a/modules/agents/ArchitectAI.js
+++ b/modules/agents/ArchitectAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // ArchitectAI - Implements boss B8: The Architect

--- a/modules/agents/BasiliskAI.js
+++ b/modules/agents/BasiliskAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // BasiliskAI - Implements boss B15: The Basilisk

--- a/modules/agents/CenturionAI.js
+++ b/modules/agents/CenturionAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // CenturionAI - Implements boss B24: The Centurion

--- a/modules/agents/EMPOverloadAI.js
+++ b/modules/agents/EMPOverloadAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // EMPOverloadAI - Implements boss B7: EMP Overload

--- a/modules/agents/EpochEnderAI.js
+++ b/modules/agents/EpochEnderAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // EpochEnderAI - Implements boss B28: The Epoch-Ender

--- a/modules/agents/FractalHorrorAI.js
+++ b/modules/agents/FractalHorrorAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // FractalHorrorAI - Implements boss B25: The Fractal Horror

--- a/modules/agents/GlitchAI.js
+++ b/modules/agents/GlitchAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { moveTowards } from '../movement3d.js';
 

--- a/modules/agents/GravityAI.js
+++ b/modules/agents/GravityAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { uvToSpherePos, spherePosToUv } from '../utils.js';
 

--- a/modules/agents/HelixWeaverAI.js
+++ b/modules/agents/HelixWeaverAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // HelixWeaverAI - Implements boss B27: The Helix Weaver

--- a/modules/agents/JuggernautAI.js
+++ b/modules/agents/JuggernautAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { moveTowards } from '../movement3d.js';
 

--- a/modules/agents/LoopingEyeAI.js
+++ b/modules/agents/LoopingEyeAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // LoopingEyeAI - Implements boss B10: Looping Eye

--- a/modules/agents/MiasmaAI.js
+++ b/modules/agents/MiasmaAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // MiasmaAI - Implements boss B21: The Miasma

--- a/modules/agents/MirrorMirageAI.js
+++ b/modules/agents/MirrorMirageAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { uvToSpherePos } from '../utils.js';
 

--- a/modules/agents/ObeliskAI.js
+++ b/modules/agents/ObeliskAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // ObeliskAI - Implements boss B26: The Obelisk

--- a/modules/agents/PantheonAI.js
+++ b/modules/agents/PantheonAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { moveTowards } from '../movement3d.js';
 import { JuggernautAI } from './JuggernautAI.js';

--- a/modules/agents/ParasiteAI.js
+++ b/modules/agents/ParasiteAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // ParasiteAI - Implements boss B17: The Parasite

--- a/modules/agents/PuppeteerAI.js
+++ b/modules/agents/PuppeteerAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { moveTowards } from '../movement3d.js';
 

--- a/modules/agents/QuantumShadowAI.js
+++ b/modules/agents/QuantumShadowAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // QuantumShadowAI - Implements boss B18: Quantum Shadow

--- a/modules/agents/ReflectorAI.js
+++ b/modules/agents/ReflectorAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 export class ReflectorAI extends BaseAgent {

--- a/modules/agents/SentinelPairAI.js
+++ b/modules/agents/SentinelPairAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { moveTowards } from '../movement3d.js';
 

--- a/modules/agents/ShaperOfFateAI.js
+++ b/modules/agents/ShaperOfFateAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // ShaperOfFateAI - Implements boss B29: The Shaper of Fate

--- a/modules/agents/SingularityAI.js
+++ b/modules/agents/SingularityAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // SingularityAI - Implements boss B20: The Singularity

--- a/modules/agents/SplitterAI.js
+++ b/modules/agents/SplitterAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { spherePosToUv } from '../utils.js';
 import { spawnEnemy } from '../gameLoop.js';

--- a/modules/agents/SwarmLinkAI.js
+++ b/modules/agents/SwarmLinkAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { uvToSpherePos, spherePosToUv } from '../utils.js';
 

--- a/modules/agents/SyphonAI.js
+++ b/modules/agents/SyphonAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // SyphonAI - Implements boss B23: The Syphon

--- a/modules/agents/TemporalParadoxAI.js
+++ b/modules/agents/TemporalParadoxAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // TemporalParadoxAI - Implements boss B22: The Temporal Paradox

--- a/modules/agents/TimeEaterAI.js
+++ b/modules/agents/TimeEaterAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 
 // TimeEaterAI - Implements boss B19: Time Eater

--- a/modules/agents/VampireAI.js
+++ b/modules/agents/VampireAI.js
@@ -1,3 +1,4 @@
+import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { spherePosToUv } from '../utils.js';
 


### PR DESCRIPTION
## Summary
- import the local `three.module.js` in every file under `modules/agents`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688993a1b0f48331a966502981b4923c