### PR TITLE
Implement Phase Momentum talent

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -166,7 +166,8 @@ export function updatePlayerController() {
     gripJustPressed = false;
 
     if (state.player.stunnedUntil < Date.now()) {
-        moveTowards(avatar.position, targetPoint, state.player.speed, radius);
+        const speedMult = state.player.talent_states.phaseMomentum.active ? 1.1 : 1.0;
+        moveTowards(avatar.position, targetPoint, state.player.speed * speedMult, radius);
         state.player.position.copy(avatar.position);
     }
     

--- a/modules/ascension.js
+++ b/modules/ascension.js
@@ -106,6 +106,12 @@ export function applyAllTalentEffects() {
         }
     });
 
+    // Reset dynamic talent states
+    state.player.talent_states.phaseMomentum.active = false;
+    if (state.player.purchasedTalents.has('phase-momentum')) {
+        state.player.talent_states.phaseMomentum.lastDamageTime = Date.now();
+    }
+
     // After applying all maxHealth modifiers, ensure current health isn't higher.
     state.player.health = Math.min(state.player.health, state.player.maxHealth);
 }

--- a/modules/cores.js
+++ b/modules/cores.js
@@ -267,6 +267,14 @@ export function handleCoreOnPlayerDamage(damage) {
             gameHelpers.play('mirrorSwap');
         }
     }
+
+    // Reset Phase Momentum on any damage taken
+    if (damageTaken > 0) {
+        const pmState = state.player.talent_states.phaseMomentum;
+        pmState.lastDamageTime = Date.now();
+        pmState.active = false;
+    }
+
     return damageTaken;
 }
 

--- a/modules/vrGameLoop.js
+++ b/modules/vrGameLoop.js
@@ -8,6 +8,19 @@ import { AudioManager } from './audio.js';
 import { showUnlockNotification } from './UIManager.js';
 import { gameHelpers } from './gameHelpers.js';
 
+function updatePhaseMomentum() {
+    const rank = state.player.purchasedTalents.get('phase-momentum');
+    const pmState = state.player.talent_states.phaseMomentum;
+    if (!rank) {
+        pmState.active = false;
+        return;
+    }
+    const now = Date.now();
+    if (now - pmState.lastDamageTime > 8000) {
+        pmState.active = true;
+    }
+}
+
 let lastSpawnTime = 0;
 let lastPowerUpTime = 0;
 
@@ -67,6 +80,8 @@ export function vrGameLoop() {
 
     handleLevelProgression();
     handleEnemyAndPowerSpawning();
+
+    updatePhaseMomentum();
 
     updateEnemies3d();
     updateProjectiles3d();


### PR DESCRIPTION
## Summary
- implement Phase Momentum passive logic
- reset phase momentum state on damage
- include speed boost when active
- refresh dynamic talent state after applying talents

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cd6510d148331965a7176ea72cb2a