### PR TITLE
Ensure old assets referenced

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,10 +14,13 @@ const homeScreen = document.getElementById('homeScreen');
 const ASSET_MANIFEST = [
     'assets/bg.png', 'assets/cursors/crosshair.cur', 'assets/load.png',
     'assets/home.mp4',
-    'assets/bgMusic_01.mp3', 'assets/bossSpawnSound.mp3', 'assets/hitSound.mp3',
-    'assets/pickupSound.mp3', 'assets/uiClickSound.mp3', 'assets/uiHoverSound.mp3',
-    'assets/shieldBreak.mp3', 'assets/shockwaveSound.mp3', 'assets/talentPurchase.mp3',
-    'assets/talentError.mp3', 'assets/bossDefeatSound.mp3', 'assets/systemErrorSound.mp3'
+    'assets/bgMusic_01.mp3', 'assets/bgMusic_02.mp3', 'assets/bgMusic_03.mp3', 'assets/bgMusic_04.mp3',
+    'assets/bgMusic_05.mp3', 'assets/bgMusic_06.mp3', 'assets/bgMusic_07.mp3',
+    'assets/bgMusic_08.mp3', 'assets/bgMusic_09.mp3', 'assets/bgMusic_10.mp3',
+    'assets/bossSpawnSound.mp3', 'assets/hitSound.mp3', 'assets/pickupSound.mp3',
+    'assets/uiClickSound.mp3', 'assets/uiHoverSound.mp3', 'assets/shieldBreak.mp3',
+    'assets/shockwaveSound.mp3', 'assets/talentPurchase.mp3', 'assets/talentError.mp3',
+    'assets/bossDefeatSound.mp3', 'assets/systemErrorSound.mp3'
 ];
 
 async function preloadAssets() {

--- a/docs/asset_analysis.md
+++ b/docs/asset_analysis.md
@@ -1,0 +1,7 @@
+# Asset Analysis
+
+This document compares the assets referenced by the original 2D game with the assets present in the VR port. It also lists assets that currently have no in-game references.
+
+The script `scripts/checkAssetUsage.js` extracts all asset names from `Eternal-Momentum-OLD GAME/index.html` and scans the VR source for matching references. Running the script will report any assets that exist in the old game but are unused in the VR code.
+
+At the time of writing, every old asset except `aspectDefeated` and `shaperFail` is referenced somewhere in the VR project. These two sounds were present in the original game's HTML but were never referenced in its code and remain unused in the VR port.

--- a/modules/audio.js
+++ b/modules/audio.js
@@ -11,7 +11,10 @@ export const AudioManager = {
   musicGain: null,
   soundBuffers: {},
   loopingSounds: {},
-  musicPlaylist: ['bgMusic_01', 'bgMusic_02', 'bgMusic_03', 'bgMusic_04', 'bgMusic_05'],
+  musicPlaylist: [
+    'bgMusic_01', 'bgMusic_02', 'bgMusic_03', 'bgMusic_04', 'bgMusic_05',
+    'bgMusic_06', 'bgMusic_07', 'bgMusic_08', 'bgMusic_09', 'bgMusic_10'
+  ],
   currentTrackIndex: -1,
   currentMusic: null,
   soundBtn: null,
@@ -128,8 +131,11 @@ export const AudioManager = {
 
   playMusic() {
     if (this.musicPlaylist.length === 0 || this.currentMusic) return;
-    this.currentTrackIndex = 0;
-    this._playMusicTrack(this.musicPlaylist[0]);
+    if (this.currentTrackIndex === -1) {
+      this.musicPlaylist.sort(() => Math.random() - 0.5);
+      this.currentTrackIndex = 0;
+    }
+    this._playMusicTrack(this.musicPlaylist[this.currentTrackIndex]);
   },
 
   setMusicVolume(v) {

--- a/scripts/checkAssetUsage.js
+++ b/scripts/checkAssetUsage.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+
+const indexHtml = fs.readFileSync('Eternal-Momentum-OLD GAME/index.html','utf8');
+const oldAssets = Array.from(indexHtml.matchAll(/assets\/([A-Za-z0-9_\-]+)\.[a-z0-9]+/g)).map(m => m[1]);
+const assetNames = [...new Set(oldAssets)];
+
+function searchDir(dir, fileFilter) {
+  let results = [];
+  const files = fs.readdirSync(dir);
+  for (const file of files) {
+    const p = path.join(dir, file);
+    if (fs.statSync(p).isDirectory()) {
+      if (file === 'Eternal-Momentum-OLD GAME' || file === '.git' || file === 'node_modules') continue;
+      results = results.concat(searchDir(p, fileFilter));
+    } else if (fileFilter(p)) {
+      results.push(p);
+    }
+  }
+  return results;
+}
+
+const sourceFiles = searchDir('.', p => p.endsWith('.js') || p.endsWith('.html') || p.endsWith('.css'));
+
+let missing = [];
+for (const name of assetNames) {
+  const regex = new RegExp(name.replace(/[.*+?^${}()|[\]\\]/g,'\\$&'));
+  let found = false;
+  for (const file of sourceFiles) {
+    const content = fs.readFileSync(file,'utf8');
+    if (regex.test(content)) { found = true; break; }
+  }
+  if (!found) missing.push(name);
+}
+
+if (missing.length) {
+  console.log('Missing assets:', missing.join(', '));
+  process.exit(1);
+} else {
+  console.log('All old assets referenced in code.');
+}


### PR DESCRIPTION
## Summary
- expand background music playlist to include all tracks
- randomize playlist when starting music
- preload all music tracks in asset manifest
- add asset verification script
- document asset usage status

## Testing
- `node scripts/checkAssetUsage.js`

------
https://chatgpt.com/codex/tasks/task_e_688cbe7d6e1c833195e7d179d8d7e378