### PR TITLE
Fix HUD and orrery menu overflow

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -633,12 +633,19 @@ function createOrreryModal() {
     modal.userData.refresh = () => {
         disposeGroupChildren(list);
         const costs = {1:2,2:5,3:8};
-        bossData.filter(b=>b.difficulty_tier).forEach((b,i)=>{
+        const bosses = bossData.filter(b=>b.difficulty_tier);
+        bosses.forEach((b,i)=>{
             const cost = costs[b.difficulty_tier] || 2;
             const btn = createButton(`${b.name} (${cost})`, () => showBossInfo([b.id], 'mechanics'), 1.2);
-            btn.position.set(0, 0.4 - i*0.12, 0.01);
+            btn.position.set(0, -i*0.12, 0.01);
             list.add(btn);
         });
+        const btnHeight = 0.1;
+        const spacing = 0.12;
+        const totalHeight = (bosses.length - 1) * spacing + btnHeight;
+        const available = 0.9;
+        const scale = Math.min(1, available / totalHeight);
+        list.scale.setScalar(scale);
     };
 
     const closeBtn = createButton('Close', () => hideModal(), 0.6, 0.1, 0xf000ff);

--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -16,6 +16,7 @@ let coreIcon, coreCooldown, coreSocket;
 let bossContainer;
 const bossBars = new Map();
 let notificationGroup, notificationTimeout;
+const AP_RIGHT_EDGE = 0.44;
 
 let bgTexture = null;
 export function getBgTexture() {
@@ -209,7 +210,7 @@ function createHudElements() {
     hudMesh.add(ascGroup);
     
     apText = createTextSprite('AP: 0', 24, '#00ffff');
-    apText.position.set(0.45, 0.03, 0.001);
+    apText.position.set(AP_RIGHT_EDGE, 0.03, 0.001);
     hudMesh.add(apText);
 
     statusGroup = new THREE.Group();
@@ -297,6 +298,7 @@ export function updateHud() {
     ascFill.scale.x = state.player.essence / state.player.essenceToNextLevel;
     updateTextSprite(ascText, `LVL ${state.player.level}`);
     updateTextSprite(apText, `AP: ${state.player.ascensionPoints}`);
+    apText.position.x = AP_RIGHT_EDGE - apText.scale.x / 2;
 
     const updateSlot = (slot, key, isVisible) => {
         if (!slot) return;


### PR DESCRIPTION
## Summary
- Anchor Ascension Points HUD text so it stays inside the command bar
- Scale the Orrery boss list to keep all buttons within its modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f80ccfbbc8331a773dfdb395ca427