### PR TITLE
Fix WebGL capture warning and projectile cleanup loop

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,8 +68,13 @@ async function startGame(resetSave = false) {
   await startVR();
   showHud();
 
-  if (navigator.xr) {
+  if (navigator.xr && navigator.xr.isSessionSupported) {
     try {
+      const supported = await navigator.xr.isSessionSupported('immersive-vr');
+      if (!supported) {
+        console.warn('WebXR immersive-vr session not supported');
+        return;
+      }
       const sessionInit = { optionalFeatures: ['local-floor', 'bounded-floor'] };
       const session = await navigator.xr.requestSession('immersive-vr', sessionInit);
       getRenderer().xr.setSession(session);

--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -59,12 +59,12 @@ export function updateProjectiles3d(radius, width, height){
   });
 
   // Clean up meshes for any projectiles that no longer exist
-  for(const [p, d] of dataMap.entries()){
+  dataMap.forEach((d, p) => {
     if(!state.effects.includes(p)){
       if(d.mesh && projectileGroup) projectileGroup.remove(d.mesh);
       if(d.mesh) d.mesh.geometry.dispose();
       if(d.mesh) d.mesh.material.dispose();
       dataMap.delete(p);
     }
-  }
+  });
 }

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -10,6 +10,7 @@
 // the bundled three.js module directly so they can be used in unit tests and in
 // builds without exposing THREE globally.
 import * as THREE from '../vendor/three.module.js';
+import { getRenderer } from './scene.js';
 
 let screenShakeEnd = 0;
 let screenShakeMagnitude = 0;
@@ -288,7 +289,16 @@ export function safeAddEventListener(el, type, handler, options){
 export async function captureElementToTexture(el){
   if(!el || typeof html2canvas === 'undefined') return null;
   el.classList.add('is-rendering');
+
+  // Hide the WebGL canvas during capture to avoid html2canvas warnings
+  const renderer = getRenderer && getRenderer();
+  const renderCanvas = renderer ? renderer.domElement : null;
+  const prevDisplay = renderCanvas ? renderCanvas.style.display : null;
+  if(renderCanvas) renderCanvas.style.display = 'none';
+
   const canvas = await html2canvas(el);
+
+  if(renderCanvas) renderCanvas.style.display = prevDisplay || '';
   el.classList.remove('is-rendering');
   const tex = new THREE.CanvasTexture(canvas);
   tex.colorSpace = THREE.SRGBColorSpace;


### PR DESCRIPTION
## Summary
- hide the renderer canvas when using `html2canvas` to capture DOM modals
- use `Map.forEach` for projectile cleanup to avoid iterator errors
- check `isSessionSupported` before requesting a WebXR session

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a7e2808148331a691f7b540cd9944