### PR TITLE
Fix freeze from Object3D id collisions

### DIFF
--- a/modules/agents/AnnihilatorAI.js
+++ b/modules/agents/AnnihilatorAI.js
@@ -17,7 +17,10 @@ export class AnnihilatorAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "annihilator", name: "The Annihilator", maxHP: 480 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.isChargingBeam = false;
     this.lastBeamTime = 0;

--- a/modules/agents/ArchitectAI.js
+++ b/modules/agents/ArchitectAI.js
@@ -16,7 +16,10 @@ export class ArchitectAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "architect", name: "The Architect", maxHP: 280 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.lastBuildTime = 0;
   }

--- a/modules/agents/BasiliskAI.js
+++ b/modules/agents/BasiliskAI.js
@@ -20,7 +20,10 @@ export class BasiliskAI extends BaseAgent {
     super({ model: new THREE.Mesh(placeholderGeo, material) });
 
     const bossData = { id: "basilisk", name: "The Basilisk", maxHP: 384 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.zones = [];
     const zonePositions = [

--- a/modules/agents/CenturionAI.js
+++ b/modules/agents/CenturionAI.js
@@ -16,7 +16,10 @@ export class CenturionAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "centurion", name: "The Centurion", maxHP: 480 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.lastWallTime = 0;
   }

--- a/modules/agents/EMPOverloadAI.js
+++ b/modules/agents/EMPOverloadAI.js
@@ -14,7 +14,10 @@ export class EMPOverloadAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "emp", name: "EMP Overload", maxHP: 260 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
 
     this.lastEMPTime = 0;
     this.isCharging = false;

--- a/modules/agents/EpochEnderAI.js
+++ b/modules/agents/EpochEnderAI.js
@@ -16,7 +16,10 @@ export class EpochEnderAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "epoch_ender", name: "The Epoch-Ender", maxHP: 550 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.damageInWindow = 0;
     this.lastStateSnapshot = { position: this.position.clone(), health: this.health };

--- a/modules/agents/FractalHorrorAI.js
+++ b/modules/agents/FractalHorrorAI.js
@@ -16,7 +16,10 @@ export class FractalHorrorAI extends BaseAgent {
     
     if (generation === 1) {
         const bossData = { id: "fractal_horror", name: "The Fractal Horror", maxHP: 10000 };
-        Object.assign(this, bossData);
+        this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
         state.fractalHorrorSharedHp = this.maxHP;
     } else {
         this.maxHP = 10000 / generation;
@@ -34,7 +37,7 @@ export class FractalHorrorAI extends BaseAgent {
     const hpPercent = state.fractalHorrorSharedHp / this.maxHP;
     const expectedSplits = Math.floor((1 - hpPercent) * 20); // Split roughly every 5%
 
-    if (state.enemies.filter(e => e.id === 'fractal_horror').length < expectedSplits && this.generation < 5) {
+    if (state.enemies.filter(e => e.kind === 'fractal_horror').length < expectedSplits && this.generation < 5) {
         this.split();
     }
   }
@@ -59,7 +62,7 @@ export class FractalHorrorAI extends BaseAgent {
       // All instances die when shared health is gone
       if (state.fractalHorrorSharedHp <= 0) {
           state.enemies.forEach(e => {
-              if (e.id === 'fractal_horror') e.hp = 0;
+              if (e.kind === 'fractal_horror') e.hp = 0;
           });
       }
   }
@@ -72,7 +75,7 @@ export class FractalHorrorAI extends BaseAgent {
       this.model.visible = false;
 
       // If this is the very last fragment, trigger the actual boss death
-      if (isFinal && state.enemies.filter(e => e.id === 'fractal_horror').length === 0) {
+      if (isFinal && state.enemies.filter(e => e.kind === 'fractal_horror').length === 0) {
           super.die();
       }
   }

--- a/modules/agents/GlitchAI.js
+++ b/modules/agents/GlitchAI.js
@@ -17,7 +17,10 @@ export class GlitchAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "glitch", name: "The Glitch", maxHP: 336 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.lastTeleportTime = 0;
   }

--- a/modules/agents/GravityAI.js
+++ b/modules/agents/GravityAI.js
@@ -15,7 +15,10 @@ export class GravityAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "gravity", name: "Gravity Tyrant", maxHP: 168 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.wells = [];
     this.wellObjects = new THREE.Group();

--- a/modules/agents/HelixWeaverAI.js
+++ b/modules/agents/HelixWeaverAI.js
@@ -16,7 +16,10 @@ export class HelixWeaverAI extends BaseAgent {
     super({ model });
 
     const bossData = { id: "helix_weaver", name: "The Helix Weaver", maxHP: 500 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
 
     this.position.set(0, 0, 0); // Stays at the center
     this.angle = 0;

--- a/modules/agents/JuggernautAI.js
+++ b/modules/agents/JuggernautAI.js
@@ -19,7 +19,10 @@ export class JuggernautAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "juggernaut", name: "The Juggernaut", maxHP: 360 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.isCharging = false;
     this.chargeEndTime = 0;

--- a/modules/agents/LoopingEyeAI.js
+++ b/modules/agents/LoopingEyeAI.js
@@ -16,7 +16,10 @@ export class LoopingEyeAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "looper", name: "Looping Eye", maxHP: 320 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.lastTeleportTime = Date.now();
     this.isChargingTeleport = false;

--- a/modules/agents/MiasmaAI.js
+++ b/modules/agents/MiasmaAI.js
@@ -16,7 +16,10 @@ export class MiasmaAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "miasma", name: "The Miasma", maxHP: 400 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.isGasActive = false;
     this.lastGasAttack = 0;

--- a/modules/agents/MirrorMirageAI.js
+++ b/modules/agents/MirrorMirageAI.js
@@ -10,7 +10,10 @@ export class MirrorMirageAI extends BaseAgent {
     super({ model: new THREE.Group() });
 
     const bossData = { id: "mirror", name: "Mirror Mirage", maxHP: 240 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
 
     this.clones = [];
     const cloneGeo = new THREE.OctahedronGeometry(0.8, 0);

--- a/modules/agents/ObeliskAI.js
+++ b/modules/agents/ObeliskAI.js
@@ -84,7 +84,10 @@ export class ObeliskAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "obelisk", name: "The Obelisk", maxHP: 800 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
 
     this.position.set(0, 0, 0);
     this.invulnerable = true;

--- a/modules/agents/PantheonAI.js
+++ b/modules/agents/PantheonAI.js
@@ -21,7 +21,10 @@ export class PantheonAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "pantheon", name: "The Pantheon", maxHP: 3000 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.nextActionTime = Date.now() + 3000;
     this.activeAspects = new Map(); // Use a Map to store aspect AI instances

--- a/modules/agents/ParasiteAI.js
+++ b/modules/agents/ParasiteAI.js
@@ -31,7 +31,10 @@ export class ParasiteAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "parasite", name: "The Parasite", maxHP: 416 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
   }
 
   infect(target) {

--- a/modules/agents/PuppeteerAI.js
+++ b/modules/agents/PuppeteerAI.js
@@ -14,7 +14,10 @@ export class PuppeteerAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
     
     const bossData = { id: "puppeteer", name: "The Puppeteer", maxHP: 320 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
 
     this.lastConvertTime = 0;
   }

--- a/modules/agents/QuantumShadowAI.js
+++ b/modules/agents/QuantumShadowAI.js
@@ -18,7 +18,10 @@ export class QuantumShadowAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "quantum_shadow", name: "Quantum Shadow", maxHP: 360 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.phase = 'seeking'; // 'seeking' or 'superposition'
     this.lastPhaseChangeTime = Date.now();

--- a/modules/agents/ReflectorAI.js
+++ b/modules/agents/ReflectorAI.js
@@ -16,7 +16,7 @@ export class ReflectorAI extends BaseAgent {
     this.add(this.shieldMesh);
 
     this.name = "Reflector Warden";
-    this.id = "reflector";
+    this.kind = "reflector";
     this.phase = "idle";
     this.lastPhaseChange = Date.now();
     this.cycles = 0;

--- a/modules/agents/SentinelPairAI.js
+++ b/modules/agents/SentinelPairAI.js
@@ -17,7 +17,10 @@ export class SentinelPairAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
     
     const bossData = { id: "sentinel_pair", name: "Sentinel Pair", maxHP: 400 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
 
     this.partner = partner;
     if (this.partner) {

--- a/modules/agents/ShaperOfFateAI.js
+++ b/modules/agents/ShaperOfFateAI.js
@@ -16,7 +16,10 @@ export class ShaperOfFateAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "shaper_of_fate", name: "The Shaper of Fate", maxHP: 600 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.phase = 'idle'; // idle -> prophecy -> fulfillment
     this.phaseTimer = Date.now() + 3000;

--- a/modules/agents/SingularityAI.js
+++ b/modules/agents/SingularityAI.js
@@ -16,7 +16,10 @@ export class SingularityAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "singularity", name: "The Singularity", maxHP: 600 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.phase = 1;
     this.lastActionTime = 0;

--- a/modules/agents/SplitterAI.js
+++ b/modules/agents/SplitterAI.js
@@ -15,7 +15,7 @@ export class SplitterAI extends BaseAgent {
     const model = new THREE.Mesh(geometry, material)
     super({ health: 96, model });
     this.name = "Splitter Sentinel";
-    this.id = "splitter";
+    this.kind = "splitter";
   }
 
   die() {

--- a/modules/agents/SwarmLinkAI.js
+++ b/modules/agents/SwarmLinkAI.js
@@ -14,7 +14,10 @@ export class SwarmLinkAI extends BaseAgent {
     super({ model: new THREE.Mesh(headGeo, headMat) });
     
     const bossData = { id: "swarm", name: "Swarm Link", maxHP: 200 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
 
     this.tailSegments = [];
     this.tailGroup = new THREE.Group();

--- a/modules/agents/SyphonAI.js
+++ b/modules/agents/SyphonAI.js
@@ -14,7 +14,10 @@ export class SyphonAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "syphon", name: "The Syphon", maxHP: 450 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.isCharging = false;
     this.lastSyphonTime = 0;

--- a/modules/agents/TemporalParadoxAI.js
+++ b/modules/agents/TemporalParadoxAI.js
@@ -16,7 +16,10 @@ export class TemporalParadoxAI extends BaseAgent {
     super({ model });
 
     const bossData = { id: "temporal_paradox", name: "The Temporal Paradox", maxHP: 420 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
 
     this.playerHistory = [];
     this.lastEchoTime = 0;

--- a/modules/agents/TimeEaterAI.js
+++ b/modules/agents/TimeEaterAI.js
@@ -16,7 +16,10 @@ export class TimeEaterAI extends BaseAgent {
     super({ model: new THREE.Mesh(geometry, material) });
 
     const bossData = { id: "time_eater", name: "Time Eater", maxHP: 440 };
-    Object.assign(this, bossData);
+    this.kind = bossData.id;
+    this.name = bossData.name;
+    this.maxHP = bossData.maxHP;
+    this.health = this.maxHP;
     
     this.lastAbilityTime = 0;
   }

--- a/modules/agents/VampireAI.js
+++ b/modules/agents/VampireAI.js
@@ -10,7 +10,7 @@ export class VampireAI extends BaseAgent {
     super({ health: 144, model: new THREE.Mesh(geometry, material) });
     
     this.name = "Vampire Veil";
-    this.id = "vampire";
+    this.kind = "vampire";
     this.lastHitTime = Date.now();
     this.lastHealTime = Date.now();
   }

--- a/modules/bosses.js
+++ b/modules/bosses.js
@@ -416,7 +416,7 @@ export const bossData = [{
         b.r = 50;
         b.enraged = false;
         
-        const partner = state.enemies.find(e => e.id === 'aethel_and_umbra' && e !== b);
+        const partner = state.enemies.find(e => e.kind === 'aethel_and_umbra' && e !== b);
         
         if (!partner) {
             // This is the first twin, it defines both its own role and its partner's.
@@ -473,7 +473,7 @@ export const bossData = [{
         }
     },
     onDeath: (b, state) => {
-        const partner = state.enemies.find(e => e.id === 'aethel_and_umbra' && e !== b && e.hp > 0);
+        const partner = state.enemies.find(e => e.kind === 'aethel_and_umbra' && e !== b && e.hp > 0);
         if (partner && !partner.enraged) {
             partner.enraged = true;
             if (b.role === 'Aethel') { // Partner is Umbra, becomes faster
@@ -757,7 +757,7 @@ export const bossData = [{
     mechanics_desc: "Two bosses that share a single health pool and are connected by a constant, lethal energy beam. The beam will damage you on contact. The bosses will attempt to reposition themselves to keep the beam on you.",
     hasCustomMovement: true,
     init: (b, state, spawnEnemy) => {
-        if (!state.enemies.find(e => e.id === 'sentinel_pair' && e !== b)) {
+        if (!state.enemies.find(e => e.kind === 'sentinel_pair' && e !== b)) {
             const partner = spawnEnemy(true, 'sentinel_pair');
             if (partner) {
                 b.partner = partner;
@@ -939,7 +939,7 @@ export const bossData = [{
         
         if (Date.now() - (lastTime || 0) > 12000 && !b.isChargingBeam) {
             b.isChargingBeam = true;
-            if (b.id === 'pantheon') {
+            if (b.kind === 'pantheon') {
                 b.isChargingAnnihilatorBeam = true;
             }
 
@@ -947,7 +947,7 @@ export const bossData = [{
             setTimeout(() => {
                 if(b.hp <= 0) {
                     b.isChargingBeam = false;
-                    if (b.id === 'pantheon') {
+                    if (b.kind === 'pantheon') {
                         b.isChargingAnnihilatorBeam = false;
                     }
                     return;
@@ -966,7 +966,7 @@ export const bossData = [{
                 b.isChargingBeam = false;
 
                 setTimeout(() => {
-                    if (b.id === 'pantheon') {
+                    if (b.kind === 'pantheon') {
                         b.isChargingAnnihilatorBeam = false;
                     }
                 }, 1200); // Duration of the beam effect
@@ -1351,7 +1351,7 @@ export const bossData = [{
         ctx.globalAlpha = 1.0;
         if (!b.isGasActive && Date.now() - b.lastGasAttack > 10000) {
             b.isGasActive = true;
-            state.effects.push({ type: 'miasma_gas', endTime: Date.now() + 99999, id: b.id });
+            state.effects.push({ type: 'miasma_gas', endTime: Date.now() + 99999, id: b.kind });
             gameHelpers.play('miasmaGasRelease');
         }
         if (b.isGasActive && !b.isChargingSlam) {
@@ -1367,7 +1367,7 @@ export const bossData = [{
                     if (Date.now() > v.cooldownUntil && Math.hypot(b.x - v.x, b.y - v.y) < 120) {
                         v.cooldownUntil = Date.now() + 10000;
                         b.isGasActive = false;
-                        state.effects = state.effects.filter(e => e.type !== 'miasma_gas' || e.id !== b.id);
+                        state.effects = state.effects.filter(e => e.type !== 'miasma_gas' || e.kind !== b.kind);
                         b.lastGasAttack = Date.now();
                         gameHelpers.play('ventPurify');
                         utils.spawnParticles(state.particles, v.x, v.y, '#ffffff', 100, 6, 50, 5);
@@ -1379,7 +1379,7 @@ export const bossData = [{
         }
     },
     onDamage: (b, dmg) => { if (b.isGasActive) b.hp += dmg; },
-    onDeath: (b, state) => { state.effects = state.effects.filter(e => e.type !== 'miasma_gas' || e.id !== b.id); }
+    onDeath: (b, state) => { state.effects = state.effects.filter(e => e.type !== 'miasma_gas' || e.kind !== b.kind); }
 }, {
     id: "temporal_paradox",
     name: "The Temporal Paradox",
@@ -1536,7 +1536,7 @@ export const bossData = [{
         if (b.hp <= 0 || !state.fractalHorrorAi) return;
 
         const target = state.player;
-        let allFractals = state.enemies.filter(e => e.id === 'fractal_horror');
+        let allFractals = state.enemies.filter(e => e.kind === 'fractal_horror');
         const hpPercent = state.fractalHorrorSharedHp / b.maxHP;
         const expectedSplits = Math.floor((1 - hpPercent) / 0.02);
         
@@ -1561,7 +1561,7 @@ export const bossData = [{
             }
             biggestFractal.hp = 0;
             state.fractalHorrorSplits++;
-            allFractals = state.enemies.filter(e => e.id === 'fractal_horror');
+            allFractals = state.enemies.filter(e => e.kind === 'fractal_horror');
         }
 
         const myIndex = allFractals.indexOf(b);
@@ -1661,7 +1661,7 @@ export const bossData = [{
         }
     },
     onDeath: (b, state) => {
-        const remaining = state.enemies.filter(e => e.id === 'fractal_horror' && e !== b);
+        const remaining = state.enemies.filter(e => e.kind === 'fractal_horror' && e !== b);
         if (remaining.length === 0) {
             delete state.fractalHorrorSharedHp;
             delete state.fractalHorrorSplits;
@@ -1738,7 +1738,7 @@ export const bossData = [{
         
         if (b.invulnerable) {
             gameHelpers.playLooping('obeliskHum');
-            const livingConduits = state.enemies.filter(e => e.id === 'obelisk_conduit' && e.parentObelisk === b);
+            const livingConduits = state.enemies.filter(e => e.kind === 'obelisk_conduit' && e.parentObelisk === b);
             livingConduits.forEach(conduit => {
                 utils.drawLightning(ctx, topCenter.x, topCenter.y, conduit.x, conduit.y, conduit.color, 3);
             });
@@ -1849,7 +1849,7 @@ export const bossData = [{
     onDeath: (b, state, sE, sP, play) => {
         play('conduitShatter');
         if (b.parentObelisk) {
-            const remainingConduits = state.enemies.filter(e => e.id === 'obelisk_conduit' && e.hp > 0 && e.parentObelisk === b.parentObelisk);
+            const remainingConduits = state.enemies.filter(e => e.kind === 'obelisk_conduit' && e.hp > 0 && e.parentObelisk === b.parentObelisk);
             if (remainingConduits.length === 0) {
                 b.parentObelisk.invulnerable = false;
             }

--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -201,7 +201,7 @@ export function spawnEnemy(isBoss = false, bossId = null) {
         const minionMat = new THREE.MeshStandardMaterial({ color: 0xc0392b, emissive: 0xc0392b, emissiveIntensity: 0.3 });
         const minionModel = new THREE.Mesh(minionGeo, minionMat);
         enemy = new BaseAgent({ health: 20, model: minionModel });
-        enemy.id = 'minion';
+        enemy.kind = 'minion';
         enemy.speed = 2.0;
         enemy.isFriendly = false;
         enemy.update = function(delta) {

--- a/modules/powers.js
+++ b/modules/powers.js
@@ -151,7 +151,7 @@ export const powers = {
   }},
   freeze:{emoji:"🧊",desc:"Freeze enemies for 4s",apply:()=>{
       state.enemies.forEach(e=>{
-          if (e.id === 'fractal_horror' || e.isFriendly) return;
+          if (e.kind === 'fractal_horror' || e.isFriendly) return;
           if (e.frozen) return;
           e.frozen=true;
           e.wasFrozen = true;


### PR DESCRIPTION
## Summary
- avoid assigning to THREE.Object3D `id`
- track enemy type using new `kind` field
- update references in boss logic, powers and game loop

## Testing
- `npm test` *(fails: AethelAI is not a constructor, gameHelpers.play is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688c68e2f87083318cbb675b08e0c7d3