### PR TITLE
Fix menu scale, text stability, and restart stage controller swap

### DIFF
--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -63,6 +63,13 @@ export function createTextSprite(text, size = 32, color = '#eaf2ff', align = 'ce
     const scale = 0.001;
     sprite.scale.set(canvas.width * scale, canvas.height * scale, 1);
     sprite.userData = { text, canvas, ctx, font: `${size}px ${fontStack}`, color, size, align };
+
+    // Sprites automatically match the camera's roll, which caused text to tilt
+    // when the player tilted their head. Counter-rotate the material each frame
+    // so text stays upright and easier to read.
+    sprite.onBeforeRender = (_, __, camera) => {
+        sprite.material.rotation = -camera.rotation.z;
+    };
     return sprite;
 }
 


### PR DESCRIPTION
## Summary
- Enlarge modal menus and position them at the player's head height
- Keep text sprites upright regardless of head tilt
- Refresh controller mapping when restarting to avoid swapped hands

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ec78d9d5483319c1a102c6f2d4634