### PR TITLE
Apply FP-07: use player position vector

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -31,3 +31,8 @@
   game loop and unit tests to use the new vector-based position. All tests
   continue to pass.
 
+
+## 2025-08-06
+- Continued FP-07 by updating `vrGameLoop.js` to read the player's
+  3D `position` vector from state. Enemy updates now use this value
+  directly. All tests continue to pass.

--- a/modules/vrGameLoop.js
+++ b/modules/vrGameLoop.js
@@ -34,7 +34,7 @@ export function updateVrGameLoop() {
   const width = 2048; // legacy canvas width
   const height = 1024; // legacy canvas height
 
-  const playerPos = uvToSpherePos(state.player.x / width, state.player.y / height, radius);
+  const playerPos = state.player.position.clone();
 
   updateEnemies3d(playerPos, radius, width, height);
   updateProjectiles3d(radius, width, height);


### PR DESCRIPTION
## Summary
- centralize player position for VR game loop
- log progress on FP-07 in `TASK_LOG.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a6c2f6f488331a7dc1a3206070fb0