### PR TITLE
Add desktop debug mode with pointer lock

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -556,3 +556,5 @@ export function showBossInfo(bossIds, type = 'mechanics') {
     if (modal.userData.titleSprite) updateTextSprite(modal.userData.titleSprite, title);
     if (modal.userData.contentSprite) updateTextSprite(modal.userData.contentSprite, content);
 }
+
+window.showModal = showModal;

--- a/vendor/PointerLockControls.js
+++ b/vendor/PointerLockControls.js
@@ -1,0 +1,162 @@
+import {
+	Euler,
+	EventDispatcher,
+	Vector3
+} from 'three';
+
+const _euler = new Euler( 0, 0, 0, 'YXZ' );
+const _vector = new Vector3();
+
+const _changeEvent = { type: 'change' };
+const _lockEvent = { type: 'lock' };
+const _unlockEvent = { type: 'unlock' };
+
+const _PI_2 = Math.PI / 2;
+
+class PointerLockControls extends EventDispatcher {
+
+	constructor( camera, domElement ) {
+
+		super();
+
+		this.camera = camera;
+		this.domElement = domElement;
+
+		this.isLocked = false;
+
+		// Set to constrain the pitch of the camera
+		// Range is 0 to Math.PI radians
+		this.minPolarAngle = 0; // radians
+		this.maxPolarAngle = Math.PI; // radians
+
+		this.pointerSpeed = 1.0;
+
+		this._onMouseMove = onMouseMove.bind( this );
+		this._onPointerlockChange = onPointerlockChange.bind( this );
+		this._onPointerlockError = onPointerlockError.bind( this );
+
+		this.connect();
+
+	}
+
+	connect() {
+
+		this.domElement.ownerDocument.addEventListener( 'mousemove', this._onMouseMove );
+		this.domElement.ownerDocument.addEventListener( 'pointerlockchange', this._onPointerlockChange );
+		this.domElement.ownerDocument.addEventListener( 'pointerlockerror', this._onPointerlockError );
+
+	}
+
+	disconnect() {
+
+		this.domElement.ownerDocument.removeEventListener( 'mousemove', this._onMouseMove );
+		this.domElement.ownerDocument.removeEventListener( 'pointerlockchange', this._onPointerlockChange );
+		this.domElement.ownerDocument.removeEventListener( 'pointerlockerror', this._onPointerlockError );
+
+	}
+
+	dispose() {
+
+		this.disconnect();
+
+	}
+
+	getObject() { // retaining this method for backward compatibility
+
+		return this.camera;
+
+	}
+
+	getDirection( v ) {
+
+		return v.set( 0, 0, - 1 ).applyQuaternion( this.camera.quaternion );
+
+	}
+
+	moveForward( distance ) {
+
+		// move forward parallel to the xz-plane
+		// assumes camera.up is y-up
+
+		const camera = this.camera;
+
+		_vector.setFromMatrixColumn( camera.matrix, 0 );
+
+		_vector.crossVectors( camera.up, _vector );
+
+		camera.position.addScaledVector( _vector, distance );
+
+	}
+
+	moveRight( distance ) {
+
+		const camera = this.camera;
+
+		_vector.setFromMatrixColumn( camera.matrix, 0 );
+
+		camera.position.addScaledVector( _vector, distance );
+
+	}
+
+	lock() {
+
+		this.domElement.requestPointerLock();
+
+	}
+
+	unlock() {
+
+		this.domElement.ownerDocument.exitPointerLock();
+
+	}
+
+}
+
+// event listeners
+
+function onMouseMove( event ) {
+
+	if ( this.isLocked === false ) return;
+
+	const movementX = event.movementX || event.mozMovementX || event.webkitMovementX || 0;
+	const movementY = event.movementY || event.mozMovementY || event.webkitMovementY || 0;
+
+	const camera = this.camera;
+	_euler.setFromQuaternion( camera.quaternion );
+
+	_euler.y -= movementX * 0.002 * this.pointerSpeed;
+	_euler.x -= movementY * 0.002 * this.pointerSpeed;
+
+	_euler.x = Math.max( _PI_2 - this.maxPolarAngle, Math.min( _PI_2 - this.minPolarAngle, _euler.x ) );
+
+	camera.quaternion.setFromEuler( _euler );
+
+	this.dispatchEvent( _changeEvent );
+
+}
+
+function onPointerlockChange() {
+
+	if ( this.domElement.ownerDocument.pointerLockElement === this.domElement ) {
+
+		this.dispatchEvent( _lockEvent );
+
+		this.isLocked = true;
+
+	} else {
+
+		this.dispatchEvent( _unlockEvent );
+
+		this.isLocked = false;
+
+	}
+
+}
+
+function onPointerlockError() {
+
+	console.error( 'THREE.PointerLockControls: Unable to use Pointer Lock API' );
+
+}
+
+export { PointerLockControls };

--- a/vrMain.js
+++ b/vrMain.js
@@ -1,5 +1,6 @@
 import * as THREE from './vendor/three.module.js';
 import { VRButton } from './vendor/addons/webxr/VRButton.js';
+import { PointerLockControls } from './vendor/PointerLockControls.js';
 import { initScene, getScene, getRenderer, getCamera } from './modules/scene.js';
 import { initPlayerController, updatePlayerController } from './modules/PlayerController.js';
 import { initUI, updateHud, showHud } from './modules/UIManager.js';
@@ -14,7 +15,7 @@ import { bossData } from './modules/bosses.js'; // Import bossData here
 let renderer;
 
 function render(timestamp, frame) {
-    if (!renderer.xr.isPresenting) return;
+    if (navigator.xr && !renderer.xr.isPresenting) return;
 
     Telemetry.recordFrame();
     updatePlayerController();
@@ -47,13 +48,40 @@ export async function launchVR(initialStage = 1) {
     state.currentStage = initialStage;
     state.isPaused = false;
 
+    // --- START DESKTOP DEBUG CONTROLS ---
+    if (!navigator.xr) {
+        console.log("No XR device found. Initializing desktop debug mode.");
+        const controls = new PointerLockControls(getCamera(), document.body);
+        const scene = getScene();
+
+        document.body.addEventListener('click', () => {
+            controls.lock();
+        });
+
+        scene.add(controls.getObject());
+
+        // Add a keyboard listener to open a menu with the space bar
+        document.addEventListener('keydown', (event) => {
+            if (event.code === 'Space') {
+                console.log("Space bar pressed. Forcing 'gameOver' modal.");
+                // Directly call the function to show a menu we know crashes.
+                window.showModal('gameOver');
+            }
+        });
+
+        showHud();
+        renderer.setAnimationLoop(render);
+        return;
+    }
+    // --- END DESKTOP DEBUG CONTROLS ---
+
     // Use the official VRButton logic to handle the session request
     const button = VRButton.createButton(renderer);
 
     // Hide the button and programmatically click it to start the session
     button.style.display = 'none';
     document.body.appendChild(button);
-    
+
     renderer.xr.addEventListener('sessionstart', () => {
         showHud();
         renderer.setAnimationLoop(render);


### PR DESCRIPTION
## Summary
- Add Three.js PointerLockControls vendor module and import it in the main VR entry point
- Start a desktop debug mode when no XR device is present, enabling mouse look and a spacebar shortcut to crash-test the gameOver modal
- Expose `showModal` on the `window` object for global access

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e64b0ad3c8331afe92be7eefc86ad