### PR TITLE
Restore Basilisk freeze synergies

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -439,3 +439,7 @@ Verification: npm test fails due to missing package.json.
 2025-10-21 – FR-03 – Asset parity
 Summary: Verified that all sound effects used in the 2D game are present in the VR port. The old but unused `aspectDefeated` and `shaperFail` sounds remain unreferenced. Applied `bg.png` as the common texture for all modal and button backgrounds and updated the asset analysis.
 Verification: `node scripts/checkAssetUsage.js` (with ignore list) reports all required assets referenced.
+
+2025-10-22 – FR-05 – Basilisk synergy restoration
+Summary: Restored Cryo‑Shatter and Glacial Propagation mechanics. `BaseAgent.takeDamage` now boosts damage by 20% while petrified. Added shockwave and optional freeze burst when frozen enemies die.
+Verification: Manual code review; npm test unavailable due to missing package.json.

--- a/modules/BaseAgent.js
+++ b/modules/BaseAgent.js
@@ -20,6 +20,9 @@ export class BaseAgent extends THREE.Group {
   takeDamage(amount = 0, fromPlayer = false, gameHelpers = null) {
     if (!this.alive) return;
     if (!gameHelpers) gameHelpers = {};
+    if (this.petrifiedUntil && this.petrifiedUntil > Date.now()) {
+      amount *= 1.2;
+    }
     this.health -= amount;
     if (fromPlayer) {
       CoreManager.onDamageDealt(this, gameHelpers);

--- a/modules/cores.js
+++ b/modules/cores.js
@@ -205,6 +205,33 @@ export function handleCoreOnEnemyDeath(enemy) {
             gameHelpers.play('splitterOnDeath');
         }
     }
+
+    const cryoRank = state.player.purchasedTalents.get('cryo-shatter');
+    if (cryoRank && enemy.wasFrozen) {
+        const chance = cryoRank === 1 ? 0.25 : 0.5;
+        if (Math.random() < chance) {
+            state.effects.push({
+                type: 'shockwave',
+                caster: state.player,
+                position: enemy.position.clone(),
+                maxRadius: 15,
+                speed: 50,
+                startTime: now,
+                hitEnemies: new Set(),
+                damage: 5 * state.player.talent_modifiers.damage_multiplier,
+                color: new THREE.Color(0x00c8ff)
+            });
+
+            if (state.player.purchasedTalents.has('glacial-propagation')) {
+                state.effects.push({
+                    type: 'small_freeze',
+                    position: enemy.position.clone(),
+                    radius: 15,
+                    endTime: now + 200
+                });
+            }
+        }
+    }
     if (playerHasCore('swarm')) {
         const swarmState = state.player.talent_states.core_states.swarm;
         if (!swarmState.tail) swarmState.tail = [];


### PR DESCRIPTION
## Summary
- add petrify damage bonus in `BaseAgent.takeDamage`
- implement Cryo-Shatter and Glacial Propagation logic when frozen enemies die
- document the work in `TASK_LOG.md`

## Testing
- `node scripts/checkAssetUsage.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cc9c76578833181fbd776d40dd638