### PR TITLE
Fix modal open state handling

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -10,7 +10,6 @@ import { holoMaterial, createTextSprite, updateTextSprite, getBgTexture } from '
 import { gameHelpers } from './gameHelpers.js';
 
 let modalGroup;
-let activeModalId = null;
 const modals = {};
 let confirmCallback;
 
@@ -282,9 +281,9 @@ export function initModals() {
 
 export function showModal(id) {
     ensureGroup();
-    
-    if (activeModalId && modals[activeModalId]) {
-        modals[activeModalId].visible = false;
+
+    if (state.activeModalId && modals[state.activeModalId]) {
+        modals[state.activeModalId].visible = false;
     }
 
     if (!modals[id]) {
@@ -298,7 +297,7 @@ export function showModal(id) {
     }
     
     const modal = modals[id];
-    activeModalId = id;
+    state.activeModalId = id;
     
     const camera = getCamera();
     if (!camera) {
@@ -326,7 +325,7 @@ export function showModal(id) {
     if (modal.userData.refresh) {
         // Defer refresh to the next frame so the paused state takes effect
         requestAnimationFrame(() => {
-            if (activeModalId === id) {
+            if (state.activeModalId === id) {
                 modal.userData.refresh();
             }
         });
@@ -334,9 +333,9 @@ export function showModal(id) {
 }
 
 export function hideModal() {
-    if (activeModalId && modals[activeModalId]) {
-        modals[activeModalId].visible = false;
-        activeModalId = null;
+    if (state.activeModalId && modals[state.activeModalId]) {
+        modals[state.activeModalId].visible = false;
+        state.activeModalId = null;
         state.isPaused = false; // Unpause unless another condition requires it
         resetInputFlags();
         AudioManager.playSfx('uiModalClose');

--- a/modules/state.js
+++ b/modules/state.js
@@ -66,8 +66,9 @@ export const state = {
     gravityActive: false,
     gravityEnd: 0,
     customOrreryBosses: [],
-    
+
     // Game flow state
+    activeModalId: null,
     currentStage: 1,
     bossActive: false,
     bossHasSpawnedThisRun: false,

--- a/modules/vrGameLoop.js
+++ b/modules/vrGameLoop.js
@@ -101,6 +101,7 @@ function handlePlayerEnemyCollisions() {
 
 export function vrGameLoop() {
     if (state.gameOver) return;
+    if (state.activeModalId) return;
 
     handleLevelProgression();
     handleEnemyAndPowerSpawning();


### PR DESCRIPTION
## Summary
- track active modal in global state
- reference new state field in ModalManager
- stop vrGameLoop while a modal is open

## Testing
- `node scripts/checkAssetUsage.js`

------
https://chatgpt.com/codex/tasks/task_e_688d4f4883388331b35a1304a1dd6bc9