### PR TITLE
Avoid crash when raycaster lacks camera

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -133,6 +133,14 @@ export function updatePlayerController() {
     const controllerUI = getControllerMenuObjects();
     const allUI = [...modalUI, ...controllerUI];
 
+    // --- CRASH FIX ---
+    // Do not attempt to raycast if the camera is not yet set.
+    // This prevents a fatal error when a modal appears.
+    if (!raycaster.camera) {
+        return;
+    }
+    // --- END CRASH FIX ---
+
     const uiHits = raycaster.intersectObjects(allUI, true);
     const uiHit = uiHits[0];
 


### PR DESCRIPTION
## Summary
- prevent PlayerController from raycasting when `raycaster.camera` is undefined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ea3f7177c8331a60a4d09ddaad6a0