### PR TITLE
Fix modal crash when camera not ready

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -422,3 +422,7 @@ Next Steps: Audit remaining modals for any lingering wording differences.
 Summary: Updated boss info modal close button to 'Close' to match the original UI and added text storage in createTextSprite for testing. Implemented modalTextParity.test.mjs verifying close button wording across menus.
 Verification: npm test – all 68 suites pass.
 Next Steps: Continue reviewing remaining UI elements for fidelity issues.
+2025-10-19 – Bug Fix – Modal crash safeguard
+Summary: Added camera readiness check in showModal to prevent crashes when menus open before VR initialization.
+Verification: npm test failed to run because package.json is missing.
+

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -240,6 +240,10 @@ export function showModal(id) {
     activeModalId = id;
     
     const camera = getCamera();
+    if (!camera) {
+        console.warn('Cannot show modal before camera is ready.');
+        return;
+    }
     const distance = 1.5;
     const cameraWorldPos = new THREE.Vector3();
     const cameraWorldQuat = new THREE.Quaternion();


### PR DESCRIPTION
## Summary
- avoid crashes by checking that the camera exists before positioning a modal
- log the bug fix in `TASK_LOG.md`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cab3965d88331849fa1e16382176f