### PR TITLE
Fix enemy pathing when game starts

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -73,9 +73,10 @@ export async function initPlayerController() {
         new THREE.MeshStandardMaterial({ color: 0x3498db, emissive: 0x3498db })
     );
     avatar.name = 'playerAvatar';
-    avatar.position.set(0, 0, 0); 
-    state.player.position.copy(avatar.position);
-    targetPoint.copy(avatar.position);
+    const startPos = new THREE.Vector3(0, 0, radius);
+    avatar.position.copy(startPos);
+    state.player.position.copy(startPos);
+    targetPoint.copy(startPos);
     scene.add(avatar);
 
     const chTex = await assetManager.loadTexture("assets/cursors/crosshair.cur");


### PR DESCRIPTION
## Summary
- spawn the player avatar on the arena wall instead of at the origin

This prevents enemies from pathing toward the north pole when the game starts.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d254ec0b483318c589ca50f701977