### PR TITLE
Implement cursor direction and canvas conversion helper

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -284,3 +284,7 @@ screen. startStage is now exported for external use.
 Verification: `npm test` – all suites pass.
 Next Steps: Review stage flow to ensure progress persists and continue with
 remaining FR tasks.
+2025-09-22 – FR-12 – Coordinate system overhaul initial step
+Summary: Added cursorDir vector in state and refactored controller input, powers and cores to use it. Implemented utils.toCanvasPos helper and new test.
+Verification: npm install && npm test – all suites including new toCanvasPos test pass.
+Next Steps: Continue FR-12 by replacing remaining x/y references and updating enemy AI distance calculations.

--- a/modules/CoreManager.js
+++ b/modules/CoreManager.js
@@ -18,7 +18,7 @@ const SCREEN_HEIGHT = 1024;
  * when the player presses both trigger and grip.
  */
 export function useCoreActive(gameHelpers) {
-  const uv = spherePosToUv(state.mousePosition.clone().normalize(), 1);
+  const uv = spherePosToUv(state.cursorDir.clone().normalize(), 1);
   Cores.activateCorePower(uv.u * SCREEN_WIDTH, uv.v * SCREEN_HEIGHT, gameHelpers);
 }
 

--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -74,9 +74,9 @@ export function initPlayerController() {
     });
   }
 
-  // Initialize shared cursor position in state if not already set
-  if (!state.mousePosition || !state.mousePosition.isVector3) {
-    state.mousePosition = new THREE.Vector3();
+  // Initialize shared cursor direction in state if not already set
+  if (!state.cursorDir || !state.cursorDir.isVector3) {
+    state.cursorDir = new THREE.Vector3();
   }
 }
 
@@ -146,7 +146,7 @@ export function updatePlayerController() {
   const hit = raycaster.intersectObject(arena, false)[0];
   if (hit) {
     targetPoint.copy(hit.point);
-    state.mousePosition.copy(hit.point);
+    state.cursorDir.copy(hit.point).sub(avatar.position).normalize();
     if (crosshair) {
       crosshair.visible = true;
       crosshair.position.copy(hit.point);

--- a/modules/cores.js
+++ b/modules/cores.js
@@ -100,7 +100,7 @@ export function activateCorePower(mx, my, gameHelpers) {
       // here to capture the cursor coordinates at the moment of activation.
       setTimeout(() => {
         if (state.gameOver) return;
-        const uv = spherePosToUv(state.mousePosition.clone().normalize(), 1);
+        const uv = spherePosToUv(state.cursorDir.clone().normalize(), 1);
         const cursorX = uv.u * CANVAS_W;
         const cursorY = uv.v * CANVAS_H;
         const angle = Math.atan2(cursorY - playerY, cursorX - playerX);
@@ -238,7 +238,7 @@ export function applyCoreTickEffects(gameHelpers) {
   // --- Miasma passive ---
   if (playerHasCore('miasma')) {
       const miasmaState = state.player.talent_states.core_states.miasma;
-      const uvCursor = spherePosToUv(state.mousePosition.clone().normalize(), 1);
+      const uvCursor = spherePosToUv(state.cursorDir.clone().normalize(), 1);
       const cursorX = uvCursor.u * CANVAS_W;
       const cursorY = uvCursor.v * CANVAS_H;
       const moveDist = Math.hypot(cursorX - playerX, cursorY - playerY);
@@ -308,7 +308,7 @@ export function applyCoreTickEffects(gameHelpers) {
   if (playerHasCore('helix_weaver')) {
     const helixState = state.player.talent_states.core_states.helix_weaver;
     // Only spawn bolts when the player is stationary; movement cancels the effect.
-    const uvCursor2 = spherePosToUv(state.mousePosition.clone().normalize(), 1);
+    const uvCursor2 = spherePosToUv(state.cursorDir.clone().normalize(), 1);
     const curX2 = uvCursor2.u * CANVAS_W;
     const curY2 = uvCursor2.v * CANVAS_H;
     const moveDist = Math.hypot(curX2 - playerX, curY2 - playerY);

--- a/modules/powers.js
+++ b/modules/powers.js
@@ -2,7 +2,7 @@
 import { state } from './state.js';
 import * as utils from './utils.js';
 import * as Cores from './cores.js';
-import { spherePosToUv } from './utils.js';
+import { toCanvasPos } from './utils.js';
 import { gameHelpers } from './gameHelpers.js';
 
 const SCREEN_WIDTH = 2048;
@@ -16,8 +16,7 @@ function playerHasCore(coreId) {
 
 function getCanvasPos(obj) {
   if (obj.position && obj.position.isVector3) {
-    const uv = spherePosToUv(obj.position.clone().normalize(), 1);
-    return { x: uv.u * 2048, y: uv.v * 1024 };
+    return toCanvasPos(obj.position);
   }
   return { x: obj.x, y: obj.y };
 }
@@ -367,10 +366,8 @@ export function usePower(powerKey, isFreeCast = false, options = {}){
   slotEl.classList.add('activated');
   setTimeout(()=> slotEl.classList.remove('activated'), 200);
 
-  // Use mouse position stored in state
-  const uv = spherePosToUv(state.mousePosition.clone().normalize(), 1);
-  const mx = uv.u * SCREEN_WIDTH;
-  const my = uv.v * SCREEN_HEIGHT;
+  // Use cursor direction stored in state
+  const { x: mx, y: my } = utils.toCanvasPos(state.cursorDir, SCREEN_WIDTH, SCREEN_HEIGHT);
   
   const applyArgs = [utils, gameHelpers, mx, my, options];
   

--- a/modules/state.js
+++ b/modules/state.js
@@ -22,9 +22,9 @@ export const state = {
   // Track mouse buttons for detecting LMB/RMB combos when activating cores
   LMB_down: false,
   RMB_down: false,
-  // Cursor location where the player's controller ray hits the arena sphere.
-  // Stored as a THREE.Vector3 on the sphere surface.
-  mousePosition: new THREE.Vector3(),
+  // Direction from the player avatar toward the current cursor target on the
+  // arena sphere. Stored as a normalised THREE.Vector3.
+  cursorDir: new THREE.Vector3(),
   player: {
     position: new THREE.Vector3(0, 0, 0),
     // Player hitbox radius.  Fractal Horror modifies this value on equip.
@@ -240,7 +240,7 @@ export function resetGame(isArena = false) {
   state.player.lastSpore = 0;
   state.player.contingencyUsed = false;
   state.player.preordinanceUsed = false;
-  state.mousePosition.set(0, 0, 0);
+  state.cursorDir.set(0, 0, 0);
   // Recreate the core state container to wipe out any lingering cooldowns.
   state.player.talent_states.core_states = {
     architect: { lastPillarTime: 0 },

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -269,6 +269,19 @@ export function spherePosToUv(vec, radius = 1) {
 }
 
 /**
+ * Convert a 3D position on the gameplay sphere to pixel coordinates.
+ *
+ * @param {THREE.Vector3} vec - Vector on the sphere's surface.
+ * @param {number} [width=2048] - Canvas width in pixels.
+ * @param {number} [height=1024] - Canvas height in pixels.
+ * @returns {{x:number,y:number}}
+ */
+export function toCanvasPos(vec, width = 2048, height = 1024) {
+  const { u, v } = spherePosToUv(vec.clone().normalize(), 1);
+  return { x: u * width, y: v * height };
+}
+
+/**
  * Safely add an event listener if the element exists.
  * @param {EventTarget|null} el
  * @param {string} type

--- a/tests/coreManager.test.mjs
+++ b/tests/coreManager.test.mjs
@@ -41,7 +41,7 @@ global.spherePosToUv = utils.spherePosToUv;
 resetGame(false);
 
 state.player.equippedAberrationCore = 'juggernaut';
-state.mousePosition = new THREE.Vector3(1, 0, 0);
+state.cursorDir = new THREE.Vector3(1, 0, 0);
 
 const beforeCount = state.effects.length;
 useCoreActive(gameHelpers);

--- a/tests/toCanvasPos.test.mjs
+++ b/tests/toCanvasPos.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'assert';
+import * as THREE from 'three';
+
+const utils = await import('../modules/utils.js');
+
+const vec = new THREE.Vector3(-1, 0, 0);
+const pos = utils.toCanvasPos(vec, 2048, 1024);
+assert.strictEqual(pos.x, 2048, 'x pixel coordinate');
+assert.strictEqual(pos.y, 512, 'y pixel coordinate');
+
+console.log('toCanvasPos test passed');


### PR DESCRIPTION
## Summary
- introduce `cursorDir` in state and reset logic
- update PlayerController to track cursor direction
- convert core and power logic to use the new vector
- add `toCanvasPos` utility for consistent 3D→2D mapping
- provide test coverage for `toCanvasPos`
- document progress in `TASK_LOG.md`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bb54ae36083318cdfb18cc44ce125