### PR TITLE
Add VR game over modal

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -273,6 +273,7 @@ const createModalFunctions = {
     "lore": createLoreModal,
     "bossInfo": createBossInfoModal,
     "orrery": createOrreryModal,
+    "gameOver": createGameOverModal,
 };
 
 export function initModals() {
@@ -486,6 +487,32 @@ function createBossInfoModal() {
     modal.add(closeBtn);
     modal.userData.contentSprite = content;
     modal.userData.titleSprite = modal.children.find(c => c.userData.isTitle);
+    return modal;
+}
+
+function createGameOverModal() {
+    const modal = createModalContainer(1.2, 1.0, 'TIMELINE COLLAPSED');
+    modal.name = 'modal_gameOver';
+
+    const restartBtn = createButton('Restart Stage', () => {
+        resetGame(bossData);
+        hideModal();
+    }, 0.8, 0.1, 0x00ffff);
+    restartBtn.position.set(0, 0.2, 0.01);
+    modal.add(restartBtn);
+
+    const ascBtn = createButton('Ascension Conduit', () => { hideModal(); showModal('ascension'); }, 0.8, 0.1, 0xff8800);
+    ascBtn.position.set(0, 0.05, 0.01);
+    modal.add(ascBtn);
+
+    const coreBtn = createButton('Aberration Cores', () => { hideModal(); showModal('cores'); }, 0.8, 0.1, 0x00ff00);
+    coreBtn.position.set(0, -0.1, 0.01);
+    modal.add(coreBtn);
+
+    const stageBtn = createButton('Stage Select', () => { hideModal(); showModal('levelSelect'); }, 0.8, 0.1, 0x9b59b6);
+    stageBtn.position.set(0, -0.25, 0.01);
+    modal.add(stageBtn);
+
     return modal;
 }
 

--- a/vrMain.js
+++ b/vrMain.js
@@ -3,7 +3,7 @@ import { VRButton } from './vendor/addons/webxr/VRButton.js';
 import { initScene, getScene, getRenderer, getCamera } from './modules/scene.js';
 import { initPlayerController, updatePlayerController } from './modules/PlayerController.js';
 import { initUI, updateHud, showHud } from './modules/UIManager.js';
-import { initModals } from './modules/ModalManager.js';
+import { initModals, showModal } from './modules/ModalManager.js';
 import { vrGameLoop } from './modules/vrGameLoop.js';
 import { Telemetry } from './modules/telemetry.js';
 import { state, resetGame } from './modules/state.js';
@@ -18,11 +18,15 @@ function render(timestamp, frame) {
 
     Telemetry.recordFrame();
     updatePlayerController();
-    
+
     if (!state.isPaused) {
         vrGameLoop();
     }
-    
+
+    if (state.gameOver && !state.isPaused) {
+        showModal('gameOver');
+    }
+
     updateHud();
     renderer.render(getScene(), getCamera());
 }


### PR DESCRIPTION
## Summary
- add game over modal to ModalManager with restart and menu buttons
- expose gameOver modal in modal creation map
- display game over modal when player dies

## Testing
- `node -c modules/ModalManager.js`
- `node -c vrMain.js`

------
https://chatgpt.com/codex/tasks/task_e_688d14765adc833181905381c7dc54de