### PR TITLE
Synchronize VR menu style with classic game

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,9 @@
   </div>
 
   <div id="homeScreen" style="display: none;">
-    <video autoplay muted loop playsinline id="homeVideoBg"></video>
+    <video autoplay muted loop playsinline id="homeVideoBg">
+      <source src="./assets/home.mp4" type="video/mp4" />
+    </video>
     <div id="home-overlay">
       <h1 id="game-title">ETERNAL MOMENTUM</h1>
       <div id="home-actions">

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -42,7 +42,7 @@ function createButton(label, onSelect, width = 0.5, height = 0.1) {
 
 function createModalContainer(width, height, title) {
     const group = new THREE.Group();
-    const bg = new THREE.Mesh(new THREE.PlaneGeometry(width, height), holoMaterial(0x141428, 0.95));
+    const bg = new THREE.Mesh(new THREE.PlaneGeometry(width, height), holoMaterial(0x1e1e2f, 0.95));
     const tex = getBgTexture();
     if (tex) { bg.material.map = tex; bg.material.needsUpdate = true; }
     const border = new THREE.Mesh(new THREE.PlaneGeometry(width + 0.02, height + 0.02), holoMaterial(0x00ffff, 0.5));

--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -26,7 +26,7 @@ export function getBgTexture() {
   return bgTexture;
 }
 
-export function holoMaterial(color = 0x141428, opacity = 0.85) {
+export function holoMaterial(color = 0x1e1e2f, opacity = 0.85) {
   return new THREE.MeshStandardMaterial({
     color,
     emissive: color,

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,17 @@
 :root {
   --primary-glow: #00ffff;
-  --dark-bg: #111;
-  --font-color: #eaf2ff;
-  --border-color: rgba(0, 255, 255, 0.4);
-  --health-low: #e74c3c;
+  --secondary-glow: #f000ff;
+  --dark-bg: #1e1e2f;
   --ui-bg: rgba(20, 20, 40, 0.85);
+  --border-color: rgba(0, 255, 255, 0.4);
+  --font-color: #eaf2ff;
+  --health-high: #3498db;
+  --health-medium: #f1c40f;
+  --health-low: #e74c3c;
+  --health-bar-bg: #444;
+  --disabled-color: rgba(255, 255, 255, 0.2);
+  --shield-color: rgba(241, 196, 15, 0.7);
+  --nexus-glow: #00ff00;
 }
 
 html, body { 


### PR DESCRIPTION
## Summary
- port old game's theme variables to VR `styles.css`
- use same video background source as the original game
- update default menu material color
- update modal background color

## Testing
- `node scripts/checkAssetUsage.js`

------
https://chatgpt.com/codex/tasks/task_e_688cf468299c8331a7ba00f05ce3936a