### PR TITLE
Fix menu crash by pausing before refresh

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -316,13 +316,19 @@ export function showModal(id) {
     
     modalGroup.position.copy(cameraWorldPos).add(offset);
     modalGroup.quaternion.copy(cameraWorldQuat);
-    
-    modal.visible = true;
+
+    // Pause the game before heavy UI creation to avoid race conditions
     state.isPaused = true;
+    modal.visible = true;
     AudioManager.playSfx('uiModalOpen');
 
     if (modal.userData.refresh) {
-        modal.userData.refresh();
+        // Defer refresh to the next frame so the paused state takes effect
+        requestAnimationFrame(() => {
+            if (activeModalId === id) {
+                modal.userData.refresh();
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- pause the game before showing modals
- defer heavy modal `refresh()` work to the next frame

## Testing
- `node scripts/checkAssetUsage.js`

------
https://chatgpt.com/codex/tasks/task_e_688d1628e2008331a971b7f767d9cfc9