### PR TITLE
Fix WebGL errors for DOM-based textures

### DIFF
--- a/modules/ControllerMenu.js
+++ b/modules/ControllerMenu.js
@@ -22,7 +22,7 @@ function createTextSprite(text, size = 48, color = '#eaf2ff') {
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
   ctx.font = `${size}px sans-serif`;
-  const width = Math.ceil(ctx.measureText(text).width);
+  const width = Math.ceil(ctx.measureText(text).width) || 1;
   canvas.width = width;
   canvas.height = size * 1.2;
   ctx.font = `${size}px sans-serif`;
@@ -30,6 +30,9 @@ function createTextSprite(text, size = 48, color = '#eaf2ff') {
   ctx.textBaseline = 'middle';
   ctx.fillText(text, 0, canvas.height / 2);
   const texture = new THREE.CanvasTexture(canvas);
+  texture.minFilter = THREE.LinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.generateMipmaps = false;
   const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
   const sprite = new THREE.Sprite(material);
   const scale = 0.001;

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -31,7 +31,7 @@ function createTextSprite(text, size = 48, color = '#eaf2ff') {
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
   ctx.font = `${size}px sans-serif`;
-  const width = Math.ceil(ctx.measureText(text).width);
+  const width = Math.ceil(ctx.measureText(text).width) || 1;
   canvas.width = width;
   canvas.height = size * 1.2;
   ctx.font = `${size}px sans-serif`;
@@ -39,6 +39,9 @@ function createTextSprite(text, size = 48, color = '#eaf2ff') {
   ctx.textBaseline = 'middle';
   ctx.fillText(text, 0, canvas.height / 2);
   const texture = new THREE.CanvasTexture(canvas);
+  texture.minFilter = THREE.LinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.generateMipmaps = false;
   const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
   const sprite = new THREE.Sprite(material);
   const scale = 0.001;

--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -73,7 +73,7 @@ function createTextSprite(text, color = '#eaf2ff', size = 32) {
   const ctx = canvas.getContext('2d');
   const fontStack = "'Segoe UI','Roboto',sans-serif";
   ctx.font = `${size}px ${fontStack}`;
-  const width = Math.ceil(ctx.measureText(text).width);
+  const width = Math.ceil(ctx.measureText(text).width) || 1;
   canvas.width = width;
   canvas.height = size * 1.2;
   ctx.font = `${size}px ${fontStack}`;
@@ -81,6 +81,9 @@ function createTextSprite(text, color = '#eaf2ff', size = 32) {
   ctx.textBaseline = 'middle';
   ctx.fillText(text, 0, canvas.height / 2);
   const texture = new THREE.CanvasTexture(canvas);
+  texture.minFilter = THREE.LinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.generateMipmaps = false;
   const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
   const sprite = new THREE.Sprite(material);
   const scale = 0.001;

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -302,7 +302,11 @@ export async function captureElementToTexture(el){
 
   if(renderCanvas) renderCanvas.style.display = prevDisplay || '';
   el.classList.remove('is-rendering');
+  if(!canvas || canvas.width === 0 || canvas.height === 0) return null;
   const tex = new THREE.CanvasTexture(canvas);
   tex.colorSpace = THREE.SRGBColorSpace;
+  tex.minFilter = THREE.LinearFilter;
+  tex.magFilter = THREE.LinearFilter;
+  tex.generateMipmaps = false;
   return tex;
 }


### PR DESCRIPTION
## Summary
- avoid zero-size textures when capturing DOM elements
- disable mipmap generation and use linear filtering on CanvasTexture sprites

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a8443a3f08331900320b3fdf406d2