### PR TITLE
Add pointer boss health UI

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -1,5 +1,6 @@
 import * as THREE from '../vendor/three.module.js';
 import { getScene, getArena, getPrimaryController, getCamera } from './scene.js';
+import { attachBossUI } from './UIManager.js';
 import { moveTowards } from './movement3d.js';
 import { state } from './state.js';
 import { useOffensivePower, useDefensivePower } from './PowerManager.js';
@@ -58,6 +59,7 @@ export function refreshPrimaryController() {
         primaryController.addEventListener('selectend', onSelectEnd);
         primaryController.addEventListener('squeezestart', onSqueezeStart);
         primaryController.addEventListener('squeezeend', onSqueezeEnd);
+        attachBossUI();
     }
 }
 


### PR DESCRIPTION
## Summary
- recreate boss health bar from old game and attach to VR pointer
- update UIManager to manage boss bars
- reattach boss bar whenever the primary controller changes

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d2cd4eea8833192bdbe3059160fba