### PR TITLE
Fix modal close unpause logic

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -10,7 +10,6 @@ import { holoMaterial, createTextSprite, updateTextSprite, getBgTexture } from '
 import { gameHelpers } from './gameHelpers.js';
 
 let modalGroup;
-let activeModalId = null;
 const modals = {};
 let confirmCallback;
 
@@ -282,9 +281,9 @@ export function initModals() {
 
 export function showModal(id) {
     ensureGroup();
-    
-    if (activeModalId && modals[activeModalId]) {
-        modals[activeModalId].visible = false;
+
+    if (state.activeModalId && modals[state.activeModalId]) {
+        modals[state.activeModalId].visible = false;
     }
 
     if (!modals[id]) {
@@ -298,7 +297,7 @@ export function showModal(id) {
     }
     
     const modal = modals[id];
-    activeModalId = id;
+    state.activeModalId = id;
     
     const camera = getCamera();
     if (!camera) {
@@ -326,7 +325,7 @@ export function showModal(id) {
     if (modal.userData.refresh) {
         // Defer refresh to the next frame so the paused state takes effect
         requestAnimationFrame(() => {
-            if (activeModalId === id) {
+            if (state.activeModalId === id) {
                 modal.userData.refresh();
             }
         });
@@ -334,10 +333,15 @@ export function showModal(id) {
 }
 
 export function hideModal() {
-    if (activeModalId && modals[activeModalId]) {
-        modals[activeModalId].visible = false;
-        activeModalId = null;
-        state.isPaused = false; // Unpause unless another condition requires it
+    if (state.activeModalId && modals[state.activeModalId]) {
+        modals[state.activeModalId].visible = false;
+        state.activeModalId = null;
+        // Defer unpausing to allow another modal to open within the same frame
+        requestAnimationFrame(() => {
+            if (!state.activeModalId) {
+                state.isPaused = false;
+            }
+        });
         resetInputFlags();
         AudioManager.playSfx('uiModalClose');
     }

--- a/modules/state.js
+++ b/modules/state.js
@@ -66,8 +66,9 @@ export const state = {
     gravityActive: false,
     gravityEnd: 0,
     customOrreryBosses: [],
-    
+
     // Game flow state
+    activeModalId: null,
     currentStage: 1,
     bossActive: false,
     bossHasSpawnedThisRun: false,

--- a/modules/vrGameLoop.js
+++ b/modules/vrGameLoop.js
@@ -101,6 +101,7 @@ function handlePlayerEnemyCollisions() {
 
 export function vrGameLoop() {
     if (state.gameOver) return;
+    if (state.activeModalId) return;
 
     handleLevelProgression();
     handleEnemyAndPowerSpawning();

--- a/tests/modalManager.test.js
+++ b/tests/modalManager.test.js
@@ -1,0 +1,82 @@
+const assert = require('assert');
+
+(async () => {
+  global.window = {
+    innerWidth: 800,
+    innerHeight: 600,
+    devicePixelRatio: 1,
+    startGame: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  const glStub = new Proxy({}, {
+    get: (obj, prop) => {
+      if (prop === 'canvas') return {};
+      if (prop === 'getParameter') return () => 'WebGL 1.0';
+      if (prop === 'getExtension') return () => null;
+      if (prop === 'getSupportedExtensions') return () => [];
+      if (prop === 'getShaderPrecisionFormat') return () => ({ precision: 0 });
+      if (typeof prop === 'string' && prop.toUpperCase() === prop) return 0;
+      return () => {};
+    }
+  });
+  const ctx2d = {
+    font: '',
+    fillStyle: '',
+    textBaseline: '',
+    textAlign: '',
+    measureText: () => ({ width: 100 }),
+    fillText: () => {},
+  };
+  const canvasStub = () => ({
+    width: 0,
+    height: 0,
+    style: {},
+    addEventListener: () => {},
+    getContext: (type) => (type === '2d' ? ctx2d : glStub),
+  });
+  global.document = {
+    createElement: tag => (tag === 'canvas' ? canvasStub() : {}),
+    createElementNS: (ns, tag) => (tag === 'canvas' ? canvasStub() : {}),
+    body: { appendChild: () => {} },
+  };
+  global.localStorage = {
+    _data: {},
+    getItem(key) { return this._data[key] || null; },
+    setItem(key, val) { this._data[key] = String(val); },
+    removeItem(key) { delete this._data[key]; },
+  };
+  global.requestAnimationFrame = cb => setTimeout(() => cb(Date.now()), 0);
+
+  const audio = await import('../modules/audio.js');
+  audio.AudioManager.playSfx = () => {};
+  audio.AudioManager.toggleMute = () => {};
+  audio.AudioManager.updateButtonIcon = () => {};
+
+  const scene = await import('../modules/scene.js');
+  scene.initScene();
+
+  const modalModule = await import('../modules/ModalManager.js');
+  const { showModal, hideModal, getModalByName } = modalModule;
+  const stateModule = await import('../modules/state.js');
+  const { state } = stateModule;
+
+  showModal('home');
+  assert.strictEqual(state.activeModalId, 'home');
+  assert.strictEqual(state.isPaused, true);
+
+  showModal('settings');
+  assert.strictEqual(state.activeModalId, 'settings');
+  const homeModal = getModalByName('home');
+  const settingsModal = getModalByName('settings');
+  assert.strictEqual(homeModal.visible, false);
+  assert.strictEqual(settingsModal.visible, true);
+
+  hideModal();
+  await new Promise(res => setTimeout(res, 0));
+  assert.strictEqual(state.activeModalId, null);
+  assert.strictEqual(state.isPaused, false);
+
+  console.log('modalManager.test.js passed');
+})();
+


### PR DESCRIPTION
## Summary
- defer unpausing when closing a modal so another modal can open
- add integration test covering modal open/close pause state

## Testing
- `node tests/modalManager.test.js`
- `node scripts/checkAssetUsage.js`


------
https://chatgpt.com/codex/tasks/task_e_688d4f4883388331b35a1304a1dd6bc9