### PR TITLE
Enhance VR talent UI with connectors and info

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -130,9 +130,11 @@ export function updatePlayerController() {
         targetPoint.copy(uiHit.point);
         laser.scale.z = uiHit.distance;
         crosshair.visible = false;
-        
+
         if (hoveredUi !== uiHit.object) {
+            if (hoveredUi && hoveredUi.userData.onHover) hoveredUi.userData.onHover(false);
             hoveredUi = uiHit.object;
+            if (hoveredUi.userData.onHover) hoveredUi.userData.onHover(true);
             gameHelpers.play('uiHoverSound');
         }
         if (triggerJustPressed) {
@@ -140,6 +142,7 @@ export function updatePlayerController() {
             gameHelpers.play('uiClickSound');
         }
     } else {
+        if (hoveredUi && hoveredUi.userData.onHover) hoveredUi.userData.onHover(false);
         hoveredUi = null;
         const arenaHit = raycaster.intersectObject(arena, false)[0];
         if (arenaHit) {


### PR DESCRIPTION
## Summary
- add hover callbacks to PlayerController so UI elements can respond when focused
- expand Ascension Conduit modal with AP display, info panel, and talent connectors

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cce2c8d6c83318da3dfc492ecedcb