### PR TITLE
Fix loading screen blocking VR entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This document lays out the **step‑by‑step tasks** and architectural guidelin
 
 - **Control Mapping** – The original rewrite hard‑coded the laser pointer to the right controller.  Implement a **handedness setting** so that left‑handed players can swap controls.  Add a small cog icon to the HUD; clicking it opens a Settings panel where players can toggle “Swap Primary/Offhand” and adjust **Music** and **SFX** volume sliders.  Save these preferences to persistent state (e.g. localStorage) and honour them when spawning controllers.
 
-    - **Automatic Home Screen** – After assets finish loading, the VR build should enter immersive mode and display the floating home screen panel.  From this holographic menu the player can choose **AWAKEN**, **CONTINUE MOMENTUM** or other options.  This ensures the user sees the menu immediately instead of launching a stage without context.
+    - **Home Screen After Loading** – Once assets are loaded the game displays the home screen with **AWAKEN** and **CONTINUE MOMENTUM** buttons. Selecting either option starts the VR session and shows the floating home panel.
 
     - **3D Coordinate System** – The VR port must abandon 2D pixel positions (e.g. `state.player.x`, `state.mousePosition.x`) in favour of 3D vectors.  Every entity should have a `THREE.Vector3` position.  When a 2D coordinate is required (for example, to place UI elements on the sphere), convert the 3D position using a helper that maps a point on the unit sphere to UV coordinates.  Powers, cores, projectiles and AI must compute distances and directions using 3D vectors rather than flat‐screen formulas.
 

--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -360,3 +360,7 @@ Summary: Modified app.js to display the VR home screen panel after assets finish
 Verification: npm install && npm test – all suites pass.
 Next Steps: Continue UI reconstruction and stage flow improvements.
 2025-08-01 – FR-03 – Weaver's Orrery VR menu\nSummary: Implemented full Orrery modal with boss selection, point tracking, and startOrrery helper. Added automated test orreryModal.test.mjs and updated modal rendering logic.\nVerification: npm install && npm test – all suites pass.\nNext Steps: Continue porting remaining UI screens.
+2025-10-05 – FR-11 – Loading screen stuck fix
+Summary: Adjusted app.js to stop auto-starting VR. After assets load we now call showHome() so the loading screen hides and the user can launch VR via the AWAKEN/CONTINUE buttons. Updated README to describe this flow.
+Verification: npm install && npm test – all suites pass.
+Next Steps: Monitor for any additional VR initialization issues as UI refactor continues.

--- a/app.js
+++ b/app.js
@@ -107,10 +107,7 @@ async function startGame(resetSave = false) {
 window.addEventListener('load', async () => {
   showLoading();
   await preloadAssets();
-  await startGame(false);
-  if (typeof window !== 'undefined' && window.showHomeMenu) {
-    window.showHomeMenu();
-  }
+  showHome();
   startBtn?.addEventListener('click', () => startGame(true));
   continueBtn?.addEventListener('click', () => startGame(false));
   eraseBtn?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- stop auto-starting VR on page load
- show the home screen after assets finish loading
- update documentation for the new home-screen flow
- log the fix

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c04949c988331bd7e7eedc6ff5097