### PR TITLE
Fix crash calling VR home menu before initialization

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -368,3 +368,8 @@ Next Steps: Monitor for any additional VR initialization issues as UI refactor c
 Summary: Added line connectors between talents in the Ascension Conduit VR menu and confirmation prompt for ERASE TIMELINE. Updated ascensionModal.test to cover new confirm flow and page reload. All tests pass.
 Verification: npm install && npm test – all 65 suites pass.
 Next Steps: Continue polishing UI layouts and verify other menus for fidelity gaps.
+
+2025-10-07 – FR-11 – Home menu initialization guard
+Summary: Fixed crash when showHomeMenu was called before VR initialization by checking ensureGroup() in ModalManager.
+Verification: npm install && npm test – all 65 suites pass.
+Next Steps: Continue monitoring VR start sequence for edge cases.

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -771,7 +771,10 @@ export function hideModal(id) {
 }
 
 export function showHomeMenu() {
-  ensureGroup();
+  if (!ensureGroup()) {
+    // VR has not been initialized yet; don't attempt to create modals
+    return;
+  }
   if (!modals.home) {
     modals.home = createHomeModal();
     modalGroup.add(modals.home);


### PR DESCRIPTION
## Summary
- prevent `showHomeMenu` from running when VR hasn't started
- log update in `TASK_LOG.md`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c07b86f5c8331881a260e907a0550