### PR TITLE
Update core modal wording

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -408,3 +408,8 @@ Next Steps: Continue FR-03 UI parity work.
 Summary: Rebuilt Lore Codex modal with full story paragraphs and added scroll bar using createTextBlock helper. Updated test to verify lines and scroll controls.
 Verification: npm test – all 67 suites pass.
 Next Steps: Continue FR-03 by auditing remaining menu layouts for accuracy.
+
+2025-10-16 – FR-03 – Core menu text parity
+Summary: Updated createCoresModal to display heading 'ABERRATION CORE ATTUNEMENT' and label 'CURRENTLY ATTUNED'. Added attunedName sprite and named buttons for tests. Revised coresModal.test to check wording and use object names.
+Verification: Ran `npm test`; all 67 suites pass.
+Next Steps: Continue reviewing other menus for exact wording matches.

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -549,14 +549,20 @@ function createCoresModal() {
   const coresStars = new THREE.Mesh(new THREE.PlaneGeometry(w, h), new THREE.MeshBasicMaterial({ map: starTexture, transparent: true, opacity: 0.15, depthWrite: false }));
   coresStars.position.z = 0.001;
   modal.add(coresStars);
-  const header = createTextSprite('ABERRATION CORES', 64, FONT_COLOR);
+  const header = createTextSprite('ABERRATION CORE ATTUNEMENT', 64, FONT_COLOR);
   header.position.set(0, 0.65, 0.01);
   modal.add(header);
-  const equippedText = createTextSprite('Equipped: None', 32, FONT_COLOR);
-  equippedText.position.set(0, 0.45, 0.01);
-  modal.add(equippedText);
+  const attunedLabel = createTextSprite('CURRENTLY ATTUNED', 32, FONT_COLOR);
+  attunedLabel.name = 'attunedLabel';
+  attunedLabel.position.set(0, 0.5, 0.01);
+  modal.add(attunedLabel);
+  const attunedName = createTextSprite('None', 32, FONT_COLOR);
+  attunedName.name = 'attunedName';
+  attunedName.position.set(0, 0.4, 0.01);
+  modal.add(attunedName);
   const list = new THREE.Group();
-  list.position.set(0, 0.3, 0.02);
+  list.name = 'coreList';
+  list.position.set(0, 0.25, 0.02);
   let index = 0;
   bossData.forEach(core => {
     if (!core.core_desc) return;
@@ -566,17 +572,20 @@ function createCoresModal() {
   });
   modal.add(list);
   const unequipBtn = createButton('UNEQUIP CORE', () => equipCore(null));
+  unequipBtn.name = 'unequipBtn';
   unequipBtn.position.set(0, -0.5, 0.02);
   modal.add(unequipBtn);
   const closeBtn2 = createButton('CLOSE', () => hideModal('cores'));
+  closeBtn2.name = 'closeBtn';
   closeBtn2.position.set(0, -0.75, 0.02);
   modal.add(closeBtn2);
   function equipCore(id) {
     state.player.equippedAberrationCore = id;
     const core = bossData.find(b => b.id === id);
-    updateTextSprite(equippedText, `Equipped: ${core ? core.name : 'None'}`, FONT_COLOR);
+    updateTextSprite(attunedName, core ? core.name : 'None', FONT_COLOR);
     savePlayerState();
   }
+  modal.userData.attunedName = attunedName;
   modal.visible = false;
   return modal;
 }

--- a/tests/coresModal.test.mjs
+++ b/tests/coresModal.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import * as THREE from 'three';
+import fs from 'fs';
 
 // stub DOM
 global.window = {};
@@ -24,13 +25,18 @@ await initModals(camera);
 const cores = getModalObjects().find(m => m && m.name === 'cores');
 assert(cores, 'cores modal created');
 
-// list of core buttons is stored in child index 5
-const list = cores.children[5];
+// verify header and label text are correct in source
+const src = fs.readFileSync('./modules/ModalManager.js', 'utf8');
+assert(src.includes("ABERRATION CORE ATTUNEMENT"), 'heading text match');
+assert(src.includes("CURRENTLY ATTUNED"), 'label text match');
+
+// list of core buttons stored under coreList
+const list = cores.getObjectByName('coreList');
 const firstBtn = list.children[0];
 firstBtn.children[1].userData.onSelect();
 assert(state.player.equippedAberrationCore, 'core equipped');
 
-const unequip = cores.children.find(c => c.children && c.children[1]?.userData?.onSelect && c.children[1].userData.onSelect.toString().includes('null'));
+const unequip = cores.getObjectByName('unequipBtn');
 unequip.children[1].userData.onSelect();
 assert.strictEqual(state.player.equippedAberrationCore, null, 'core unequipped');
 


### PR DESCRIPTION
## Summary
- fix wording in the aberration core menu
- expose buttons and sprites by name for tests
- verify core modal text via new unit tests
- document work in TASK_LOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c2fe635f883319408d4a201bcc251