### PR TITLE
fix: clear enemies on stage restart

### DIFF
--- a/modules/state.js
+++ b/modules/state.js
@@ -119,6 +119,19 @@ export function loadPlayerState() {
 }
 
 export function resetGame(bossData) { // Now accepts bossData to avoid circular dependency
+    // Remove any lingering objects from the scene before wiping state arrays
+    const collections = ['enemies', 'pickups', 'effects', 'decoys', 'particles', 'pathObstacles'];
+    for (const key of collections) {
+        const arr = state[key];
+        if (Array.isArray(arr)) {
+            arr.forEach(obj => {
+                if (obj && obj.parent) {
+                    obj.parent.remove(obj);
+                }
+            });
+        }
+    }
+
     state.player.position.set(0, 0, 0);
     state.player.health = state.player.maxHealth;
     state.player.statusEffects = [];

--- a/tests/resetGameCleanup.test.js
+++ b/tests/resetGameCleanup.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+const { state, resetGame } = await import('../modules/state.js');
+
+test('resetGame removes enemies from scene', () => {
+  const scene = new THREE.Group();
+  const enemy = new THREE.Group();
+  scene.add(enemy);
+  state.enemies.push(enemy);
+
+  resetGame();
+
+  assert.equal(enemy.parent, null);
+  assert.equal(state.enemies.length, 0);
+});


### PR DESCRIPTION
## Summary
- remove lingering scene objects during `resetGame`
- add test covering enemy cleanup on game restart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f7f6d04f4833190d743438ac5e858