### PR TITLE
Implement auto game over modal

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -347,3 +347,10 @@ Next Steps: Continue recreating remaining menus using the original phrasing.
 Summary: Added Boss Info modal and integrated mechanics/lore buttons in the stage select menu. Updated tests accordingly.
 Verification: npm test – all suites including updated stage select test pass.
 Next Steps: Continue rebuilding remaining menus for parity.
+
+2025-10-03 – FR-03 – Game over screen parity
+Summary: Updated game over modal button text to match the original UI and added
+logic in vrMain to automatically display the modal when `state.gameOver` is
+set. The game over screen now appears upon player death with accurate wording.
+Verification: Ran `npm test`; all suites pass.
+Next Steps: Continue auditing menus for any remaining discrepancies.

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -578,8 +578,8 @@ export async function initModals(cam = getCamera()) {
 
   modals.gameOver = createModal('gameOver', 'TIMELINE COLLAPSED', [
     { label: 'Restart Stage', onSelect: () => startStage(state.currentStage) },
-    { label: 'Ascension', onSelect: () => showModal('ascension') },
-    { label: 'Cores', onSelect: () => showModal('cores') },
+    { label: 'Ascension Conduit', onSelect: () => showModal('ascension') },
+    { label: 'Aberration Cores', onSelect: () => showModal('cores') },
     { label: 'Stage Select', onSelect: () => showModal('levelSelect') }
   ]);
   group.add(modals.gameOver);

--- a/vrMain.js
+++ b/vrMain.js
@@ -1,13 +1,14 @@
 import { initScene, getRenderer, getScene, getCamera } from './modules/scene.js';
 import { initPlayerController, updatePlayerController } from './modules/PlayerController.js';
 import { initUI, updateHud } from './modules/UIManager.js';
-import { initModals, startStage } from './modules/ModalManager.js';
+import { initModals, startStage, showModal } from './modules/ModalManager.js';
 import { initVrGameLoop, updateVrGameLoop } from './modules/vrGameLoop.js';
 import { initControllerMenu, updateControllerMenu } from './modules/ControllerMenu.js';
 import { AudioManager } from './modules/audio.js';
 import { loadPlayerState, state } from './modules/state.js';
 
 let initialized = false;
+let gameOverShown = false;
 
 export async function start(initialStage) {
   if (initialized) return;
@@ -28,10 +29,15 @@ export async function start(initialStage) {
       ? state.player.highestStageBeaten + 1
       : 1
   );
+  gameOverShown = false;
   initialized = true;
   getRenderer().setAnimationLoop(() => {
     updatePlayerController();
     updateVrGameLoop();
+    if (state.gameOver && !gameOverShown) {
+      showModal('gameOver');
+      gameOverShown = true;
+    }
     updateControllerMenu();
     updateHud();
     getRenderer().render(getScene(), getCamera());


### PR DESCRIPTION
## Summary
- adjust Game Over modal button text to match original UI
- show Game Over modal automatically when `state.gameOver` is triggered
- document task progress in `TASK_LOG.md`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bfe80d0408331b8a5dfb858b8cde9