### PR TITLE
Fix missing state flags and minor bugs

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -429,3 +429,6 @@ Verification: npm test failed to run because package.json is missing.
 2025-10-19 – Bug Fix – Stage select resetGame
 Summary: Pass bossData when resetting game from stage select to avoid missing core states.
 Verification: npm test failed due to missing package.json.
+2025-10-20 – Bug Fix – Restore missing global flags
+Summary: Reintroduced several global state flags (stacked, arenaMode, gravityActive, gravityEnd, customOrreryBosses) lost during the VR refactor. Updated resetGame to reset these fields. Fixed projectile property defaults, safeguarded pickup lookAt, and documented in this log.
+Verification: Manual code review; npm test unavailable due to missing package.json.

--- a/modules/ProjectileManager.js
+++ b/modules/ProjectileManager.js
@@ -11,8 +11,8 @@ export function spawnProjectile(props = {}) {
   p.velocity = (props.velocity instanceof THREE.Vector3)
     ? props.velocity.clone()
     : new THREE.Vector3(props.dx || 0, props.dy || 0, props.dz || 0);
-  p.r = props.r || p.r || 0;
-  p.damage = props.damage || p.damage || 0;
+  p.r = props.r ?? p.r ?? 0;
+  p.damage = props.damage ?? p.damage ?? 0;
   p.alive = true;
   active.push(p);
   return p;

--- a/modules/pickupPhysics3d.js
+++ b/modules/pickupPhysics3d.js
@@ -64,7 +64,8 @@ export function updatePickups3d(radius = ARENA_RADIUS){
         }
         data.group.position.copy(p.position);
         data.group.rotation.y += 0.03;
-        data.sprite.lookAt(getCamera().position);
+        const cam = getCamera();
+        if (cam) data.sprite.lookAt(cam.position);
         if(dist < state.player.r + p.r){
             gameHelpers.play('pickupSound');
             if(p.type === 'rune_of_fate'){

--- a/modules/state.js
+++ b/modules/state.js
@@ -54,7 +54,15 @@ export const state = {
     pickups: [],
     effects: [],
     decoys: [],
+    particles: [],
     pathObstacles: [],
+
+    // Arena run flags
+    stacked: false,
+    arenaMode: false,
+    gravityActive: false,
+    gravityEnd: 0,
+    customOrreryBosses: [],
     
     // Game flow state
     currentStage: 1,
@@ -122,9 +130,15 @@ export function resetGame(bossData) { // Now accepts bossData to avoid circular 
         pickups: [],
         effects: [],
         decoys: [],
+        particles: [],
         pathObstacles: [],
         offensiveInventory: [null, null, null],
         defensiveInventory: [null, null, null],
+        stacked: false,
+        arenaMode: false,
+        gravityActive: false,
+        gravityEnd: 0,
+        customOrreryBosses: [],
         bossActive: false,
         gameOver: false,
         bossHasSpawnedThisRun: false,


### PR DESCRIPTION
## Summary
- restore lost global flags in `state.js`
- reset new fields in `resetGame`
- handle zero values when spawning projectiles
- avoid crash if camera missing when orienting pickup text
- document fixes in task log

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cae9ba88083319e60e2c8acd8e385