### PR TITLE
Ensure power-up HUD refresh and test pickup flow

### DIFF
--- a/modules/PowerManager.js
+++ b/modules/PowerManager.js
@@ -6,6 +6,7 @@
 
 import { state } from './state.js';
 import { usePower } from './powers.js';
+import { gameHelpers } from './gameHelpers.js';
 
 /**
  * Use the offensive power in the first inventory slot.
@@ -13,7 +14,10 @@ import { usePower } from './powers.js';
  */
 export function useOffensivePower(options = {}) {
   const key = state.offensiveInventory[0];
-  if (key) usePower(key, false, options);
+  if (key) {
+    usePower(key, false, options);
+    if (gameHelpers.updateHud) gameHelpers.updateHud();
+  }
 }
 
 /**
@@ -22,5 +26,8 @@ export function useOffensivePower(options = {}) {
  */
 export function useDefensivePower(options = {}) {
   const key = state.defensiveInventory[0];
-  if (key) usePower(key, false, options);
+  if (key) {
+    usePower(key, false, options);
+    if (gameHelpers.updateHud) gameHelpers.updateHud();
+  }
 }

--- a/tests/powerUpFlow.test.js
+++ b/tests/powerUpFlow.test.js
@@ -1,0 +1,45 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+// Mock UI and scene dependencies to avoid DOM and WebXR
+await mock.module('../modules/UIManager.js', {
+  namedExports: { createTextSprite: () => new THREE.Object3D() }
+});
+await mock.module('../modules/scene.js', {
+  namedExports: {
+    getScene: () => null,
+    getCamera: () => null,
+    getRenderer: () => ({}),
+    getPrimaryController: () => null
+  }
+});
+await mock.module('../modules/cores.js', {
+  namedExports: { handleCoreOnDefensivePower: () => {} }
+});
+await mock.module('../modules/CoreManager.js', {
+  namedExports: { onPickup: () => {} }
+});
+
+// Import modules under test
+const { state } = await import('../modules/state.js');
+const { updatePickups3d } = await import('../modules/pickupPhysics3d.js');
+const { useOffensivePower } = await import('../modules/PowerManager.js');
+const { initGameHelpers } = await import('../modules/gameHelpers.js');
+
+test('pickup adds power and trigger uses it', () => {
+  const updateHud = mock.fn();
+  initGameHelpers({ play: () => {}, updateHud });
+
+  state.player.position.set(0, 0, 50);
+  state.cursorDir.set(0, 0, 1);
+  state.pickups.push({ position: new THREE.Vector3(0, 0, 50), r: 0.5, type: 'missile' });
+
+  updatePickups3d(50);
+  assert.equal(state.offensiveInventory[0], 'missile');
+  assert.equal(updateHud.mock.calls.length, 1);
+
+  useOffensivePower();
+  assert.equal(state.offensiveInventory[0], null);
+  assert.equal(updateHud.mock.calls.length, 2);
+});


### PR DESCRIPTION
## Summary
- refresh HUD after consuming offensive or defensive powers
- add unit test covering power-up pickup and trigger usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f79ff4f308331b9e4f37d625baaec