### PR TITLE
Fix power-up pickup visibility and inventory

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -446,3 +446,7 @@ Verification: Manual code review; npm test unavailable due to missing package.js
 2025-10-23 – UI Update – Modal style improvements
 Summary: Added multiline text support and updated modal button colors to match the original game. Updated Stage Select info icons.
 Verification: node scripts/checkAssetUsage.js
+
+2025-10-24 – Bug Fix – Power-up inventory
+Summary: Fixed pickup handling to update the HUD immediately and scaled emoji sprites to nearly fill the pickup sphere for better visibility.
+Verification: node scripts/checkAssetUsage.js

--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -3,7 +3,7 @@ import { state, savePlayerState } from './state.js';
 import { LEVELING_CONFIG, THEMATIC_UNLOCKS, SPAWN_WEIGHTS, STAGE_CONFIG } from './config.js';
 import { powers } from './powers.js';
 import { bossData } from './bosses.js';
-import { showUnlockNotification, showBossBanner } from './UIManager.js';
+import { showUnlockNotification, showBossBanner, updateHud } from './UIManager.js';
 import { AudioManager } from './audio.js';
 import { initGameHelpers } from './gameHelpers.js';
 import { getScene } from './scene.js';
@@ -65,6 +65,7 @@ const gameHelpers = {
     playLooping: (id, obj) => AudioManager.playLoopingSfx(id, obj),
     stopLoopingSfx: (id) => AudioManager.stopLoopingSfx(id),
     addEssence,
+    updateHud,
 };
 initGameHelpers(gameHelpers);
 

--- a/modules/pickupPhysics3d.js
+++ b/modules/pickupPhysics3d.js
@@ -20,7 +20,8 @@ function createMesh(pickup){
         opacity: 0.4
     });
     const sphere = new THREE.Mesh(new THREE.SphereGeometry(pickup.r, 16, 16), material);
-    const sprite = createTextSprite(pickup.emoji || powers[pickup.type]?.emoji || '?', 48);
+    const spriteSize = pickup.r * 2000;
+    const sprite = createTextSprite(pickup.emoji || powers[pickup.type]?.emoji || '?', spriteSize);
     sprite.position.set(0, 0, pickup.r + 0.05);
     group.add(sphere, sprite);
     const scene = getScene();
@@ -90,6 +91,7 @@ export function updatePickups3d(radius = ARENA_RADIUS){
                 const idx = inv.indexOf(null);
                 if(idx !== -1 && idx < maxSlots){
                     inv[idx] = p.type;
+                    if(gameHelpers.updateHud) gameHelpers.updateHud();
                 }else if(state.player.purchasedTalents.has('overload-protocol')){
                     gameHelpers.addStatusEffect('Auto-Used', powers[p.type]?.emoji || '?', 2000);
                     usePower(p.type, true);


### PR DESCRIPTION
## Summary
- enlarge pickup emoji sprites so they're visible from afar
- update HUD immediately when pickups fill an inventory slot
- expose `updateHud` via `gameHelpers`
- document changes in `TASK_LOG.md`

## Testing
- `node scripts/checkAssetUsage.js`

------
https://chatgpt.com/codex/tasks/task_e_688d2776e9bc8331abb988f245f8d1ce