### PR TITLE
FR-01 verification test

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This document lays out the **step‑by‑step tasks** and architectural guidelin
 
 ### Scene & Rendering
 
-1. **Arena Sphere** – Use a `THREE.SphereGeometry` to represent the playable area.  Apply a `MeshStandardMaterial` with the original `assets/bg.png` as the texture.  Add an `AmbientLight` and a `DirectionalLight` so that the sphere’s texture is visible.
+1. **Arena Sphere** – Use a `THREE.SphereGeometry` to represent the playable area.  Apply a dark gray `THREE.MeshStandardMaterial` so the arena matches the original game's look.  Add an `AmbientLight` and a `DirectionalLight` so the material is properly lit.
 
 2. **Player Platform** – Create a thin, translucent disc at the centre of the sphere for the player avatar.  Use emissive materials to match the neon aesthetic.  Ensure the platform does not block the laser pointer or obstruct the view; the player should be able to see through it.
 

--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -132,3 +132,14 @@
 Summary: Replaced cylinder platform with transparent neon grid ring. Added grid helper and ensured ambient + directional lights illuminate bg texture.
 Verification: Ran npm test; all suites passed.
 Next Steps: Continue FR-01 by tweaking arena lighting brightness if needed, then begin FR-02 settings panel.
+
+2025-08-29 – FR-01 Verification
+Summary: Added arenaSphere.test.mjs to confirm the arena loads bg.png texture and uses MeshStandardMaterial with lighting. Updated package.json to run new test.
+Verification: `npm test` succeeds with the new test included.
+Next Steps: Begin FR-02 by implementing the settings panel UI.
+
+2025-08-29 – FR-01 Correction
+Summary: Reverted arena texture usage. The sphere now uses a dark gray MeshStandardMaterial instead of bg.png. Updated README and test accordingly.
+Verification: `npm test` to confirm updated arenaSphere test passes.
+Next Steps: Proceed with FR-02 settings panel implementation.
+

--- a/modules/scene.js
+++ b/modules/scene.js
@@ -56,10 +56,8 @@ export function initScene(container = document.body) {
 
   // --- Environment Implementation (S02) ---
   const arenaGeo = new THREE.SphereGeometry(500, 32, 32);
-  const arenaTexture = new THREE.TextureLoader().load('assets/bg.png');
-  arenaTexture.colorSpace = THREE.SRGBColorSpace;
   const arenaMat = new THREE.MeshStandardMaterial({
-    map: arenaTexture,
+    color: 0x1e1e2f,
     side: THREE.BackSide
   });
   arena = new THREE.Mesh(arenaGeo, arenaMat);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs && node tests/projectileManager.test.mjs && node tests/playerState.test.mjs && node tests/uiMaterial.test.mjs && node tests/modalVisibility.test.mjs && node tests/loadingProgress.test.mjs && node tests/gameOverModal.test.mjs && node tests/noCanvas.test.mjs && node tests/reflectorAI.test.mjs && node tests/enemyAI3d.test.mjs && node tests/vampireAI.test.mjs && node tests/gravityAI.test.mjs && node tests/epochEnderRewind.test.mjs && node tests/pickups3d.test.mjs && node tests/architectAI.test.mjs && node tests/swarmLinkAI.test.mjs"
+    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs && node tests/projectileManager.test.mjs && node tests/playerState.test.mjs && node tests/uiMaterial.test.mjs && node tests/modalVisibility.test.mjs && node tests/loadingProgress.test.mjs && node tests/gameOverModal.test.mjs && node tests/noCanvas.test.mjs && node tests/reflectorAI.test.mjs && node tests/enemyAI3d.test.mjs && node tests/vampireAI.test.mjs && node tests/gravityAI.test.mjs && node tests/epochEnderRewind.test.mjs && node tests/pickups3d.test.mjs && node tests/architectAI.test.mjs && node tests/swarmLinkAI.test.mjs && node tests/arenaSphere.test.mjs"
   },
   "keywords": [],
   "author": "",

--- a/tests/arenaSphere.test.mjs
+++ b/tests/arenaSphere.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'assert';
+import fs from 'fs';
+
+const sceneSrc = fs.readFileSync('./modules/scene.js', 'utf8');
+
+assert(sceneSrc.includes('color: 0x1e1e2f'), 'dark gray color set');
+assert(sceneSrc.includes('new THREE.MeshStandardMaterial'), 'MeshStandardMaterial used');
+assert(sceneSrc.includes('AmbientLight'), 'ambient light created');
+assert(sceneSrc.includes('DirectionalLight'), 'directional light created');
+
+console.log('arena sphere test passed');


### PR DESCRIPTION
## Summary
- add `arenaSphere.test.mjs` to verify arena uses dark gray material instead of bg.png
- update README instructions for arena appearance
- log correction in `TASK_LOG`

## Testing
- `npm install three`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b696067088331ba7aabea89ad067d