### PR TITLE
Fix duplicate helper functions

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -395,3 +395,7 @@ Next Steps: Continue verifying long menu text fits with scroll bars.
 Summary: Added addScrollBar helper and integrated it into createStageSelectModal with up/down buttons and draggable thumb. Updated stageSelectModal test for new scroll controls.
 Verification: npm test – all suites pass.
 Next Steps: Continue refining remaining menus for parity.
+2025-10-13 – FR-15 – Helper deduplication
+Summary: Centralized playerHasCore and getCanvasPos in new helpers.js, removed duplicates from gameLoop, powers and cores. Added helpers.test.mjs verifying functionality.
+Verification: npm test – all 66 suites pass.
+Next Steps: Continue FR-03 UI parity work.

--- a/modules/cores.js
+++ b/modules/cores.js
@@ -16,6 +16,7 @@ import { bossData } from './bosses.js';
 import { showUnlockNotification, updateUI } from './ui.js';
 import { usePower } from './powers.js';
 import * as THREE from '../vendor/three.module.js';
+import { playerHasCore } from './helpers.js';
 
 const CANVAS_W = 2048;
 const CANVAS_H = 1024;
@@ -48,16 +49,6 @@ const offscreenCanvas = {
 export function getPlayerCoords() {
   const uv = utils.spherePosToUv(state.player.position.clone().normalize(), 1);
   return { x: uv.u * CANVAS_W, y: uv.v * CANVAS_H };
-}
-
-/**
- * Returns true if the player currently has the specified core equipped or
- * temporarily granted through the Pantheon core.  This helper centralises
- * the logic for checking both the equipped core and temporary buffs.
- */
-export function playerHasCore(coreId) {
-  if (state.player.equippedAberrationCore === coreId) return true;
-  return state.player.activePantheonBuffs.some(buff => buff.coreId === coreId);
 }
 
 /**

--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -9,6 +9,7 @@ import { uvToSpherePos } from './utils.js';
 import * as THREE from '../vendor/three.module.js';
 import { AudioManager } from './audio.js';
 import * as CoreManager from './CoreManager.js';
+import { playerHasCore } from './helpers.js';
 import { getArena } from './scene.js';
 import { updateEnemies3d } from './enemyAI3d.js';
 import { updateProjectiles3d } from './projectilePhysics3d.js';
@@ -19,11 +20,7 @@ const missingStageWarned = new Set();
 const SCREEN_WIDTH = 2048;
 const SCREEN_HEIGHT = 1024;
 
-// --- Helper Function ---
-function playerHasCore(coreId) {
-    if (state.player.equippedAberrationCore === coreId) return true;
-    return state.player.activePantheonBuffs.some(buff => buff.coreId === coreId);
-}
+// --- Helper Functions ---
 
 // --- Audio Helpers ---
 function play(soundId) { AudioManager.playSfx(soundId); }

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -1,0 +1,27 @@
+import { state } from './state.js';
+import { toCanvasPos } from './utils.js';
+import * as THREE from '../vendor/three.module.js';
+
+/**
+ * Check if the player currently has the given core equipped or granted
+ * via Pantheon buffs.
+ * @param {string} coreId - Core identifier
+ * @returns {boolean} True if the core is active
+ */
+export function playerHasCore(coreId){
+  if (state.player.equippedAberrationCore === coreId) return true;
+  return state.player.activePantheonBuffs.some(buff => buff.coreId === coreId);
+}
+
+/**
+ * Convert an object with a Vector3 position or x/y fields to canvas
+ * coordinates in pixels.
+ * @param {{position?:THREE.Vector3,x?:number,y?:number}} obj
+ * @returns {{x:number,y:number}}
+ */
+export function getCanvasPos(obj){
+  if (obj.position && obj.position.isVector3){
+    return toCanvasPos(obj.position);
+  }
+  return { x: obj.x, y: obj.y };
+}

--- a/modules/powers.js
+++ b/modules/powers.js
@@ -4,22 +4,12 @@ import * as utils from './utils.js';
 import * as Cores from './cores.js';
 import { gameHelpers } from './gameHelpers.js';
 import * as THREE from '../vendor/three.module.js';
+import { playerHasCore, getCanvasPos } from './helpers.js';
 
 const SCREEN_WIDTH = 2048;
 const SCREEN_HEIGHT = 1024;
 
-// Helper function to check for core presence (equipped or via Pantheon)
-function playerHasCore(coreId) {
-    if (state.player.equippedAberrationCore === coreId) return true;
-    return state.player.activePantheonBuffs.some(buff => buff.coreId === coreId);
-}
-
-function getCanvasPos(obj) {
-  if (obj.position && obj.position.isVector3) {
-    return utils.toCanvasPos(obj.position);
-  }
-  return { x: obj.x, y: obj.y };
-}
+// helper functions provided by helpers.js
 
 export const powers={
   shield:{

--- a/tests/helpers.test.mjs
+++ b/tests/helpers.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'assert';
+import { playerHasCore, getCanvasPos } from '../modules/helpers.js';
+import { state } from '../modules/state.js';
+import { toCanvasPos } from '../modules/utils.js';
+import * as THREE from '../vendor/three.module.js';
+
+state.player.equippedAberrationCore = 'gravity';
+state.player.activePantheonBuffs = [{ coreId: 'vampire' }];
+
+assert.strictEqual(playerHasCore('gravity'), true, 'equipped core');
+assert.strictEqual(playerHasCore('vampire'), true, 'buffed core');
+assert.strictEqual(playerHasCore('swarm'), false, 'missing core');
+
+const vecObj = { position: new THREE.Vector3(1, 0, 0) };
+const expected = toCanvasPos(vecObj.position);
+const result = getCanvasPos(vecObj);
+assert.ok(Math.abs(result.x - expected.x) < 1e-6, 'vector x match');
+assert.ok(Math.abs(result.y - expected.y) < 1e-6, 'vector y match');
+
+const plain = { x: 5, y: 10 };
+const plainResult = getCanvasPos(plain);
+assert.deepStrictEqual(plainResult, plain, 'plain object passthrough');
+
+console.log('helpers test passed');


### PR DESCRIPTION
## Summary
- centralize `playerHasCore` and `getCanvasPos` in `helpers.js`
- use helpers in `gameLoop`, `powers`, and `cores`
- add unit tests for helper utilities
- log FR-15 completion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c27169f4483318af4a24170f19cf6