### PR TITLE
Fix spherical movement direction without Vector3.slerp

### DIFF
--- a/modules/movement3d.js
+++ b/modules/movement3d.js
@@ -8,6 +8,22 @@ import * as THREE from '../vendor/three.module.js';
 import { spherePosToUv } from './utils.js';
 
 /**
+ * Perform spherical linear interpolation (slerp) between two unit vectors.
+ * @param {THREE.Vector3} start - Normalized start vector.
+ * @param {THREE.Vector3} end - Normalized end vector.
+ * @param {number} t - Interpolation factor in [0,1].
+ * @returns {THREE.Vector3} Interpolated unit vector.
+ */
+function slerpUnitVectors (start, end, t) {
+  const theta = start.angleTo(end);
+  if (theta === 0) return start.clone();
+  const sinTheta = Math.sin(theta);
+  const coeffStart = Math.sin((1 - t) * theta) / sinTheta;
+  const coeffEnd = Math.sin(t * theta) / sinTheta;
+  return start.clone().multiplyScalar(coeffStart).add(end.clone().multiplyScalar(coeffEnd));
+}
+
+/**
  * Compute the tangent direction along the surface of a sphere from one point
  * to another. Both inputs are treated as positions on the sphere and the
  * resulting vector lies tangent to the sphere at the start point.
@@ -20,8 +36,9 @@ export function getSphericalDirection(from, to) {
   const fromNorm = from.clone().normalize();
   const toNorm = to.clone().normalize();
   // Step a small amount along the great-circle arc toward the target using
-  // spherical linear interpolation.
-  const intermediate = fromNorm.clone().slerp(toNorm, 0.01);
+  // spherical linear interpolation. Vector3 lacks a built-in slerp on the
+  // project's Three.js version, so we compute it manually.
+  const intermediate = slerpUnitVectors(fromNorm, toNorm, 0.01);
   return intermediate.sub(fromNorm).normalize();
 }
 

--- a/tests/movement3d.test.js
+++ b/tests/movement3d.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+import { getSphericalDirection } from '../modules/movement3d.js';
+
+test('getSphericalDirection returns a tangent unit vector toward target', () => {
+  const from = new THREE.Vector3(1, 0, 0);
+  const to = new THREE.Vector3(0, 1, 0);
+  const dir = getSphericalDirection(from, to);
+  assert.ok(Math.abs(dir.length() - 1) < 1e-6, 'direction should be unit length');
+  assert.ok(Math.abs(dir.dot(from)) < 1e-2, 'direction should be tangent to from');
+  assert.ok(dir.dot(to) > 0, 'direction should point toward target');
+});


### PR DESCRIPTION
## Summary
- replace missing THREE.Vector3.slerp usage with custom slerpUnitVectors helper
- add unit test verifying getSphericalDirection behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ecd1067c083318116119bb2b6d552