### PR TITLE
fix: prevent UI raycast crash

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -122,6 +122,11 @@ function handleInput() {
 export function updatePlayerController() {
     if (!primaryController || !raycaster) return;
 
+    const camera = getCamera();
+    if (!camera) return;
+    // Needed for raycasting against sprites and other UI elements
+    raycaster.camera = camera;
+
     const arena = getArena();
     const radius = arena.geometry.parameters.radius;
 
@@ -129,8 +134,8 @@ export function updatePlayerController() {
     raycaster.ray.origin.setFromMatrixPosition(primaryController.matrixWorld);
     raycaster.ray.direction.set(0, 0, -1).applyMatrix4(tempMatrix);
 
-    const modalUI = getModalObjects().filter(m => m.visible);
-    const controllerUI = getControllerMenuObjects();
+    const modalUI = getModalObjects().filter(m => m && m.visible);
+    const controllerUI = getControllerMenuObjects().filter(Boolean);
     const allUI = [...modalUI, ...controllerUI];
 
     const uiHits = raycaster.intersectObjects(allUI, true);
@@ -165,7 +170,7 @@ export function updatePlayerController() {
             if (crosshair) {
                 crosshair.visible = true;
                 crosshair.position.copy(arenaHit.point);
-                crosshair.lookAt(getCamera().position);
+                crosshair.lookAt(camera.position);
             }
             handleInput();
         } else {


### PR DESCRIPTION
## Summary
- ensure PlayerController sets raycaster camera to avoid null matrix errors
- skip null UI elements during raycast and reuse the current camera for crosshair alignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ec4e886448331b0850e92cca3b46a