### PR TITLE
Add scroll bar to stage select menu

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -391,3 +391,7 @@ Next Steps: Continue auditing menu layouts for parity with the 2D game.
 Summary: Updated ModalManager so modalGroup attaches to the scene instead of the camera. When a modal is shown the group positions itself at the player’s current location and orientation then stays fixed in the arena. Added null checks in updateStatusEffectsUI for test safety and documented world-space panels in README.
 Verification: npm test – all 65 suites pass.
 Next Steps: Continue verifying long menu text fits with scroll bars.
+2025-10-12 – FR-03 – Stage select scroll bar
+Summary: Added addScrollBar helper and integrated it into createStageSelectModal with up/down buttons and draggable thumb. Updated stageSelectModal test for new scroll controls.
+Verification: npm test – all suites pass.
+Next Steps: Continue refining remaining menus for parity.

--- a/tests/stageSelectModal.test.mjs
+++ b/tests/stageSelectModal.test.mjs
@@ -22,6 +22,17 @@ await initModals(camera);
 const levelSelect = getModalObjects().find(m => m && m.name === 'levelSelect');
 assert(levelSelect, 'levelSelect modal created');
 
+const scrollBar = levelSelect.getObjectByName('scrollBar');
+assert(scrollBar, 'scroll bar created');
+const up = scrollBar.getObjectByName('scrollUp');
+const down = scrollBar.getObjectByName('scrollDown');
+const list = levelSelect.getObjectByName('stageList');
+const initialY = list.position.y;
+down.children[1].userData.onSelect();
+assert(list.position.y < initialY, 'list scrolled down');
+up.children[1].userData.onSelect();
+assert.strictEqual(list.position.y, initialY, 'list scrolled back up');
+
 const stageRow = levelSelect.getObjectByName('stage1');
 assert(stageRow, 'stage row exists');
 // button structure: [border, bg, label]. onSelect is attached to the bg mesh


### PR DESCRIPTION
## Summary
- build a simple scroll bar with up/down buttons in `ModalManager`
- add scroll controls to the Stage Select menu
- test the new scroll bar behaviour
- log work in `TASK_LOG`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c24cd838c8331bc83bec101f5fe55