### PR TITLE
Implement VR Orrery menu

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -359,3 +359,4 @@ Next Steps: Continue auditing menus for any remaining discrepancies.
 Summary: Modified app.js to display the VR home screen panel after assets finish loading. Updated README and AGENTS text to clarify that the game should enter VR and show the home menu before gameplay begins.
 Verification: npm install && npm test – all suites pass.
 Next Steps: Continue UI reconstruction and stage flow improvements.
+2025-08-01 – FR-03 – Weaver's Orrery VR menu\nSummary: Implemented full Orrery modal with boss selection, point tracking, and startOrrery helper. Added automated test orreryModal.test.mjs and updated modal rendering logic.\nVerification: npm install && npm test – all suites pass.\nNext Steps: Continue porting remaining UI screens.

--- a/tests/orreryModal.test.mjs
+++ b/tests/orreryModal.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'assert';
+import * as THREE from 'three';
+
+global.window = {};
+global.document = {
+  createElement: () => ({
+    getContext: () => ({
+      measureText: () => ({ width: 0 }),
+      fillText: () => {},
+      clearRect: () => {}
+    })
+  }),
+  getElementById: () => null
+};
+const store = {};
+global.localStorage = {
+  getItem: k => store[k] || null,
+  setItem: (k,v) => { store[k] = v; },
+  removeItem: k => { delete store[k]; }
+};
+
+const { initModals, getModalObjects } = await import('../modules/ModalManager.js');
+const { state } = await import('../modules/state.js');
+
+state.player.highestStageBeaten = 30;
+const camera = new THREE.PerspectiveCamera();
+await initModals(camera);
+
+const orrery = getModalObjects().find(m => m && m.name === 'orrery');
+assert(orrery, 'orrery modal created');
+orrery.userData.render();
+
+const bossList = orrery.getObjectByName('bossList');
+const firstRow = bossList.children[0];
+firstRow.children[0].children[0].userData.onSelect();
+assert.strictEqual(orrery.userData.selectedBosses.length, 1, 'boss selected');
+
+const startBtn = orrery.userData.startBtn;
+startBtn.children[0].userData.onSelect();
+assert(state.arenaMode, 'arena mode active');
+assert.deepStrictEqual(state.customOrreryBosses, orrery.userData.selectedBosses, 'boss list applied');
+
+console.log('orrery modal test passed');


### PR DESCRIPTION
## Summary
- recreate Weaver's Orrery panel using Three.js primitives
- allow selecting bosses, track echo cost and start custom timeline
- expose `startOrrery()` helper
- add automated test for the Orrery modal
- log progress in `TASK_LOG.md`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c01f7c1988331b63b37d44bb655b8