### PR TITLE
Mirror ascension conduit UI styling in VR

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -451,8 +451,10 @@ function createAscensionModal() {
                 const canPurchase = prereqsMet && state.player.ascensionPoints >= cost;
 
                 if (state.player.purchasedTalents.has(t.id) || isTalentVisible(t)) {
-                    let borderColor = 0x555555;
-                    if (isMax) {
+                    let borderColor = 0xaaaaaa;
+                    if (t.isNexus || t.isInfinite) {
+                        borderColor = 0x00ff00;
+                    } else if (isMax) {
                         borderColor = new THREE.Color(getConstellationColorOfTalent(t.id)).getHex();
                     } else if (canPurchase) {
                         borderColor = 0x00ff00;
@@ -466,6 +468,7 @@ function createAscensionModal() {
                         0x111122,
                         0xffffff
                     );
+                    btn.userData.talentId = t.id;
                     btn.position.copy(positions[t.id]);
                     btn.userData.onHover = hovered => {
                         if (hovered) {
@@ -479,7 +482,13 @@ function createAscensionModal() {
                                 tooltip.userData.footer,
                                 `Rank: ${purchased}/${t.isInfinite ? '∞' : t.maxRanks}  Cost: ${displayCost}`
                             );
-                            tooltip.position.copy(positions[t.id]).add(new THREE.Vector3(0.25, 0.15, 0));
+                            const basePos = positions[t.id];
+                            let offsetX = 0.25;
+                            if (basePos.x > 0.35) offsetX = -0.25;
+                            else if (basePos.x < -0.35) offsetX = 0.25;
+                            let offsetY = 0.15;
+                            if (basePos.y > 0.3) offsetY = -0.15;
+                            tooltip.position.copy(basePos).add(new THREE.Vector3(offsetX, offsetY, 0));
                             tooltip.visible = true;
                         } else if (tooltip) {
                             tooltip.visible = false;

--- a/tests/ascensionNexus.test.js
+++ b/tests/ascensionNexus.test.js
@@ -1,0 +1,86 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+// Utility to set up minimal environment for ModalManager
+async function setup() {
+  mock.reset();
+  global.requestAnimationFrame = (fn) => fn();
+  const scene = { children: [], add(obj) { this.children.push(obj); } };
+  await mock.module('../modules/scene.js', {
+    namedExports: {
+      getScene: () => scene,
+      getCamera: () => ({
+        position: new THREE.Vector3(),
+        rotation: new THREE.Euler(),
+        quaternion: new THREE.Quaternion()
+      }),
+      getRenderer: () => ({}),
+      getPrimaryController: () => ({})
+    }
+  });
+
+  const state = {
+    activeModalId: null,
+    isPaused: false,
+    uiInteractionCooldownUntil: 0,
+    player: {
+      ascensionPoints: 0,
+      purchasedTalents: new Map(),
+      unlockedPowers: new Set()
+    }
+  };
+
+  await mock.module('../modules/state.js', {
+    namedExports: { state, savePlayerState: mock.fn(), resetGame: mock.fn() }
+  });
+
+  await mock.module('../modules/PlayerController.js', {
+    namedExports: { refreshPrimaryController: mock.fn(), resetInputFlags: mock.fn() }
+  });
+
+  await mock.module('../modules/audio.js', {
+    namedExports: { AudioManager: { playSfx: mock.fn() } }
+  });
+
+  await mock.module('../modules/gameHelpers.js', {
+    namedExports: { gameHelpers: {} }
+  });
+
+  await mock.module('../modules/UIManager.js', {
+    namedExports: {
+      holoMaterial: (color = 0x1e1e2f, opacity = 0.85) => ({
+        color: new THREE.Color(color),
+        emissive: new THREE.Color(color),
+        emissiveIntensity: 1,
+        transparent: true,
+        opacity
+      }),
+      createTextSprite: () => {
+        const obj = new THREE.Object3D();
+        obj.material = { color: new THREE.Color(0xffffff) };
+        return obj;
+      },
+      updateTextSprite: () => {},
+      getBgTexture: () => null,
+      showUnlockNotification: () => {}
+    }
+  });
+
+  const { initModals, showModal } = await import('../modules/ModalManager.js');
+  return { scene, initModals, showModal };
+}
+
+test('nexus talents use green border color', async () => {
+  const { scene, initModals, showModal } = await setup();
+  initModals();
+  showModal('ascension');
+  const modalGroup = scene.children[0];
+  const ascensionModal = modalGroup.children.find(c => c.name === 'modal_ascension');
+  assert.ok(ascensionModal);
+  const grid = ascensionModal.children.find(c => c.position && c.position.y === -0.1);
+  const nexusButton = grid.children.find(c => c.userData && c.userData.talentId === 'core-nexus');
+  assert.ok(nexusButton, 'core nexus button should exist');
+  const border = nexusButton.children[1];
+  assert.equal(border.material.color.getHex(), 0x00ff00);
+});


### PR DESCRIPTION
## Summary
- Align VR ascension modal with 2D game's style: nexus talents now glow green and tooltips flip when near edges
- Store talent ids on buttons for easier refresh logic
- Add unit test ensuring nexus talents render with the correct color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f714291908331aa22aeefb0ff4933