### PR TITLE
Update player state tracking with unit test

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -143,7 +143,9 @@ export function updatePlayerController() {
     crosshair.visible = false;
   }
 
-  moveTowards(avatar.position, targetPoint, state.player.speed, radius);
+  const uv = moveTowards(avatar.position, targetPoint, state.player.speed, radius);
+  state.player.x = uv.u * 2048;
+  state.player.y = uv.v * 1024;
 }
 
 export function getAvatar() {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs && node tests/projectileManager.test.mjs"
+    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs && node tests/projectileManager.test.mjs && node tests/playerState.test.mjs"
   },
   "keywords": [],
   "author": "",

--- a/tests/playerState.test.mjs
+++ b/tests/playerState.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import * as THREE from 'three';
+
+global.window = {};
+global.document = {
+  getElementById: () => null,
+  createElement: () => ({ getContext: () => ({}) })
+};
+
+const { state, resetGame } = await import('../modules/state.js');
+const { moveTowards } = await import('../modules/movement3d.js');
+const { uvToSpherePos } = await import('../modules/utils.js');
+
+resetGame();
+
+const radius = 1;
+const startUv = { u: 0.5, v: 0 };
+state.player.x = startUv.u * 2048;
+state.player.y = startUv.v * 1024;
+const avatar = uvToSpherePos(startUv.u, startUv.v, radius);
+const target = uvToSpherePos(0.6, 0.2, radius);
+
+const uv = moveTowards(avatar, target, 1, radius);
+state.player.x = uv.u * 2048;
+state.player.y = uv.v * 1024;
+
+assert.notStrictEqual(state.player.x, startUv.u * 2048, 'state.x updated');
+assert.notStrictEqual(state.player.y, startUv.v * 1024, 'state.y updated');
+
+console.log('player state update tests passed');


### PR DESCRIPTION
## Summary
- update `updatePlayerController` to persist UV coordinates
- add a unit test covering player state updates
- run all tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a0d2587588331af7b57648e84f948