### PR TITLE
Implement 3D homing projectiles

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -300,3 +300,7 @@ Next Steps: Begin FR-13 projectile physics refactor.
 Summary: Updated projectilePhysics3d to store Vector3 position and velocity for projectiles, converting legacy x/y fields. Powers and AIs now spawn nova bullets, shrapnel and helix bolts using 3D vectors. Added projectilePhysics3d.test.mjs verifying movement.
 Verification: npm test – all 61 suites including new projectile physics test pass.
 Next Steps: Continue FR-13 by refining homing behaviour and converting remaining projectiles.
+2025-07-31 – FR-13 – Homing projectile update
+Summary: Implemented 3D homing logic for seeking_shrapnel and player_fragment projectiles. Spawned fragments using Vector3 data and added homingProjectile.test.mjs.
+Verification: npm install && npm test – all 62 suites including new homing test pass.
+Next Steps: Continue FR-13 by auditing other powers for remaining 2D calculations.

--- a/modules/cores.js
+++ b/modules/cores.js
@@ -15,6 +15,7 @@ import * as utils from './utils.js';
 import { bossData } from './bosses.js';
 import { showUnlockNotification, updateUI } from './ui.js';
 import { usePower } from './powers.js';
+import * as THREE from '../vendor/three.module.js';
 
 const CANVAS_W = 2048;
 const CANVAS_H = 1024;
@@ -401,8 +402,20 @@ export function handleCoreOnEnemyDeath(enemy, gameHelpers) {
       splitterState.cooldownUntil = now + 500;
       for (let i = 0; i < 3; i++) {
         const angle = Math.random() * Math.PI * 2;
-        const { u, v } = utils.spherePosToUv(enemy.position, 1);
-        state.effects.push({ type: 'player_fragment', x: u * CANVAS_W, y: v * CANVAS_H, dx: Math.cos(angle) * 4, dy: Math.sin(angle) * 4, r: 10, speed: 5, damage: 8 * state.player.talent_modifiers.damage_multiplier, life: 4000, startTime: now, targetIndex: i });
+        const originVec = enemy.position.clone();
+        const dir = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle))
+          .normalize()
+          .multiplyScalar(0.2);
+        state.effects.push({
+          type: 'player_fragment',
+          position: originVec.clone(),
+          velocity: dir,
+          r: 10,
+          damage: 8 * state.player.talent_modifiers.damage_multiplier,
+          life: 4000,
+          startTime: now,
+          targetIndex: i
+        });
       }
       gameHelpers.play('splitterOnDeath');
     }

--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -52,6 +52,22 @@ export function updateProjectiles3d(radius, width, height){
       dataMap.set(p, mesh);
     }
 
+    if(p.type === 'seeking_shrapnel' || p.type === 'player_fragment'){
+      const enemies = state.enemies.filter(e => !e.isFriendly && e.position);
+      if(enemies.length){
+        const sorted = enemies.slice().sort((a,b)=>
+          a.position.distanceTo(p.position) - b.position.distanceTo(p.position));
+        const target = sorted[p.targetIndex] || sorted[0];
+        if(target){
+          const desired = target.position.clone().sub(p.position).normalize();
+          const tangent = new THREE.Vector3().crossVectors(p.position, desired)
+            .cross(p.position).normalize();
+          const speed = p.velocity.length();
+          p.velocity.lerp(tangent.multiplyScalar(speed), 0.1);
+        }
+      }
+    }
+
     p.position.add(p.velocity).normalize().multiplyScalar(radius);
     const uv = spherePosToUv(p.position, radius);
     p.x = uv.u * width;

--- a/tests/homingProjectile.test.mjs
+++ b/tests/homingProjectile.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'assert';
+import * as THREE from '../vendor/three.module.js';
+
+global.window = {};
+global.document = { getElementById: () => null, createElement: () => ({ getContext: () => ({}) }) };
+
+const { state, resetGame } = await import('../modules/state.js');
+const { updateProjectiles3d } = await import('../modules/projectilePhysics3d.js');
+const { uvToSpherePos } = await import('../modules/utils.js');
+
+resetGame(false);
+const radius = 1;
+const width = 2048;
+const height = 1024;
+
+const startPos = uvToSpherePos(0.5, 0.5, radius);
+const enemyPos = uvToSpherePos(0.55, 0.55, radius);
+
+state.effects.push({
+  type: 'seeking_shrapnel',
+  position: startPos.clone(),
+  velocity: new THREE.Vector3(0, 0.05, 0)
+});
+
+state.enemies.push({ position: enemyPos.clone(), r: 10, isFriendly: false, hp: 10 });
+
+const proj = state.effects[0];
+const targetDir = enemyPos.clone().sub(startPos).normalize();
+const initialDot = proj.velocity.clone().normalize().dot(targetDir);
+
+updateProjectiles3d(radius, width, height);
+
+const newDot = proj.velocity.clone().normalize().dot(targetDir);
+assert(newDot > initialDot, 'projectile turned toward target');
+
+console.log('homing projectile test passed');
+


### PR DESCRIPTION
## Summary
- add 3D homing logic for seeking_shrapnel and player_fragment projectiles
- spawn player fragments using Vector3 position and velocity
- test homing behaviour with new homingProjectile.test.mjs
- record progress in TASK_LOG

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bc2deaf8c83319bc096bb37719d91