### PR TITLE
Fix menu pause/input handling

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -1,7 +1,7 @@
 import * as THREE from '../vendor/three.module.js';
 import { getCamera, getScene } from './scene.js';
 import { state, savePlayerState, resetGame } from './state.js';
-import { refreshPrimaryController } from './PlayerController.js';
+import { refreshPrimaryController, resetInputFlags } from './PlayerController.js';
 import { AudioManager } from './audio.js';
 import { bossData } from './bosses.js';
 import { TALENT_GRID_CONFIG } from './talents.js';
@@ -319,6 +319,7 @@ export function showModal(id) {
 
     // Pause the game before heavy UI creation to avoid race conditions
     state.isPaused = true;
+    resetInputFlags();
     modal.visible = true;
     AudioManager.playSfx('uiModalOpen');
 
@@ -337,6 +338,7 @@ export function hideModal() {
         modals[activeModalId].visible = false;
         activeModalId = null;
         state.isPaused = false; // Unpause unless another condition requires it
+        resetInputFlags();
         AudioManager.playSfx('uiModalClose');
     }
 }

--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -39,6 +39,13 @@ function onSqueezeStart() {
 }
 function onSqueezeEnd() { gripDown = false; }
 
+export function resetInputFlags() {
+    triggerDown = false;
+    gripDown = false;
+    triggerJustPressed = false;
+    gripJustPressed = false;
+}
+
 export function refreshPrimaryController() {
     const newPrimary = getPrimaryController();
     if (newPrimary === primaryController) return;
@@ -144,7 +151,7 @@ export function updatePlayerController() {
             hoveredUi.userData.onSelect();
             gameHelpers.play('uiClickSound');
         }
-    } else {
+    } else if (!state.isPaused) {
         if (hoveredUi && hoveredUi.userData.onHover) hoveredUi.userData.onHover(false);
         hoveredUi = null;
         const arenaHit = raycaster.intersectObject(arena, false)[0];
@@ -163,12 +170,18 @@ export function updatePlayerController() {
             laser.scale.z = radius * 2;
             if (crosshair) crosshair.visible = false;
         }
+    } else {
+        // When paused and not hitting UI, hide crosshair
+        if (hoveredUi && hoveredUi.userData.onHover) hoveredUi.userData.onHover(false);
+        hoveredUi = null;
+        laser.scale.z = radius * 2;
+        if (crosshair) crosshair.visible = false;
     }
     
     triggerJustPressed = false;
     gripJustPressed = false;
 
-    if (state.player.stunnedUntil < Date.now()) {
+    if (!state.isPaused && state.player.stunnedUntil < Date.now()) {
         const speedMult = state.player.talent_states.phaseMomentum.active ? 1.1 : 1.0;
         moveTowards(avatar.position, targetPoint, state.player.speed * speedMult, radius);
         state.player.position.copy(avatar.position);


### PR DESCRIPTION
## Summary
- prevent player movement and abilities while game is paused
- clear controller input state when opening/closing a modal

## Testing
- `node scripts/checkAssetUsage.js`

------
https://chatgpt.com/codex/tasks/task_e_688d481ca0248331bb58cdb438ae6a59