### PR TITLE
Fix grid orientation and update tests

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -373,3 +373,7 @@ Next Steps: Continue polishing UI layouts and verify other menus for fidelity ga
 Summary: Fixed crash when showHomeMenu was called before VR initialization by checking ensureGroup() in ModalManager.
 Verification: npm install && npm test – all 65 suites pass.
 Next Steps: Continue monitoring VR start sequence for edge cases.
+2025-10-08 – FR-01 – Grid orientation fix
+Summary: Corrected neon grid floor orientation in scene.js so the disc lies horizontally. Updated ModalManager texture loading to skip when DOM functions are missing. Added Jest setup for createElementNS and updated tests for new button structure and boss info handler.
+Verification: npm install && npm test – all 65 suites pass.
+Next Steps: Continue addressing Critical User Feedback items such as pointer reliability.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 export default {
   testEnvironment: 'node',
   transform: {},
+  setupFiles: ['./tests/setup.mjs'],
   testMatch: ['**/all.test.mjs', '**/webxrIntegration.test.mjs']
 };

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -27,12 +27,18 @@ const FONT_COLOR    = '#eaf2ff'; // --font-color【802164479894751†L0-L8】
 // image should be placed in the assets folder at ../assets/bg.png.  A low
 // opacity overlay using this texture is drawn on top of each panel to
 // approximate the translucent nebula seen in the old menus.  If the texture
-// fails to load the material will simply be transparent.
-const starTexture = new THREE.TextureLoader().load('../assets/bg.png', tex => {
-  tex.encoding = THREE.sRGBEncoding;
-  tex.minFilter = THREE.LinearFilter;
-  tex.magFilter = THREE.LinearFilter;
-});
+// fails to load or the test environment lacks DOM methods, the material will
+// simply remain empty.
+let starTexture;
+if (typeof document !== 'undefined' && document.createElementNS) {
+  starTexture = new THREE.TextureLoader().load('../assets/bg.png', tex => {
+    tex.encoding = THREE.sRGBEncoding;
+    tex.minFilter = THREE.LinearFilter;
+    tex.magFilter = THREE.LinearFilter;
+  });
+} else {
+  starTexture = new THREE.Texture();
+}
 
 let modalGroup;
 const modals = {};
@@ -298,10 +304,10 @@ function createStageSelectModal() {
     row.name = `stage${i}`;
     const btn = createButton(`STAGE ${i}: ${stageInfo.displayName}`, () => startStage(i));
     row.add(btn);
-    const mech = createButton('❔', () => showBossInfoModal(stageInfo.bosses, 'mechanics'));
+    const mech = createButton('❔', () => showBossInfo(stageInfo.bosses, 'mechanics'));
     mech.position.set(0.6, 0, 0);
     row.add(mech);
-    const loreIcon = createButton('ℹ️', () => showBossInfoModal(stageInfo.bosses, 'lore'));
+    const loreIcon = createButton('ℹ️', () => showBossInfo(stageInfo.bosses, 'lore'));
     loreIcon.position.set(0.8, 0, 0);
     row.add(loreIcon);
     row.position.set(0, -0.25 * (i - 1), 0);
@@ -568,10 +574,10 @@ function createOrreryModal() {
         }
       });
       row.add(btn);
-      const mech = createButton('❔', () => showBossInfoModal([boss.id], 'mechanics'));
+      const mech = createButton('❔', () => showBossInfo([boss.id], 'mechanics'));
       mech.position.set(0.6, 0, 0);
       row.add(mech);
-      const loreIcon = createButton('ℹ️', () => showBossInfoModal([boss.id], 'lore'));
+      const loreIcon = createButton('ℹ️', () => showBossInfo([boss.id], 'lore'));
       loreIcon.position.set(0.8, 0, 0);
       row.add(loreIcon);
       const cText = createTextSprite(String(cost), 24, FONT_COLOR);

--- a/modules/scene.js
+++ b/modules/scene.js
@@ -81,7 +81,9 @@ export function initScene(container = document.body) {
   platformGroup.add(ring);
 
   const gridHelper = new THREE.GridHelper(20, 20, 0x00ffff, 0x004444);
-  gridHelper.rotation.x = Math.PI / 2;
+  // The grid should lie flat on the XZ plane. Rotating it would place the
+  // disc vertically, which users reported seeing in the prototype.
+  gridHelper.rotation.x = 0;
   gridHelper.material.transparent = true;
   gridHelper.material.opacity = 0.25;
   platformGroup.add(gridHelper);

--- a/tests/ascensionInfo.test.mjs
+++ b/tests/ascensionInfo.test.mjs
@@ -29,9 +29,9 @@ let infoGroup = asc.children.find(c => c.children && c.children.length===3 && c.
 assert(infoGroup, 'info group exists');
 const ctx = infoGroup.children[0].userData.ctx;
 const beforeText = ctx.lastText;
-const grid = asc.children.find(g => g.children && g.children.some(n => n.children && n.children[0]?.userData?.onHover));
-const nodes = grid.children.filter(n => n.children && n.children[0]?.userData?.onHover);
+const grid = asc.children.find(g => g.children && g.children.some(n => n.children && n.children[1]?.userData?.onHover));
+const nodes = grid.children.filter(n => n.children && n.children[1]?.userData?.onHover);
 assert(nodes.length > 1, 'nodes found');
-nodes[1].children[0].userData.onHover();
+nodes[1].children[1].userData.onHover();
 assert.notStrictEqual(ctx.lastText, beforeText, 'info text updated');
 console.log('ascension info test passed');

--- a/tests/ascensionInfoPurchase.test.mjs
+++ b/tests/ascensionInfoPurchase.test.mjs
@@ -40,12 +40,12 @@ const infoGroup = asc.children.find(c => c.children && c.children.length===3);
 const costCtx = infoGroup.children[2].userData.ctx;
 const before = costCtx.lastText;
 
-const grid = asc.children.find(g => g.children && g.children.some(n => n.children && n.children[0]?.userData?.onSelect));
-const nodes = grid.children.filter(n => n.children && n.children[0]?.userData?.onSelect);
+const grid = asc.children.find(g => g.children && g.children.some(n => n.children && n.children[1]?.userData?.onSelect));
+const nodes = grid.children.filter(n => n.children && n.children[1]?.userData?.onSelect);
 assert(nodes.length > 0, 'nodes found');
 
-nodes[0].children[0].userData.onSelect();
-nodes[0].children[0].userData.onHover();
+nodes[0].children[1].userData.onSelect();
+nodes[0].children[1].userData.onHover();
 assert.notStrictEqual(costCtx.lastText, before, 'info text updated after purchase');
 assert.ok(state.player.purchasedTalents.has('core-nexus'), 'talent purchased');
 console.log('ascension info purchase test passed');

--- a/tests/ascensionModal.test.mjs
+++ b/tests/ascensionModal.test.mjs
@@ -24,12 +24,12 @@ await initModals(camera);
 const asc = getModalObjects().find(m => m && m.name === 'ascension');
 assert(asc, 'ascension modal created');
 
-const erase = asc.children.find(c => c.children && c.children[0]?.userData?.onSelect && c.children[0].userData.onSelect.toString().includes('showConfirm'));
-erase.children[0].userData.onSelect();
+const erase = asc.children.find(c => c.children && c.children[1]?.userData?.onSelect && c.children[1].userData.onSelect.toString().includes('showConfirm'));
+erase.children[1].userData.onSelect();
 
 const confirm = getModalObjects().find(m => m && m.name === 'confirm');
-const yes = confirm.children.find(c => c.children && c.children[0]?.userData?.onSelect);
-yes.children[0].userData.onSelect();
+const yes = confirm.children.find(c => c.children && c.children[1]?.userData?.onSelect);
+yes.children[1].userData.onSelect();
 
 assert.strictEqual(store.eternalMomentumSave, undefined, 'save cleared');
 assert.ok(global.window.location.reloaded, 'page reloaded');

--- a/tests/ascensionPurchase.test.mjs
+++ b/tests/ascensionPurchase.test.mjs
@@ -33,10 +33,10 @@ await initModals(camera);
 const asc = getModalObjects().find(m => m && m.name === 'ascension');
 assert(asc, 'ascension modal created');
 
-const grid = asc.children.find(g => g.children && g.children.some(c => c.children && c.children[0]?.userData?.onSelect));
-const node = grid && grid.children.find(c => c.children && c.children[0]?.userData?.onSelect);
+const grid = asc.children.find(g => g.children && g.children.some(c => c.children && c.children[1]?.userData?.onSelect));
+const node = grid && grid.children.find(c => c.children && c.children[1]?.userData?.onSelect);
 assert(node, 'talent node exists');
-node.children[0].userData.onSelect();
+node.children[1].userData.onSelect();
 
 assert.ok(state.player.purchasedTalents.size >= 1, 'talent purchased');
 console.log('ascension purchase test passed');

--- a/tests/confirmModal.test.mjs
+++ b/tests/confirmModal.test.mjs
@@ -17,7 +17,8 @@ showConfirm('Erase?', 'Really erase?', () => { confirmed = true; });
 const confirmModal = getModalObjects().find(m => m && m.name === 'confirm');
 assert(confirmModal && confirmModal.visible, 'confirm modal visible');
 // simulate pressing confirm button
-const yesGroup = confirmModal.children.find(c => c.children && c.children[0]?.userData?.onSelect);
-yesGroup.children[0].userData.onSelect();
+// onSelect handlers are stored on the second child (the button background)
+const yesGroup = confirmModal.children.find(c => c.children && c.children[1]?.userData?.onSelect);
+yesGroup.children[1].userData.onSelect();
 assert(confirmed, 'confirm callback triggered');
 console.log('confirm modal test passed');

--- a/tests/coresModal.test.mjs
+++ b/tests/coresModal.test.mjs
@@ -24,13 +24,14 @@ await initModals(camera);
 const cores = getModalObjects().find(m => m && m.name === 'cores');
 assert(cores, 'cores modal created');
 
-const list = cores.children[3];
+// list of core buttons is stored in child index 5
+const list = cores.children[5];
 const firstBtn = list.children[0];
-firstBtn.children[0].userData.onSelect();
+firstBtn.children[1].userData.onSelect();
 assert(state.player.equippedAberrationCore, 'core equipped');
 
-const unequip = cores.children.find(c => c.children && c.children[0]?.userData?.onSelect && c.children[0].userData.onSelect.toString().includes('null'));
-unequip.children[0].userData.onSelect();
+const unequip = cores.children.find(c => c.children && c.children[1]?.userData?.onSelect && c.children[1].userData.onSelect.toString().includes('null'));
+unequip.children[1].userData.onSelect();
 assert.strictEqual(state.player.equippedAberrationCore, null, 'core unequipped');
 
 console.log('cores modal test passed');

--- a/tests/gameOverModal.test.mjs
+++ b/tests/gameOverModal.test.mjs
@@ -2,7 +2,13 @@ import assert from 'assert';
 import * as THREE from 'three';
 
 // minimal DOM stubs
-const canvasStub = { getContext: () => ({ measureText: () => ({ width: 0 }), fillText: () => {} }) };
+const canvasStub = {
+  getContext: () => ({
+    measureText: () => ({ width: 0 }),
+    fillText: () => {},
+    clearRect: () => {}
+  })
+};
 
 global.window = { gameHelpers: {} };
 global.document = {
@@ -26,17 +32,19 @@ let gameOver = getModalObjects().filter(Boolean).find(m => m.name === 'gameOver'
 assert(gameOver.visible, 'gameOver modal visible');
 
 // find restart button
-const restartGroup = gameOver.children.find(c => c.children && c.children[0]?.userData?.onSelect);
+// onSelect is attached to the background mesh (child index 1)
+const restartGroup = gameOver.children.find(c => c.children && c.children[1]?.userData?.onSelect);
 state.player.health = 50;
-restartGroup.children[0].userData.onSelect();
+restartGroup.children[1].userData.onSelect();
 
 assert.strictEqual(state.player.health, state.player.maxHealth, 'player reset');
 assert(!gameOver.visible, 'gameOver hidden after restart');
 
 // test ascension button opens ascension modal
 showModal('gameOver');
-const ascGroup = gameOver.children.filter(c => c.children && c.children[0]?.userData?.onSelect)[1];
-ascGroup.children[0].userData.onSelect();
+// buttons store their handler on the background mesh (index 1)
+const ascGroup = gameOver.children.filter(c => c.children && c.children[1]?.userData?.onSelect)[1];
+ascGroup.children[1].userData.onSelect();
 const ascension = getModalObjects().filter(Boolean).find(m => m.name === 'ascension');
 assert(ascension.visible, 'ascension modal visible');
 

--- a/tests/orreryModal.test.mjs
+++ b/tests/orreryModal.test.mjs
@@ -32,11 +32,12 @@ orrery.userData.render();
 
 const bossList = orrery.getObjectByName('bossList');
 const firstRow = bossList.children[0];
-firstRow.children[0].children[0].userData.onSelect();
+// each button stores the onSelect handler on its background mesh
+firstRow.children[0].children[1].userData.onSelect();
 assert.strictEqual(orrery.userData.selectedBosses.length, 1, 'boss selected');
 
 const startBtn = orrery.userData.startBtn;
-startBtn.children[0].userData.onSelect();
+startBtn.children[1].userData.onSelect();
 assert(state.arenaMode, 'arena mode active');
 assert.deepStrictEqual(state.customOrreryBosses, orrery.userData.selectedBosses, 'boss list applied');
 

--- a/tests/setup.mjs
+++ b/tests/setup.mjs
@@ -1,0 +1,7 @@
+// Jest setup to provide minimal DOM functions used by Three.js loaders
+if (typeof global.document === 'undefined') {
+  global.document = {};
+}
+if (!global.document.createElementNS) {
+  global.document.createElementNS = () => ({ getContext: () => ({}) });
+}

--- a/tests/stageSelectModal.test.mjs
+++ b/tests/stageSelectModal.test.mjs
@@ -4,7 +4,13 @@ import * as THREE from 'three';
 // minimal DOM stubs
 global.window = {};
 global.document = {
-  createElement: () => ({ getContext: () => ({ measureText: () => ({ width: 0 }), fillText: () => {} }) }),
+  createElement: () => ({
+    getContext: () => ({
+      measureText: () => ({ width: 0 }),
+      fillText: () => {},
+      clearRect: () => {}
+    })
+  }),
   getElementById: () => null
 };
 
@@ -18,11 +24,12 @@ assert(levelSelect, 'levelSelect modal created');
 
 const stageRow = levelSelect.getObjectByName('stage1');
 assert(stageRow, 'stage row exists');
-stageRow.children[0].children[0].userData.onSelect();
+// button structure: [border, bg, label]. onSelect is attached to the bg mesh
+stageRow.children[0].children[1].userData.onSelect();
 assert.strictEqual(state.currentStage, 1, 'stage set to 1');
 
 // mechanics info button
-stageRow.children[1].children[0].userData.onSelect();
+stageRow.children[1].children[1].userData.onSelect();
 const bossInfo = getModalObjects().find(m => m && m.name === 'bossInfo');
 assert(bossInfo.visible, 'boss info visible');
 console.log('stage select modal test passed');


### PR DESCRIPTION
## Summary
- ensure the neon grid floor is horizontal
- load star texture only when DOM functions are available
- provide Jest setup file for DOM stubs
- update button tests for new hierarchy
- log the work in `TASK_LOG.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c1725ae708331adcad469e9e19f8c