### PR TITLE
Restore ascension talent effects

### DIFF
--- a/modules/agents/AnnihilatorAI.js
+++ b/modules/agents/AnnihilatorAI.js
@@ -3,6 +3,7 @@ import { BaseAgent } from '../BaseAgent.js';
 import { state } from '../state.js';
 import { gameHelpers } from '../gameHelpers.js';
 import * as CoreManager from '../CoreManager.js';
+import { applyPlayerDamage } from '../helpers.js';
 
 const ARENA_RADIUS = 50;
 
@@ -77,8 +78,7 @@ export class AnnihilatorAI extends BaseAgent {
 
         if (!this.isPlayerInShadow()) {
             const damage = 1000; // Lethal damage
-            state.player.health -= damage;
-            CoreManager.onPlayerDamage(damage, this, gameHelpers);
+            applyPlayerDamage(damage, this, gameHelpers);
         }
 
         this.isChargingBeam = false;

--- a/modules/agents/ReflectorAI.js
+++ b/modules/agents/ReflectorAI.js
@@ -3,6 +3,7 @@ import { BaseAgent } from '../BaseAgent.js';
 import { state } from '../state.js';
 import { gameHelpers } from '../gameHelpers.js';
 import * as CoreManager from '../CoreManager.js';
+import { applyPlayerDamage } from '../helpers.js';
 
 export class ReflectorAI extends BaseAgent {
   constructor() {
@@ -52,8 +53,11 @@ export class ReflectorAI extends BaseAgent {
       gameHelpers.play('reflectorOnHit');
       if (sourceObject && typeof sourceObject.health === 'number') {
         const reflectedDamage = 10;
-        sourceObject.health -= reflectedDamage;
-        CoreManager.onPlayerDamage(reflectedDamage, this, gameHelpers);
+        if (sourceObject === state.player) {
+          applyPlayerDamage(reflectedDamage, this, gameHelpers);
+        } else {
+          sourceObject.health -= reflectedDamage;
+        }
       }
     } else {
         super.takeDamage(amount, true);

--- a/modules/agents/SentinelPairAI.js
+++ b/modules/agents/SentinelPairAI.js
@@ -3,6 +3,7 @@ import { BaseAgent } from '../BaseAgent.js';
 import { state } from '../state.js';
 import { gameHelpers } from '../gameHelpers.js';
 import * as CoreManager from '../CoreManager.js';
+import { applyPlayerDamage } from '../helpers.js';
 
 const ARENA_RADIUS = 50;
 
@@ -60,11 +61,8 @@ export class SentinelPairAI extends BaseAgent {
     // Damage player if they intersect the beam
     const playerLineDist = new THREE.Line3(this.position, this.partner.position).closestPointToPoint(playerPos, true, new THREE.Vector3()).distanceTo(playerPos);
     if(playerLineDist < state.player.r + 0.2) {
-        if (!state.player.shield) {
-            const damage = 1;
-            state.player.health -= damage;
-            CoreManager.onPlayerDamage(damage, this, gameHelpers);
-        }
+        const damage = 1;
+        applyPlayerDamage(damage, this, gameHelpers);
     }
   }
 

--- a/modules/agents/SwarmLinkAI.js
+++ b/modules/agents/SwarmLinkAI.js
@@ -2,6 +2,7 @@ import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { state } from '../state.js';
 import * as CoreManager from '../CoreManager.js';
+import { applyPlayerDamage } from '../helpers.js';
 
 export class SwarmLinkAI extends BaseAgent {
   constructor() {
@@ -50,11 +51,8 @@ export class SwarmLinkAI extends BaseAgent {
       const playerPos = state.player.position;
       const distance = playerPos.distanceTo(seg.position);
       if (distance < state.player.r + 0.4) { // 0.4 is segment radius
-        if (!state.player.shield) {
-            const damage = 0.5; // Damage per frame
-            state.player.health -= damage;
-            CoreManager.onPlayerDamage(damage, this, gameHelpers);
-        }
+        const damage = 0.5; // Damage per frame
+        applyPlayerDamage(damage, this, gameHelpers);
       }
     });
   }

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -1,6 +1,7 @@
 import { state } from './state.js';
 import { toCanvasPos } from './utils.js';
 import * as THREE from '../vendor/three.module.js';
+import * as CoreManager from './CoreManager.js';
 
 /**
  * Check if the player currently has the given core equipped or granted
@@ -24,4 +25,53 @@ export function getCanvasPos(obj){
     return toCanvasPos(obj.position);
   }
   return { x: obj.x, y: obj.y };
+}
+
+/**
+ * Apply damage to the player while accounting for talent and core effects.
+ * This centralizes collision damage logic so talents like Phase Momentum,
+ * Reactive Plating and Contingency Protocol behave identically to the
+ * original game.
+ *
+ * @param {number} amount - Base damage to apply.
+ * @param {Object} [source] - The enemy or object dealing damage.
+ * @param {Object} [gameHelpers] - Optional helper functions for SFX/UI.
+ * @returns {number} The final damage applied after modifiers.
+ */
+export function applyPlayerDamage(amount, source = null, gameHelpers = {}) {
+  let damage = amount;
+
+  // Phase Momentum negates contact damage from non-boss enemies
+  const pmState = state.player.talent_states.phaseMomentum;
+  if (pmState.active && (!source || !source.boss)) {
+    pmState.lastDamageTime = Date.now();
+    pmState.active = false;
+    return 0;
+  }
+
+  // Allow cores and talents to react to the hit
+  if (damage > 0) {
+    damage = CoreManager.onPlayerDamage(damage, source, gameHelpers);
+    damage *= state.player.talent_modifiers.damage_taken_multiplier;
+  }
+
+  if (damage <= 0) return 0;
+
+  if (state.player.shield) {
+    state.player.shield = false;
+    CoreManager.onShieldBreak();
+    return 0;
+  }
+
+  const newHealth = state.player.health - damage;
+  if (newHealth <= 0) {
+    if (!CoreManager.onFatalDamage(source, gameHelpers)) {
+      state.player.health = 0;
+      state.gameOver = true;
+    }
+  } else {
+    state.player.health = newHealth;
+  }
+
+  return damage;
 }

--- a/modules/vrGameLoop.js
+++ b/modules/vrGameLoop.js
@@ -49,7 +49,8 @@ function handleEnemyAndPowerSpawning() {
         lastSpawnTime = now;
     }
 
-    if (now - lastPowerUpTime > 6000) {
+    const spawnInterval = 6000 / state.player.talent_modifiers.power_spawn_rate_modifier;
+    if (now - lastPowerUpTime > spawnInterval) {
         spawnPickup();
         lastPowerUpTime = now;
     }


### PR DESCRIPTION
## Summary
- centralize how damage to the player is applied
- use `applyPlayerDamage` in AI modules so talents like Phase Momentum, Reactive Plating and Contingency Protocol work
- scale pickup spawn timing with `resonant-frequencies`

## Testing
- `node --check modules/helpers.js`
- `node --check modules/agents/SentinelPairAI.js`
- `node --check modules/agents/SwarmLinkAI.js`
- `node --check modules/agents/AnnihilatorAI.js`
- `node --check modules/agents/ReflectorAI.js`
- `node --check modules/vrGameLoop.js`

------
https://chatgpt.com/codex/tasks/task_e_688cef3ea1788331b5b41437142be1d3