### PR TITLE
Fix projectile cleanup and canvas capture warnings

### DIFF
--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -16,7 +16,9 @@ export function setProjectileGroup(group){
   projectileGroup = group;
 }
 
-const dataMap = new WeakMap();
+// Use a standard Map so we can iterate over stored data when cleaning up.
+// WeakMap would prevent iteration and caused runtime errors.
+const dataMap = new Map();
 const projectileTypes = new Set([
   'nova_bullet',
   'ricochet_projectile',

--- a/modules/scene.js
+++ b/modules/scene.js
@@ -14,7 +14,12 @@ export function initScene(container = document.body) {
     1000
   );
 
-  renderer = new THREE.WebGLRenderer({ antialias: true });
+  // Enable preserveDrawingBuffer so html2canvas can capture the WebGL canvas
+  // without throwing a warning.
+  renderer = new THREE.WebGLRenderer({
+    antialias: true,
+    preserveDrawingBuffer: true
+  });
   renderer.setPixelRatio(window.devicePixelRatio);
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.outputColorSpace = THREE.SRGBColorSpace;


### PR DESCRIPTION
## Summary
- allow html2canvas to capture the renderer's canvas by enabling `preserveDrawingBuffer`
- switch projectile map from WeakMap to Map so clean‑up iteration works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a7b514cd48331851513d3ffe5dd53