### PR TITLE
Fix menu crash before scene init

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -20,7 +20,8 @@ function ensureGroup() {
     if (!modalGroup) {
         modalGroup = new THREE.Group();
         modalGroup.name = 'modalGroup';
-        getScene().add(modalGroup);
+        const scene = getScene();
+        if (scene) scene.add(modalGroup);
     }
 }
 


### PR DESCRIPTION
## Summary
- check for a valid scene before adding the modal group

## Testing
- `node - <<'EOF'
require('jsdom-global')();
const ModalManager = require('./modules/ModalManager.js');
ModalManager.initModals();
ModalManager.showModal('home');
console.log('done');
EOF` *(fails: HTMLCanvasElement.getContext not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_688cf1eb1b688331abd1849add1f0ca1