### PR TITLE
Implement modal text parity check

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -418,3 +418,7 @@ Next Steps: Continue reviewing other menus for exact wording matches.
 Summary: Replaced AP display in createAscensionModal with separate 'ASCENSION POINTS' label and value sprite. Updated purchase handler to refresh the value. Home menu erase timeline confirm text now matches the original game's wording.
 Verification: `npm test` – all 67 suites pass.
 Next Steps: Audit remaining modals for any lingering wording differences.
+2025-10-18 – FR-03 – Modal text parity
+Summary: Updated boss info modal close button to 'Close' to match the original UI and added text storage in createTextSprite for testing. Implemented modalTextParity.test.mjs verifying close button wording across menus.
+Verification: npm test – all 68 suites pass.
+Next Steps: Continue reviewing remaining UI elements for fidelity issues.

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -82,6 +82,7 @@ function createTextSprite(text, size = 32, color = FONT_COLOR) {
   sprite.userData.ctx = ctx;
   sprite.userData.canvas = canvas;
   sprite.userData.font = `${size}px ${fontStack}`;
+  sprite.userData.text = text; // retain original text for tests
   return sprite;
 }
 
@@ -94,6 +95,7 @@ function updateTextSprite(sprite, text, color = FONT_COLOR) {
   ctx.fillStyle = color;
   ctx.textBaseline = 'middle';
   ctx.fillText(text, 0, canvas.height / 2);
+  sprite.userData.text = text;
   sprite.material.map.needsUpdate = true;
 }
 
@@ -771,7 +773,8 @@ function createBossInfoModal() {
   const body = createTextSprite('', 24, FONT_COLOR);
   body.position.set(0, 0.15, 0.01);
   modal.add(body);
-  const closeBtn = createButton('CLOSE', () => hideModal('bossInfo'));
+  // The original UI uses mixed-case text for this button
+  const closeBtn = createButton('Close', () => hideModal('bossInfo'));
   closeBtn.position.set(0, -0.35, 0.02);
   modal.add(closeBtn);
   modal.userData.title = title;

--- a/tests/modalTextParity.test.mjs
+++ b/tests/modalTextParity.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'assert';
+import * as THREE from 'three';
+
+// minimal DOM stubs for text sprite rendering
+global.window = {};
+global.document = {
+  createElement: () => ({
+    getContext: () => ({
+      measureText: () => ({ width: 0 }),
+      fillText: () => {},
+      clearRect: () => {}
+    })
+  }),
+  getElementById: () => null
+};
+
+const { initModals, getModalObjects } = await import('../modules/ModalManager.js');
+const camera = new THREE.PerspectiveCamera();
+await initModals(camera);
+
+function findButton(modal, label) {
+  return modal.children.find(c => c.children && c.children[2]?.userData?.text === label);
+}
+
+const modals = Object.fromEntries(getModalObjects().filter(Boolean).map(m => [m.name, m]));
+
+assert(findButton(modals.levelSelect, 'Close'), 'level select close text');
+assert(findButton(modals.ascension, 'CLOSE'), 'ascension close text');
+assert(findButton(modals.cores, 'CLOSE'), 'core close text');
+assert(findButton(modals.orrery, 'CLOSE'), 'orrery close text');
+assert(findButton(modals.lore, 'Close'), 'lore close text');
+assert(findButton(modals.bossInfo, 'Close'), 'bossInfo close text');
+
+console.log('modal text parity test passed');


### PR DESCRIPTION
## Summary
- ensure boss info modal uses mixed-case close button text
- store text on sprites for easier testing
- add unit test verifying close button wording across modals
- log FR-03 progress

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c364ca7888331952fed33f0fe730f