### PR TITLE
Add UI interaction cooldown to prevent instant menu dismissal

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -315,6 +315,7 @@ export function showModal(id) {
     // Pause the game before heavy UI creation to avoid race conditions
     state.isPaused = true;
     resetInputFlags();
+    state.uiInteractionCooldownUntil = Date.now() + 250;
     modal.visible = true;
     AudioManager.playSfx('uiModalOpen');
 

--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -148,8 +148,10 @@ export function updatePlayerController() {
             gameHelpers.play('uiHoverSound');
         }
         if (triggerJustPressed) {
-            hoveredUi.userData.onSelect();
-            gameHelpers.play('uiClickSound');
+            if (Date.now() > state.uiInteractionCooldownUntil) {
+                hoveredUi.userData.onSelect();
+                gameHelpers.play('uiClickSound');
+            }
         }
     } else if (!state.isPaused) {
         if (hoveredUi && hoveredUi.userData.onHover) hoveredUi.userData.onHover(false);

--- a/modules/state.js
+++ b/modules/state.js
@@ -73,6 +73,7 @@ export const state = {
     bossActive: false,
     bossHasSpawnedThisRun: false,
     bossSpawnCooldownEnd: 0,
+    uiInteractionCooldownUntil: 0,
     gameOver: false,
     isPaused: true,
     offensiveInventory: [null, null, null],


### PR DESCRIPTION
## Summary
- Track a global `uiInteractionCooldownUntil` timestamp to delay UI reactions when a modal appears.
- Set a 250ms cooldown each time a modal is shown.
- Ignore trigger clicks during this cooldown to avoid closing a menu on the same frame it opens.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e47cf72f48331a7152fe41550c275