### PR TITLE
fix: safeguard modal activation before camera

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -450,3 +450,7 @@ Verification: node scripts/checkAssetUsage.js
 2025-10-24 – Bug Fix – Power-up inventory
 Summary: Fixed pickup handling to update the HUD immediately and scaled emoji sprites to nearly fill the pickup sphere for better visibility.
 Verification: node scripts/checkAssetUsage.js
+
+2025-10-25 – Bug Fix – Modal active state guard
+Summary: Prevented `showModal` from leaving the game in an inconsistent state by restoring the previous modal and delaying `activeModalId` assignment until after the camera is ready.
+Verification: npm test (fails: missing package.json)

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -283,9 +283,9 @@ export function initModals() {
 export function showModal(id) {
     ensureGroup();
 
-    if (state.activeModalId && modals[state.activeModalId]) {
-        modals[state.activeModalId].visible = false;
-    }
+    const prevId = state.activeModalId;
+    const prevModal = prevId ? modals[prevId] : null;
+    if (prevModal) prevModal.visible = false;
 
     if (!modals[id]) {
         if (createModalFunctions[id]) {
@@ -293,18 +293,21 @@ export function showModal(id) {
             modalGroup.add(modals[id]);
         } else {
             console.error(`Modal "${id}" creation function does not exist.`);
+            if (prevModal) prevModal.visible = true;
             return;
         }
     }
-    
+
     const modal = modals[id];
-    state.activeModalId = id;
-    
+
     const camera = getCamera();
     if (!camera) {
         console.warn('Cannot show modal before camera is ready.');
+        if (prevModal) prevModal.visible = true;
         return;
     }
+
+    state.activeModalId = id;
     const distance = 1.5;
     const cameraWorldPos = new THREE.Vector3();
     const cameraWorldQuat = new THREE.Quaternion();


### PR DESCRIPTION
## Summary
- prevent showModal from leaving game in inconsistent state when camera isn't ready
- log task entry for modal active state guard fix

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2a6ca5b08331bd77ee549b7d512a