### PR TITLE
Implement projectile meshes for VR loop

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -10,3 +10,8 @@
 - Updated `showModal` to ignore null entries and added new tests to `package.json`.
 - Added noCanvas integration test verifying `gameTick` operates without a DOM canvas.
 
+## 2025-08-03
+- Implemented FP-06 step 2 by attaching projectile meshes to a `projectileGroup`
+  in `vrGameLoop.js` and updating them in `projectilePhysics3d.js`. Added cleanup
+  logic and ensured all tests pass.
+

--- a/modules/vrGameLoop.js
+++ b/modules/vrGameLoop.js
@@ -2,10 +2,11 @@ import * as THREE from '../vendor/three.module.js';
 import { state } from './state.js';
 import { getScene, getArena } from './scene.js';
 import { updateEnemies3d } from './enemyAI3d.js';
-import { updateProjectiles3d } from './projectilePhysics3d.js';
+import { updateProjectiles3d, setProjectileGroup } from './projectilePhysics3d.js';
 import { uvToSpherePos } from './utils.js';
 
 let enemyGroup;
+let projectileGroup;
 
 export function initVrGameLoop() {
   const scene = getScene();
@@ -13,6 +14,15 @@ export function initVrGameLoop() {
   enemyGroup = new THREE.Group();
   enemyGroup.name = 'enemyGroup';
   scene.add(enemyGroup);
+
+  projectileGroup = new THREE.Group();
+  projectileGroup.name = 'projectileGroup';
+  scene.add(projectileGroup);
+  setProjectileGroup(projectileGroup);
+}
+
+export function getProjectileGroup(){
+  return projectileGroup;
 }
 
 export function updateVrGameLoop() {


### PR DESCRIPTION
## Summary
- support projectile rendering in `vrGameLoop`
- manage projectile meshes in `projectilePhysics3d`
- log completion of FP‑06 step 2 in `TASK_LOG`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a42d7654c8331a0d3d63ed4b5aa24