### PR TITLE
Add confirm modal for VR menus

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -324,3 +324,7 @@ Next Steps: Continue with FR-15 helper deduplication.
 Summary: Added explicit notes in AGENTS and README clarifying that UI reconstruction is an ongoing task until all menus match the original game's fonts, colors and behaviours.
 Verification: npm install && npm test – all suites pass.
 Next Steps: Complete FR-03 by implementing remaining menu features and backgrounds.
+2025-09-29 – FR-03 – Confirm modal
+Summary: Implemented confirm modal in ModalManager with showConfirm helper and added new unit test.
+Verification: npm install && npm test – all suites pass.
+Next Steps: Continue auditing remaining menus for parity.

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -418,6 +418,44 @@ function createLoreModal() {
   return modal;
 }
 
+let confirmCallback;
+
+function createConfirmModal() {
+  const modal = new THREE.Group();
+  modal.name = 'confirm';
+
+  const bg = new THREE.Mesh(
+    new THREE.PlaneGeometry(1.2, 0.8),
+    holoMaterial(0x141428, 0.95)
+  );
+  modal.add(bg);
+
+  const title = createTextSprite('CONFIRM', 48);
+  title.position.set(0, 0.25, 0.01);
+  modal.add(title);
+
+  const body = createTextSprite('', 32);
+  body.position.set(0, 0.05, 0.01);
+  modal.add(body);
+
+  const yesBtn = createButton('Confirm', () => {
+    hideModal('confirm');
+    if (typeof confirmCallback === 'function') confirmCallback();
+  });
+  yesBtn.position.set(-0.3, -0.25, 0.02);
+  modal.add(yesBtn);
+
+  const noBtn = createButton('Cancel', () => hideModal('confirm'));
+  noBtn.position.set(0.3, -0.25, 0.02);
+  modal.add(noBtn);
+
+  modal.userData.title = title;
+  modal.userData.body = body;
+
+  modal.visible = false;
+  return modal;
+}
+
 
 export function startStage(stage) {
   applyAllTalentEffects();
@@ -458,6 +496,9 @@ export async function initModals(cam = getCamera()) {
 
   modals.settings = createSettingsModal();
   group.add(modals.settings);
+
+  modals.confirm = createConfirmModal();
+  group.add(modals.confirm);
 }
 
 export function showModal(id) {
@@ -471,6 +512,20 @@ export function showModal(id) {
 
 export function hideModal(id) {
   if (modals[id]) modals[id].visible = false;
+}
+
+export function showConfirm(title, text, onConfirm) {
+  ensureGroup();
+  if (!modals.confirm) {
+    modals.confirm = createConfirmModal();
+    modalGroup.add(modals.confirm);
+  }
+  confirmCallback = onConfirm;
+  if (modals.confirm) {
+    updateTextSprite(modals.confirm.userData.title, title);
+    updateTextSprite(modals.confirm.userData.body, text);
+  }
+  showModal('confirm');
 }
 
 export function getModalObjects() {

--- a/tests/confirmModal.test.mjs
+++ b/tests/confirmModal.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'assert';
+import * as THREE from 'three';
+
+// minimal DOM stubs
+global.window = {};
+global.document = {
+  createElement: () => ({ getContext: () => ({ measureText: () => ({ width: 0 }), fillText: () => {}, clearRect: () => {} }) }),
+  getElementById: () => null
+};
+
+const { initModals, showConfirm, getModalObjects } = await import('../modules/ModalManager.js');
+const camera = new THREE.PerspectiveCamera();
+await initModals(camera);
+
+let confirmed = false;
+showConfirm('Erase?', 'Really erase?', () => { confirmed = true; });
+const confirmModal = getModalObjects().find(m => m && m.name === 'confirm');
+assert(confirmModal && confirmModal.visible, 'confirm modal visible');
+// simulate pressing confirm button
+const yesGroup = confirmModal.children.find(c => c.children && c.children[0]?.userData?.onSelect);
+yesGroup.children[0].userData.onSelect();
+assert(confirmed, 'confirm callback triggered');
+console.log('confirm modal test passed');


### PR DESCRIPTION
## Summary
- implement confirm modal in VR `ModalManager`
- showConfirm utility to open confirm prompts
- create initial unit test for confirm modal
- log update

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bf5389af88331b2459ae18b51bd07