### PR TITLE
Enable desktop fallback when WebXR is unavailable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "eternal-momentum-vr",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test --experimental-test-module-mocks"
+  }
+}

--- a/tests/vrMain.test.js
+++ b/tests/vrMain.test.js
@@ -1,0 +1,116 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * Sets up mocked environment and imports the launchVR function.
+ * @returns {Promise<{launchVR: Function, showHud: Function, bodyAppend: Function, createButton: Function}>}
+ */
+async function setupLaunch() {
+  const showHud = mock.fn();
+  const bodyAppend = mock.fn();
+  const createButton = mock.fn(() => ({}));
+  const containerAppend = mock.fn();
+
+  await mock.module('../modules/scene.js', {
+    namedExports: {
+      initScene: mock.fn(),
+      getScene: () => ({}),
+      getRenderer: () => ({
+        domElement: {},
+        setAnimationLoop: mock.fn(),
+        xr: { enabled: false, addEventListener: mock.fn() }
+      }),
+      getCamera: () => ({})
+    }
+  });
+
+  await mock.module('../modules/PlayerController.js', {
+    namedExports: {
+      initPlayerController: async () => {},
+      updatePlayerController: mock.fn()
+    }
+  });
+
+  await mock.module('../modules/UIManager.js', {
+    namedExports: { initUI: mock.fn(), updateHud: mock.fn(), showHud }
+  });
+
+  await mock.module('../modules/ModalManager.js', {
+    namedExports: { initModals: mock.fn(), showModal: mock.fn() }
+  });
+
+  await mock.module('../modules/vrGameLoop.js', {
+    namedExports: { vrGameLoop: mock.fn() }
+  });
+
+  await mock.module('../modules/telemetry.js', {
+    namedExports: { Telemetry: { recordFrame: mock.fn() } }
+  });
+
+  const state = { isPaused: false, gameOver: false };
+  await mock.module('../modules/state.js', {
+    namedExports: { state, resetGame: mock.fn() }
+  });
+
+  await mock.module('../modules/ascension.js', {
+    namedExports: { applyAllTalentEffects: mock.fn() }
+  });
+
+  await mock.module('../modules/audio.js', {
+    namedExports: { AudioManager: { setup: mock.fn() } }
+  });
+
+  await mock.module('../modules/bosses.js', {
+    namedExports: { bossData: [] }
+  });
+
+  await mock.module('../vendor/addons/webxr/XRButton.js', {
+    namedExports: { XRButton: { createButton } }
+  });
+
+  await mock.module('../vendor/three.module.js', {
+    namedExports: {}
+  });
+
+  global.document = {
+    getElementById: () => ({ appendChild: containerAppend }),
+    body: { appendChild: bodyAppend }
+  };
+  global.window = { addEventListener: mock.fn() };
+
+  const { launchVR } = await import('../vrMain.js');
+  return { launchVR, showHud, bodyAppend, createButton };
+}
+
+test('desktop fallback displays HUD without XR button', async (t) => {
+  mock.reset();
+  global.navigator = {};
+  const { launchVR, showHud, bodyAppend, createButton } = await setupLaunch();
+
+  await t.test('when navigator.xr is missing', async () => {
+    showHud.mock.resetCalls();
+    bodyAppend.mock.resetCalls();
+    createButton.mock.resetCalls();
+    global.navigator = {};
+    await launchVR();
+    assert.equal(showHud.mock.calls.length, 1);
+    assert.equal(bodyAppend.mock.calls.length, 0);
+    assert.equal(createButton.mock.calls.length, 0);
+  });
+
+  await t.test('when isSessionSupported returns false', async () => {
+    showHud.mock.resetCalls();
+    bodyAppend.mock.resetCalls();
+    createButton.mock.resetCalls();
+    global.navigator = { xr: { isSessionSupported: async () => false } };
+    await launchVR();
+    assert.equal(showHud.mock.calls.length, 1);
+    assert.equal(bodyAppend.mock.calls.length, 0);
+    assert.equal(createButton.mock.calls.length, 0);
+  });
+
+  mock.reset();
+  delete global.document;
+  delete global.window;
+  delete global.navigator;
+});


### PR DESCRIPTION
## Summary
- Always run the render loop and game logic even without an active XR session
- Detect WebXR support at launch and show HUD immediately on desktop
- Only create the XR button when immersive VR sessions are supported
- Add automated tests verifying desktop fallback shows HUD and skips XR button when WebXR is unsupported

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e6e376d588331b5608254e116ebc9