### PR TITLE
Implement FR-05 audio gain node control

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -168,3 +168,7 @@ Next Steps: Proceed with FR-04 by auditing remaining modules for any stray 2D re
 Summary: Removed remaining 2D references. Boss petrify zone logic now uses getPlayerCanvasPos instead of player.x/y. Audio core tick effects use an offscreen canvas stub rather than querying #gameCanvas.
 Verification: `npm test` – all suites pass.
 Next Steps: Begin FR-05 audio integration updates.
+2025-09-04 – FR-05 – Audio gain nodes
+Summary: Added global music and sfx gain nodes in AudioManager. Updated play functions to route audio through these gains and implemented setMusicVolume/setSfxVolume helpers. Settings panel and vrMain now use these helpers. Added audioGain.test.mjs and updated package.json.
+Verification: Ran `npm test`; all suites including the new audio gain test pass.
+Next Steps: Continue with FR-06 power-up system implementation.

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -136,12 +136,9 @@ function createSettingsModal() {
       state.settings[settingKey] = v;
       updateTextSprite(display, `${label}: ${v}%`);
       if (settingKey === 'musicVolume') {
-        AudioManager.musicVolume = v / 100;
-        if (AudioManager.currentMusic) {
-          AudioManager.currentMusic.setVolume(AudioManager.userMuted ? 0 : AudioManager.musicVolume);
-        }
+        AudioManager.setMusicVolume(v / 100);
       } else if (settingKey === 'sfxVolume') {
-        AudioManager.sfxVolume = v / 100;
+        AudioManager.setSfxVolume(v / 100);
       }
       savePlayerState();
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs && node tests/projectileManager.test.mjs && node tests/playerState.test.mjs && node tests/uiMaterial.test.mjs && node tests/modalVisibility.test.mjs && node tests/loadingProgress.test.mjs && node tests/gameOverModal.test.mjs && node tests/noCanvas.test.mjs && node tests/reflectorAI.test.mjs && node tests/enemyAI3d.test.mjs && node tests/vampireAI.test.mjs && node tests/gravityAI.test.mjs && node tests/epochEnderRewind.test.mjs && node tests/pickups3d.test.mjs && node tests/architectAI.test.mjs && node tests/swarmLinkAI.test.mjs && node tests/arenaSphere.test.mjs && node tests/settingsSave.test.mjs && node tests/stageSelectModal.test.mjs && node tests/coresModal.test.mjs && node tests/ascensionModal.test.mjs && node tests/loreModal.test.mjs"
+    "test": "node tests/movement3d.test.mjs && node tests/navmesh.test.mjs && node tests/projectileManager.test.mjs && node tests/playerState.test.mjs && node tests/uiMaterial.test.mjs && node tests/modalVisibility.test.mjs && node tests/loadingProgress.test.mjs && node tests/gameOverModal.test.mjs && node tests/noCanvas.test.mjs && node tests/reflectorAI.test.mjs && node tests/enemyAI3d.test.mjs && node tests/vampireAI.test.mjs && node tests/gravityAI.test.mjs && node tests/epochEnderRewind.test.mjs && node tests/pickups3d.test.mjs && node tests/architectAI.test.mjs && node tests/swarmLinkAI.test.mjs && node tests/arenaSphere.test.mjs && node tests/settingsSave.test.mjs && node tests/stageSelectModal.test.mjs && node tests/coresModal.test.mjs && node tests/ascensionModal.test.mjs && node tests/loreModal.test.mjs && node tests/audioGain.test.mjs"
   },
   "keywords": [],
   "author": "",

--- a/tests/audioGain.test.mjs
+++ b/tests/audioGain.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'assert';
+
+import { AudioManager } from '../modules/audio.js';
+
+AudioManager.musicGain = { gain: { value: 1 } };
+AudioManager.sfxGain = { gain: { value: 1 } };
+AudioManager.unlocked = true;
+
+AudioManager.setMusicVolume(0.8);
+assert.strictEqual(AudioManager.musicGain.gain.value, 0.8);
+AudioManager.setSfxVolume(0.25);
+assert.strictEqual(AudioManager.sfxGain.gain.value, 0.25);
+
+AudioManager.userMuted = false;
+AudioManager.toggleMute();
+assert.strictEqual(AudioManager.musicGain.gain.value, 0);
+assert.strictEqual(AudioManager.sfxGain.gain.value, 0);
+AudioManager.toggleMute();
+assert.strictEqual(AudioManager.musicGain.gain.value, 0.8);
+assert.strictEqual(AudioManager.sfxGain.gain.value, 0.25);
+
+console.log('audio gain test passed');
+

--- a/vrMain.js
+++ b/vrMain.js
@@ -16,8 +16,8 @@ export async function start() {
   initPlayerController();
   initVrGameLoop();
   initUI();
-  AudioManager.sfxVolume = state.settings.sfxVolume / 100;
-  AudioManager.musicVolume = state.settings.musicVolume / 100;
+  AudioManager.setSfxVolume(state.settings.sfxVolume / 100);
+  AudioManager.setMusicVolume(state.settings.musicVolume / 100);
   AudioManager.setup(getCamera(), null);
   await initModals();
   initControllerMenu();


### PR DESCRIPTION
## Summary
- add global gain nodes to `AudioManager` and route music & SFX through them
- expose `setMusicVolume`/`setSfxVolume` helpers
- use new helpers in settings menu and VR initialisation
- add unit test for AudioManager gain nodes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b7f50fc88833185a4306bc5e993c1