### PR TITLE
Implement VR home screen modal

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -328,3 +328,8 @@ Next Steps: Complete FR-03 by implementing remaining menu features and backgroun
 Summary: Implemented confirm modal in ModalManager with showConfirm helper and added new unit test.
 Verification: npm install && npm test – all suites pass.
 Next Steps: Continue auditing remaining menus for parity.
+
+2025-09-30 – FR-03 – Home menu VR panel
+Summary: Added home screen modal as a THREE.Group with dynamic button visibility and created showHomeMenu helper. Updated app.js to expose startGame globally and trigger the VR home menu when returning home. Added unit test homeModal.test.mjs.
+Verification: npm install && npm test – all suites pass.
+Next Steps: Continue auditing remaining menus for parity.

--- a/app.js
+++ b/app.js
@@ -53,6 +53,9 @@ function showHome() {
     requestAnimationFrame(() => homeEl.classList.add('visible'));
   }
   stopVR();
+  if (typeof window !== 'undefined' && window.showHomeMenu) {
+    window.showHomeMenu();
+  }
   const saveExists = !!localStorage.getItem('eternalMomentumSave');
   if (continueBtn) continueBtn.style.display = saveExists ? 'block' : 'none';
   if (eraseBtn) eraseBtn.style.display = saveExists ? 'block' : 'none';
@@ -61,6 +64,7 @@ function showHome() {
 
 if (typeof window !== 'undefined') {
   window.showHome = showHome;
+  window.startGame = startGame;
 }
 
 async function startGame(resetSave = false) {

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -165,6 +165,60 @@ function createSettingsModal() {
   return modal;
 }
 
+function createHomeModal() {
+  const modal = new THREE.Group();
+  modal.name = 'home';
+  const bg = new THREE.Mesh(
+    new THREE.PlaneGeometry(1.8, 1.2),
+    holoMaterial(0x141428, 0.95)
+  );
+  modal.add(bg);
+  const title = createTextSprite('ETERNAL MOMENTUM', 64);
+  title.position.set(0, 0.45, 0.01);
+  modal.add(title);
+
+  const startBtn = createButton('AWAKEN', () => {
+    if (typeof window !== 'undefined' && window.startGame) {
+      window.startGame(true);
+    }
+  });
+  startBtn.name = 'startBtn';
+  startBtn.position.set(0, 0.15, 0.02);
+  modal.add(startBtn);
+
+  const continueBtn = createButton('CONTINUE MOMENTUM', () => {
+    if (typeof window !== 'undefined' && window.startGame) {
+      window.startGame(false);
+    }
+  });
+  continueBtn.name = 'continueBtn';
+  continueBtn.position.set(0, -0.1, 0.02);
+  modal.add(continueBtn);
+
+  const eraseBtn = createButton('SEVER TIMELINE', () => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem('eternalMomentumSave');
+      if (typeof window !== 'undefined' && window.location) {
+        window.location.reload();
+      }
+    }
+  });
+  eraseBtn.name = 'eraseBtn';
+  eraseBtn.position.set(0, -0.35, 0.02);
+  modal.add(eraseBtn);
+
+  modal.userData.updateButtons = () => {
+    const hasSave = typeof localStorage !== 'undefined' &&
+      !!localStorage.getItem('eternalMomentumSave');
+    startBtn.visible = !hasSave;
+    continueBtn.visible = hasSave;
+    eraseBtn.visible = hasSave;
+  };
+
+  modal.visible = false;
+  return modal;
+}
+
 function createStageSelectModal() {
   const modal = new THREE.Group();
   modal.name = 'levelSelect';
@@ -497,6 +551,9 @@ export async function initModals(cam = getCamera()) {
   modals.settings = createSettingsModal();
   group.add(modals.settings);
 
+  modals.home = createHomeModal();
+  group.add(modals.home);
+
   modals.confirm = createConfirmModal();
   group.add(modals.confirm);
 }
@@ -512,6 +569,18 @@ export function showModal(id) {
 
 export function hideModal(id) {
   if (modals[id]) modals[id].visible = false;
+}
+
+export function showHomeMenu() {
+  ensureGroup();
+  if (!modals.home) {
+    modals.home = createHomeModal();
+    modalGroup.add(modals.home);
+  }
+  if (modals.home.userData.updateButtons) {
+    modals.home.userData.updateButtons();
+  }
+  showModal('home');
 }
 
 export function showConfirm(title, text, onConfirm) {
@@ -530,4 +599,8 @@ export function showConfirm(title, text, onConfirm) {
 
 export function getModalObjects() {
   return Object.values(modals);
+}
+
+if (typeof window !== 'undefined') {
+  window.showHomeMenu = showHomeMenu;
 }

--- a/tests/homeModal.test.mjs
+++ b/tests/homeModal.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'assert';
+import * as THREE from 'three';
+
+global.window = {};
+global.document = {
+  createElement: () => ({
+    getContext: () => ({
+      measureText: () => ({ width: 0 }),
+      fillText: () => {},
+      clearRect: () => {}
+    })
+  }),
+  getElementById: () => null
+};
+
+const store = {};
+global.localStorage = {
+  getItem: k => store[k] || null,
+  setItem: (k,v) => { store[k] = v; },
+  removeItem: k => { delete store[k]; }
+};
+
+const { initModals, showHomeMenu, getModalObjects } = await import('../modules/ModalManager.js');
+const camera = new THREE.PerspectiveCamera();
+await initModals(camera);
+
+showHomeMenu();
+let home = getModalObjects().find(m => m && m.name === 'home');
+assert(home && home.visible, 'home modal visible');
+
+let startBtn = home.getObjectByName('startBtn');
+let contBtn = home.getObjectByName('continueBtn');
+let eraseBtn = home.getObjectByName('eraseBtn');
+
+assert(startBtn.visible, 'start visible when no save');
+assert(!contBtn.visible && !eraseBtn.visible, 'continue/erase hidden without save');
+
+localStorage.setItem('eternalMomentumSave','{}');
+showHomeMenu();
+home = getModalObjects().find(m => m && m.name === 'home');
+contBtn = home.getObjectByName('continueBtn');
+eraseBtn = home.getObjectByName('eraseBtn');
+startBtn = home.getObjectByName('startBtn');
+
+assert(!startBtn.visible, 'start hidden when save exists');
+assert(contBtn.visible && eraseBtn.visible, 'continue/erase visible when save exists');
+
+console.log('home modal test passed');


### PR DESCRIPTION
## Summary
- build `createHomeModal` and `showHomeMenu` in ModalManager
- expose startGame globally and trigger VR home menu from `showHome`
- wire home modal into initModals
- add unit test for home modal visibility
- log progress in `TASK_LOG.md`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bf6c0d2448331b258b6f47550abea