### PR TITLE
Implement FP-07 vector-based core logic

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -77,3 +77,9 @@
 
 ## 2025-08-17
 - Continued FP-07 by replacing remaining references to `state.player.x` and `state.player.y` in `powers.js` with 3D-aware helpers. All tests pass.
+
+## 2025-08-18
+- Continued FP-07 by refactoring cores.js to remove remaining 2D player
+  coordinate references. Player position is now read via sphere
+  coordinates using getPlayerCoords(). Added epochEnderRewind unit test
+  and updated package.json. All tests pass.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs && node tests/projectileManager.test.mjs && node tests/playerState.test.mjs && node tests/uiMaterial.test.mjs && node tests/modalVisibility.test.mjs && node tests/loadingProgress.test.mjs && node tests/gameOverModal.test.mjs && node tests/noCanvas.test.mjs && node tests/reflectorAI.test.mjs && node tests/enemyAI3d.test.mjs && node tests/vampireAI.test.mjs && node tests/gravityAI.test.mjs"
+    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs && node tests/projectileManager.test.mjs && node tests/playerState.test.mjs && node tests/uiMaterial.test.mjs && node tests/modalVisibility.test.mjs && node tests/loadingProgress.test.mjs && node tests/gameOverModal.test.mjs && node tests/noCanvas.test.mjs && node tests/reflectorAI.test.mjs && node tests/enemyAI3d.test.mjs && node tests/vampireAI.test.mjs && node tests/gravityAI.test.mjs && node tests/epochEnderRewind.test.mjs"
   },
   "keywords": [],
   "author": "",

--- a/tests/epochEnderRewind.test.mjs
+++ b/tests/epochEnderRewind.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'assert';
+import * as THREE from 'three';
+
+global.window = { gameHelpers: {} };
+global.document = {
+  getElementById: () => null,
+  createElement: () => ({ getContext: () => ({}) })
+};
+
+const { state, resetGame } = await import('../modules/state.js');
+const { handleCoreOnFatalDamage } = await import('../modules/cores.js');
+const { uvToSpherePos, spherePosToUv } = await import('../modules/utils.js');
+
+resetGame(false);
+state.player.equippedAberrationCore = 'epoch_ender';
+const epochState = state.player.talent_states.core_states.epoch_ender;
+epochState.history.unshift({ x: 512, y: 256, health: 50 });
+state.player.position.copy(uvToSpherePos(0.5, 0, 1));
+state.player.health = 10;
+
+const result = handleCoreOnFatalDamage(null, { play: () => {} });
+
+const { u, v } = spherePosToUv(state.player.position, 1);
+assert(result === true, 'rewind returned true');
+assert(
+  Math.abs(u - 0.75) < 1e-6 && Math.abs(v - 0.25) < 1e-6,
+  'player position rewound'
+);
+assert.strictEqual(state.player.health, 50, 'player health restored');
+
+console.log('epoch ender rewind test passed');
+


### PR DESCRIPTION
## Summary
- unify core logic with new 3D player position API
- add helper `getPlayerCoords` in cores.js
- adjust core behaviours to use 3D-aware coordinates
- add epoch ender rewind unit test
- document task completion in `TASK_LOG.md`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a8c1579808331a800d26ea4473565