### PR TITLE
Fix spherical pathfinding for enemies

### DIFF
--- a/modules/agents/JuggernautAI.js
+++ b/modules/agents/JuggernautAI.js
@@ -1,6 +1,6 @@
 import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
-import { moveTowards } from '../movement3d.js';
+import { getSphericalDirection } from '../movement3d.js';
 import { state } from '../state.js';
 import { gameHelpers } from '../gameHelpers.js';
 
@@ -40,17 +40,25 @@ export class JuggernautAI extends BaseAgent {
             this.isCharging = false;
             this.lastChargeTime = now;
         } else {
-            // Move quickly towards the charge target
-            moveTowards(this.position, this.chargeTarget, 15 * speedMultiplier * delta, ARENA_RADIUS);
+            // Move quickly towards the charge target along the sphere
+            const dir = getSphericalDirection(this.position, this.chargeTarget);
+            const dist = this.position.distanceTo(this.chargeTarget);
+            this.position.add(dir.multiplyScalar(dist * 0.015 * 15 * speedMultiplier * delta));
+            this.position.normalize().multiplyScalar(ARENA_RADIUS);
+            this.lookAt(this.position.clone().add(dir));
             // If we reach the target, pick a new random one to simulate a bounce
             if (this.position.distanceTo(this.chargeTarget) < 2) {
                 this.chargeTarget.randomDirection().multiplyScalar(ARENA_RADIUS);
             }
         }
     } else {
-        // Normal movement
+        // Normal movement toward the player
         const playerPos = state.player.position;
-        moveTowards(this.position, playerPos, 0.8 * speedMultiplier * delta, ARENA_RADIUS);
+        const dir = getSphericalDirection(this.position, playerPos);
+        const dist = this.position.distanceTo(playerPos);
+        this.position.add(dir.multiplyScalar(dist * 0.015 * 0.8 * speedMultiplier * delta));
+        this.position.normalize().multiplyScalar(ARENA_RADIUS);
+        this.lookAt(this.position.clone().add(dir));
 
         // Check if it's time to charge
         if (now - this.lastChargeTime > 7000) {

--- a/modules/enemyAI3d.js
+++ b/modules/enemyAI3d.js
@@ -6,7 +6,7 @@
 
 import { state } from './state.js';
 import { uvToSpherePos, spherePosToUv } from './utils.js';
-import { moveTowards } from './movement3d.js';
+import { getSphericalDirection } from './movement3d.js';
 import { findPath, buildNavMesh } from './navmesh.js';
 
 export function addPathObstacle(u,v,radius=0.1){
@@ -57,7 +57,11 @@ export function updateEnemies3d(radius = DEFAULT_RADIUS, width, height){
     const target3d = uvToSpherePos(nextUv.u, nextUv.v, radius);
 
     if(!e.frozen){
-      moveTowards(pos3d, target3d, e.speed || 1, radius);
+      const dir = getSphericalDirection(pos3d, target3d);
+      const dist = pos3d.distanceTo(target3d);
+      pos3d.add(dir.multiplyScalar(dist * 0.015 * (e.speed || 1)));
+      pos3d.normalize().multiplyScalar(radius);
+      e.lookAt(pos3d.clone().add(dir));
       // Advance along the path when close to the next waypoint
       const dest3d = uvToSpherePos(nextUv.u, nextUv.v, radius);
       if(pos3d.distanceTo(dest3d) < 0.05*radius){

--- a/modules/movement3d.js
+++ b/modules/movement3d.js
@@ -4,7 +4,26 @@
 // target point.  Used for Nexus movement.  Algorithm unchanged; file included
 // in full for completeness.  
 
+import * as THREE from '../vendor/three.module.js';
 import { spherePosToUv } from './utils.js';
+
+/**
+ * Compute the tangent direction along the surface of a sphere from one point
+ * to another. Both inputs are treated as positions on the sphere and the
+ * resulting vector lies tangent to the sphere at the start point.
+ *
+ * @param {THREE.Vector3} from - Starting position on the sphere.
+ * @param {THREE.Vector3} to   - Destination position on the sphere.
+ * @returns {THREE.Vector3} Normalized direction vector along the sphere.
+ */
+export function getSphericalDirection(from, to) {
+  const fromNorm = from.clone().normalize();
+  const toNorm = to.clone().normalize();
+  // Step a small amount along the great-circle arc toward the target using
+  // spherical linear interpolation.
+  const intermediate = fromNorm.clone().slerp(toNorm, 0.01);
+  return intermediate.sub(fromNorm).normalize();
+}
 
 /**
  * Move an avatar toward a target position on the sphere.
@@ -15,10 +34,9 @@ import { spherePosToUv } from './utils.js';
  * @returns {{u:number,v:number}}    New (u,v) coords for legacy gameLoop.
  */
 export function moveTowards (avatarPos, targetPos, speedMod = 1, radius = 1) {
-  const dir = targetPos.clone().sub(avatarPos);
-  const dist = dir.length();
+  const dist = avatarPos.distanceTo(targetPos);
   if (dist > 1e-4) {
-    dir.normalize();
+    const dir = getSphericalDirection(avatarPos, targetPos);
     avatarPos.add(dir.multiplyScalar(dist * 0.015 * speedMod));
     avatarPos.normalize().multiplyScalar(radius);
   }


### PR DESCRIPTION
## Summary
- introduce `getSphericalDirection` to steer movement along the sphere with slerp
- move enemies using spherical direction and orient them with `lookAt`
- update Juggernaut AI to chase the player using new spherical pathing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ecaec7c388331866e10c66db3708d