### PR TITLE
Implement remaining FR-03 menus

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -151,3 +151,7 @@ Next Steps: Begin FR-03 UI reconstruction using Three.js panels.
 Summary: Removed html2canvas dependency and legacy DOM modals. Implemented `createStageSelectModal` in ModalManager using Three.js planes and text sprites. Added `startStage` helper and new test `stageSelectModal.test.mjs`. Updated package.json and ascension.js for DOM-less execution.
 Verification: `npm test` runs all suites including new stage select test successfully.
 Next Steps: Expand FR-03 to rebuild remaining menus (ascension, cores, lore) with interactive panels.
+2025-07-31 – FR-03 – Additional menu reconstruction
+Summary: Implemented createAscensionModal, createCoresModal, and createLoreModal with interactive buttons. Added tests for each modal and updated package.json.
+Verification: npm test – all suites including new modal tests pass.
+Next Steps: Continue FR-03 by refining layout details and begin FR-04 state unification.

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -3,6 +3,7 @@ import { getCamera } from './scene.js';
 import { resetGame, state, savePlayerState } from './state.js';
 import { AudioManager } from './audio.js';
 import { STAGE_CONFIG } from './config.js';
+import { bossData } from './bosses.js';
 import { applyAllTalentEffects } from './ascension.js';
 import { holoMaterial } from './UIManager.js';
 
@@ -187,6 +188,114 @@ function createStageSelectModal() {
   return modal;
 }
 
+function createAscensionModal() {
+  const modal = new THREE.Group();
+  modal.name = 'ascension';
+  const bg = new THREE.Mesh(
+    new THREE.PlaneGeometry(1.6, 1.4),
+    holoMaterial(0x141428, 0.95)
+  );
+  modal.add(bg);
+  const header = createTextSprite('ASCENSION CONDUIT', 64);
+  header.position.set(0, 0.55, 0.01);
+  modal.add(header);
+
+  const apDisplay = createTextSprite(`AP: ${state.player.ascensionPoints}`, 32);
+  apDisplay.position.set(0, 0.35, 0.01);
+  modal.add(apDisplay);
+
+  const clearBtn = createButton('Erase Timeline', () => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem('eternalMomentumSave');
+    }
+  });
+  clearBtn.position.set(0, 0.05, 0.02);
+  modal.add(clearBtn);
+
+  const closeBtn = createButton('Close', () => hideModal('ascension'));
+  closeBtn.position.set(0, -0.25, 0.02);
+  modal.add(closeBtn);
+
+  modal.visible = false;
+  return modal;
+}
+
+function createCoresModal() {
+  const modal = new THREE.Group();
+  modal.name = 'cores';
+  const bg = new THREE.Mesh(
+    new THREE.PlaneGeometry(1.6, 1.6),
+    holoMaterial(0x141428, 0.95)
+  );
+  modal.add(bg);
+  const header = createTextSprite('ABERRATION CORES', 64);
+  header.position.set(0, 0.65, 0.01);
+  modal.add(header);
+
+  const equippedText = createTextSprite('Equipped: None', 32);
+  equippedText.position.set(0, 0.45, 0.01);
+  modal.add(equippedText);
+
+  const list = new THREE.Group();
+  list.position.set(0, 0.3, 0.02);
+  let index = 0;
+  bossData.forEach(core => {
+    if (!core.core_desc) return;
+    const btn = createButton(core.name, () => equipCore(core.id));
+    btn.position.set(0, -0.2 * index++, 0);
+    list.add(btn);
+  });
+  modal.add(list);
+
+  const unequipBtn = createButton('Unequip', () => equipCore(null));
+  unequipBtn.position.set(0, -0.5, 0.02);
+  modal.add(unequipBtn);
+
+  const closeBtn2 = createButton('Close', () => hideModal('cores'));
+  closeBtn2.position.set(0, -0.75, 0.02);
+  modal.add(closeBtn2);
+
+  function equipCore(id) {
+    state.player.equippedAberrationCore = id;
+    const core = bossData.find(b => b.id === id);
+    updateTextSprite(
+      equippedText,
+      `Equipped: ${core ? core.name : 'None'}`
+    );
+    savePlayerState();
+  }
+
+  modal.visible = false;
+  return modal;
+}
+
+const storyContent =
+  'Reality is fraying. You are the Conduit, last anchor against the Unraveling.';
+
+function createLoreModal() {
+  const modal = new THREE.Group();
+  modal.name = 'lore';
+  const bg = new THREE.Mesh(
+    new THREE.PlaneGeometry(1.6, 1.2),
+    holoMaterial(0x141428, 0.95)
+  );
+  modal.add(bg);
+  const header = createTextSprite('LORE CODEX', 64);
+  header.position.set(0, 0.45, 0.01);
+  modal.add(header);
+
+  const body = createTextSprite(storyContent, 24);
+  body.position.set(0, 0.15, 0.01);
+  modal.add(body);
+
+  const closeBtn = createButton('Close', () => hideModal('lore'));
+  closeBtn.position.set(0, -0.35, 0.02);
+  modal.add(closeBtn);
+
+  modal.visible = false;
+  return modal;
+}
+
 
 function startStage(stage) {
   applyAllTalentEffects();
@@ -213,15 +322,14 @@ export async function initModals(cam = getCamera()) {
   modals.levelSelect = createStageSelectModal();
   group.add(modals.levelSelect);
 
-  modals.ascension = createModal('ascension', 'ASCENSION CONDUIT', [
-    { label: 'Close', onSelect: () => hideModal('ascension') }
-  ]);
+  modals.ascension = createAscensionModal();
   group.add(modals.ascension);
 
-  modals.cores = createModal('cores', 'ABERRATION CORES', [
-    { label: 'Close', onSelect: () => hideModal('cores') }
-  ]);
+  modals.cores = createCoresModal();
   group.add(modals.cores);
+
+  modals.lore = createLoreModal();
+  group.add(modals.lore);
 
   modals.settings = createSettingsModal();
   group.add(modals.settings);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs && node tests/projectileManager.test.mjs && node tests/playerState.test.mjs && node tests/uiMaterial.test.mjs && node tests/modalVisibility.test.mjs && node tests/loadingProgress.test.mjs && node tests/gameOverModal.test.mjs && node tests/noCanvas.test.mjs && node tests/reflectorAI.test.mjs && node tests/enemyAI3d.test.mjs && node tests/vampireAI.test.mjs && node tests/gravityAI.test.mjs && node tests/epochEnderRewind.test.mjs && node tests/pickups3d.test.mjs && node tests/architectAI.test.mjs && node tests/swarmLinkAI.test.mjs && node tests/arenaSphere.test.mjs && node tests/settingsSave.test.mjs && node tests/stageSelectModal.test.mjs"
+    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs && node tests/projectileManager.test.mjs && node tests/playerState.test.mjs && node tests/uiMaterial.test.mjs && node tests/modalVisibility.test.mjs && node tests/loadingProgress.test.mjs && node tests/gameOverModal.test.mjs && node tests/noCanvas.test.mjs && node tests/reflectorAI.test.mjs && node tests/enemyAI3d.test.mjs && node tests/vampireAI.test.mjs && node tests/gravityAI.test.mjs && node tests/epochEnderRewind.test.mjs && node tests/pickups3d.test.mjs && node tests/architectAI.test.mjs && node tests/swarmLinkAI.test.mjs && node tests/arenaSphere.test.mjs && node tests/settingsSave.test.mjs && node tests/stageSelectModal.test.mjs && node tests/coresModal.test.mjs && node tests/ascensionModal.test.mjs && node tests/loreModal.test.mjs"
   },
   "keywords": [],
   "author": "",

--- a/tests/ascensionModal.test.mjs
+++ b/tests/ascensionModal.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import * as THREE from 'three';
+
+// stub DOM and storage
+global.window = {};
+global.document = {
+  createElement: () => ({ getContext: () => ({ measureText: () => ({ width: 0 }), fillText: () => {}, clearRect: () => {} }) }),
+  getElementById: () => null
+};
+const store = { eternalMomentumSave: 'yes' };
+global.localStorage = {
+  getItem: k => store[k] || null,
+  setItem: (k,v) => { store[k] = v; },
+  removeItem: k => { delete store[k]; }
+};
+
+const { initModals, getModalObjects } = await import('../modules/ModalManager.js');
+const { state } = await import('../modules/state.js');
+
+state.player.ascensionPoints = 5;
+const camera = new THREE.PerspectiveCamera();
+await initModals(camera);
+
+const asc = getModalObjects().find(m => m && m.name === 'ascension');
+assert(asc, 'ascension modal created');
+
+const erase = asc.children.find(c => c.children && c.children[0]?.userData?.onSelect && c.children[0].userData.onSelect.toString().includes('removeItem'));
+erase.children[0].userData.onSelect();
+assert.strictEqual(store.eternalMomentumSave, undefined, 'save cleared');
+
+console.log('ascension modal test passed');

--- a/tests/coresModal.test.mjs
+++ b/tests/coresModal.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import * as THREE from 'three';
+
+// stub DOM
+global.window = {};
+global.document = {
+  createElement: () => ({ getContext: () => ({ measureText: () => ({ width: 0 }), fillText: () => {}, clearRect: () => {} }) }),
+  getElementById: () => null
+};
+
+const store = {};
+global.localStorage = {
+  getItem: k => store[k] || null,
+  setItem: (k,v) => { store[k] = v; },
+  removeItem: k => { delete store[k]; }
+};
+
+const { initModals, getModalObjects } = await import('../modules/ModalManager.js');
+const { state } = await import('../modules/state.js');
+
+const camera = new THREE.PerspectiveCamera();
+await initModals(camera);
+
+const cores = getModalObjects().find(m => m && m.name === 'cores');
+assert(cores, 'cores modal created');
+
+const list = cores.children[3];
+const firstBtn = list.children[0];
+firstBtn.children[0].userData.onSelect();
+assert(state.player.equippedAberrationCore, 'core equipped');
+
+const unequip = cores.children.find(c => c.children && c.children[0]?.userData?.onSelect && c.children[0].userData.onSelect.toString().includes('null'));
+unequip.children[0].userData.onSelect();
+assert.strictEqual(state.player.equippedAberrationCore, null, 'core unequipped');
+
+console.log('cores modal test passed');

--- a/tests/loreModal.test.mjs
+++ b/tests/loreModal.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import * as THREE from 'three';
+
+global.window = {};
+global.document = {
+  createElement: () => ({ getContext: () => ({ measureText: () => ({ width: 0 }), fillText: () => {}, clearRect: () => {} }) }),
+  getElementById: () => null
+};
+
+const { initModals, showModal, getModalObjects } = await import('../modules/ModalManager.js');
+const camera = new THREE.PerspectiveCamera();
+await initModals(camera);
+
+showModal('lore');
+const lore = getModalObjects().find(m => m && m.name === 'lore');
+assert(lore.visible, 'lore modal visible');
+
+console.log('lore modal test passed');


### PR DESCRIPTION
## Summary
- build Ascension, Core and Lore panels with Three.js
- hook up equip/unequip and erase save logic
- add unit tests for new modals
- run test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b73da6cb48331bdf0d164c3b96b35