### PR TITLE
Implement Ascension Conduit connectors and confirm

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -364,3 +364,7 @@ Next Steps: Continue UI reconstruction and stage flow improvements.
 Summary: Adjusted app.js to stop auto-starting VR. After assets load we now call showHome() so the loading screen hides and the user can launch VR via the AWAKEN/CONTINUE buttons. Updated README to describe this flow.
 Verification: npm install && npm test – all suites pass.
 Next Steps: Monitor for any additional VR initialization issues as UI refactor continues.
+2025-10-06 – FR-08 – Ascension menu connectors
+Summary: Added line connectors between talents in the Ascension Conduit VR menu and confirmation prompt for ERASE TIMELINE. Updated ascensionModal.test to cover new confirm flow and page reload. All tests pass.
+Verification: npm install && npm test – all 65 suites pass.
+Next Steps: Continue polishing UI layouts and verify other menus for fidelity gaps.

--- a/tests/ascensionModal.test.mjs
+++ b/tests/ascensionModal.test.mjs
@@ -2,7 +2,7 @@ import assert from 'assert';
 import * as THREE from 'three';
 
 // stub DOM and storage
-global.window = {};
+global.window = { location: { reload(){ this.reloaded = true; } } };
 global.document = {
   createElement: () => ({ getContext: () => ({ measureText: () => ({ width: 0 }), fillText: () => {}, clearRect: () => {} }) }),
   getElementById: () => null
@@ -24,8 +24,14 @@ await initModals(camera);
 const asc = getModalObjects().find(m => m && m.name === 'ascension');
 assert(asc, 'ascension modal created');
 
-const erase = asc.children.find(c => c.children && c.children[0]?.userData?.onSelect && c.children[0].userData.onSelect.toString().includes('removeItem'));
+const erase = asc.children.find(c => c.children && c.children[0]?.userData?.onSelect && c.children[0].userData.onSelect.toString().includes('showConfirm'));
 erase.children[0].userData.onSelect();
+
+const confirm = getModalObjects().find(m => m && m.name === 'confirm');
+const yes = confirm.children.find(c => c.children && c.children[0]?.userData?.onSelect);
+yes.children[0].userData.onSelect();
+
 assert.strictEqual(store.eternalMomentumSave, undefined, 'save cleared');
+assert.ok(global.window.location.reloaded, 'page reloaded');
 
 console.log('ascension modal test passed');


### PR DESCRIPTION
## Summary
- add talent line connectors in VR ascension menu
- require confirmation before erasing timeline
- update test for new confirm flow
- record work in TASK_LOG

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c0628f4a88331803ae900e4ff7cab