### PR TITLE
Align Ascension Conduit menu wording with 2D version

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -516,14 +516,14 @@ function createAscensionModal() {
         updateTextSprite(apValue, `${state.player.ascensionPoints}`);
     };
 
-    const closeBtn = createButton('Close', () => hideModal(), 0.6, 0.1, 0xf000ff);
+    const closeBtn = createButton('CLOSE', () => hideModal(), 0.6, 0.1, 0xf000ff);
     closeBtn.position.set(0.45, -0.6, 0.01);
     modal.add(closeBtn);
 
-    const clearBtn = createButton('SEVER TIMELINE', () => {
+    const clearBtn = createButton('ERASE TIMELINE', () => {
         showConfirm(
-            'SEVER TIMELINE?',
-            'All Ascension progress and unlocked powers will be lost.',
+            '|| SEVER TIMELINE? ||',
+            'All Ascension progress and unlocked powers will be lost to the void. This action cannot be undone.',
             () => {
                 localStorage.removeItem('eternalMomentumSave');
                 window.location.reload();


### PR DESCRIPTION
## Summary
- Match Ascension Conduit close/erase button labels to the original 2D game
- Show classic `|| SEVER TIMELINE? ||` confirmation text when erasing progress

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f6c7d390c833188fbe0f021300719