### PR TITLE
Add controller-attached menu

### DIFF
--- a/modules/ControllerMenu.js
+++ b/modules/ControllerMenu.js
@@ -1,0 +1,95 @@
+import * as THREE from '../vendor/three.module.js';
+import { getControllers } from './scene.js';
+import { showModal } from './ModalManager.js';
+import { AudioManager } from './audio.js';
+import { state } from './state.js';
+
+let menuGroup;
+let coreButton;
+let originalUpdateIcon;
+
+function holoMaterial(color = 0x141428, opacity = 0.85) {
+  return new THREE.MeshStandardMaterial({
+    color,
+    emissive: color,
+    transparent: true,
+    opacity,
+    side: THREE.DoubleSide
+  });
+}
+
+function createTextSprite(text, size = 48, color = '#eaf2ff') {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  ctx.font = `${size}px sans-serif`;
+  const width = Math.ceil(ctx.measureText(text).width);
+  canvas.width = width;
+  canvas.height = size * 1.2;
+  ctx.font = `${size}px sans-serif`;
+  ctx.fillStyle = color;
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, 0, canvas.height / 2);
+  const texture = new THREE.CanvasTexture(canvas);
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+  const sprite = new THREE.Sprite(material);
+  const scale = 0.001;
+  sprite.scale.set(canvas.width * scale, canvas.height * scale, 1);
+  return sprite;
+}
+
+function createButton(icon, onSelect) {
+  const group = new THREE.Group();
+  const bg = new THREE.Mesh(new THREE.PlaneGeometry(0.08, 0.08), holoMaterial(0x111111, 0.8));
+  group.add(bg);
+  const sprite = createTextSprite(icon, 48);
+  sprite.position.set(0, 0, 0.01);
+  group.add(sprite);
+  bg.userData.onSelect = onSelect;
+  return group;
+}
+
+export function initControllerMenu() {
+  const leftController = getControllers()[1];
+  if (!leftController || menuGroup) return;
+
+  menuGroup = new THREE.Group();
+  menuGroup.name = 'controllerMenu';
+  menuGroup.position.set(0.05, 0.05, -0.1);
+
+  const stageBtn = createButton('🗺️', () => showModal('levelSelect'));
+  stageBtn.position.set(0, 0.04, 0);
+  menuGroup.add(stageBtn);
+
+  const ascBtn = createButton('💠', () => showModal('ascension'));
+  ascBtn.position.set(0, -0.04, 0);
+  menuGroup.add(ascBtn);
+
+  const soundBtn = createButton('🔊', () => AudioManager.toggleMute());
+  soundBtn.position.set(0, -0.12, 0);
+  menuGroup.add(soundBtn);
+  originalUpdateIcon = AudioManager.updateButtonIcon;
+  AudioManager.updateButtonIcon = () => {
+    if (originalUpdateIcon) originalUpdateIcon.call(AudioManager);
+    const icon = AudioManager.userMuted ? '🔇' : '🔊';
+    if (soundBtn.children[1]) soundBtn.remove(soundBtn.children[1]);
+    const sprite = createTextSprite(icon, 48);
+    sprite.position.set(0, 0, 0.01);
+    soundBtn.add(sprite);
+  };
+  AudioManager.updateButtonIcon();
+
+  coreButton = createButton('◎', () => showModal('cores'));
+  coreButton.position.set(0, -0.2, 0);
+  menuGroup.add(coreButton);
+
+  leftController.add(menuGroup);
+}
+
+export function updateControllerMenu() {
+  if (!coreButton) return;
+  coreButton.visible = state.player.unlockedAberrationCores.size > 0;
+}
+
+export function getControllerMenu() {
+  return menuGroup;
+}

--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -7,6 +7,7 @@ import { usePower } from './powers.js';
 import { activateCorePower } from './cores.js';
 import { getUIRoot } from './UIManager.js';
 import { getModalObjects } from './ModalManager.js';
+import { getControllerMenu } from './ControllerMenu.js';
 
 let avatar;
 let targetPoint = new THREE.Vector3();
@@ -106,6 +107,13 @@ export function updatePlayerController() {
   if (uiRoot) {
     const uiHits = raycaster.intersectObjects(uiRoot.children, true);
     if (uiHits.length) uiHit = uiHits[0];
+  }
+  if (!uiHit) {
+    const menu = getControllerMenu();
+    if (menu) {
+      const menuHits = raycaster.intersectObjects(menu.children, true);
+      if (menuHits.length) uiHit = menuHits[0];
+    }
   }
   if (!uiHit) {
     const modalHits = raycaster.intersectObjects(getModalObjects(), true);

--- a/vrMain.js
+++ b/vrMain.js
@@ -3,6 +3,7 @@ import { initPlayerController, updatePlayerController } from './modules/PlayerCo
 import { initUI, updateHud } from './modules/UIManager.js';
 import { initModals } from './modules/ModalManager.js';
 import { initVrGameLoop, updateVrGameLoop } from './modules/vrGameLoop.js';
+import { initControllerMenu, updateControllerMenu } from './modules/ControllerMenu.js';
 
 let initialized = false;
 
@@ -13,12 +14,14 @@ export function start() {
   initVrGameLoop();
   initUI();
   initModals();
+  initControllerMenu();
   initialized = true;
   // Show level select on first launch as placeholder
   import('./modules/ModalManager.js').then(m => m.showModal('levelSelect'));
   getRenderer().setAnimationLoop(() => {
     updatePlayerController();
     updateVrGameLoop();
+    updateControllerMenu();
     updateHud();
     getRenderer().render(getScene(), getCamera());
   });


### PR DESCRIPTION
## Summary
- create `ControllerMenu` module to show stage select, ascension, sound toggle and core buttons on the left controller
- hook the menu into the main VR startup and update loops
- allow the pointer to interact with the controller menu

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a0998e4888331bf32185ab0dd277a