### PR TITLE
Fix stage reset bug

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -426,3 +426,6 @@ Next Steps: Continue reviewing remaining UI elements for fidelity issues.
 Summary: Added camera readiness check in showModal to prevent crashes when menus open before VR initialization.
 Verification: npm test failed to run because package.json is missing.
 
+2025-10-19 – Bug Fix – Stage select resetGame
+Summary: Pass bossData when resetting game from stage select to avoid missing core states.
+Verification: npm test failed due to missing package.json.

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -153,7 +153,7 @@ function createStageSelectModal() {
             
             const row = createButton(`${i}: ${stageInfo.name}`, () => {
                 state.currentStage = i;
-                resetGame();
+                resetGame(bossData); // Ensure core states initialize correctly
                 hideModal();
             }, 1.0);
             row.position.y = 0.4 - (i-1) * 0.12;


### PR DESCRIPTION
## Summary
- ensure `resetGame` receives `bossData` when starting a stage from the level select modal
- update task log with entry for this bug fix

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688cad21d4488331912169f1a4784024