### PR TITLE
Fix VR missile power-up fireball

### DIFF
--- a/modules/powers.js
+++ b/modules/powers.js
@@ -5,6 +5,7 @@ import * as Cores from './cores.js';
 import { gameHelpers } from './gameHelpers.js';
 import { playerHasCore } from './helpers.js';
 import { getPrimaryController } from './scene.js';
+import { VR_PROJECTILE_SPEED_SCALE } from './config.js';
 
 const ARENA_RADIUS = 50; // Should match the radius in scene.js
 
@@ -65,11 +66,15 @@ export const powers = {
       const startPos = new THREE.Vector3();
       if(controller){
           controller.getWorldPosition(startPos);
+          // Offset forward so the fireball spawns at the pointer tip
+          const dir = new THREE.Vector3();
+          controller.getWorldDirection(dir);
+          startPos.add(dir.multiplyScalar(0.1));
       } else {
           startPos.copy(origin.position);
       }
       const targetPos = state.cursorDir.clone().multiplyScalar(ARENA_RADIUS);
-      const velocity = targetPos.clone().sub(startPos).normalize().multiplyScalar(1);
+      const velocity = targetPos.clone().sub(startPos).normalize().multiplyScalar(VR_PROJECTILE_SPEED_SCALE);
 
       state.effects.push({
           type: 'fireball',

--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -88,14 +88,19 @@ export function updateProjectiles3d(radius = 50, width, height){
       }
     }
 
-    p.position.add(p.velocity);
-    const clamped = p.position.clone().normalize().multiplyScalar(radius);
     if(p.type !== 'fireball') {
+      p.position.add(p.velocity);
+      const clamped = p.position.clone().normalize().multiplyScalar(radius);
       p.position.copy(clamped);
+      const uv = spherePosToUv(clamped, radius);
+      p.x = uv.u * width;
+      p.y = uv.v * height;
+    } else {
+      const clamped = p.position.clone().normalize().multiplyScalar(radius);
+      const uv = spherePosToUv(clamped, radius);
+      p.x = uv.u * width;
+      p.y = uv.v * height;
     }
-    const uv = spherePosToUv(clamped, radius);
-    p.x = uv.u * width;
-    p.y = uv.v * height;
     if(mesh){
       mesh.position.copy(p.position);
     }

--- a/tests/missileFireball.test.js
+++ b/tests/missileFireball.test.js
@@ -1,0 +1,67 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+// Mock modules to avoid DOM/WebXR dependencies
+await mock.module('../modules/UIManager.js', {
+  namedExports: { createTextSprite: () => new THREE.Object3D() }
+});
+await mock.module('../modules/scene.js', {
+  namedExports: {
+    getScene: () => null,
+    getCamera: () => null,
+    getRenderer: () => ({}),
+    getPrimaryController: () => ({
+      getWorldPosition: v => v.set(0, 0, 50),
+      getWorldDirection: v => v.set(0, 0, -1)
+    })
+  }
+});
+await mock.module('../modules/cores.js', {
+  namedExports: { handleCoreOnDefensivePower: () => {} }
+});
+await mock.module('../modules/CoreManager.js', {
+  namedExports: { onPickup: () => {} }
+});
+
+const { state } = await import('../modules/state.js');
+const { useOffensivePower } = await import('../modules/PowerManager.js');
+const { updateEffects3d, updateProjectiles3d } = await import('../modules/projectilePhysics3d.js');
+const { initGameHelpers } = await import('../modules/gameHelpers.js');
+
+test('missile launches fireball that explodes on target', () => {
+  initGameHelpers({ play: () => {}, pulseControllers: () => {}, addStatusEffect: () => {} });
+
+  state.effects.length = 0;
+  state.enemies.length = 0;
+  state.offensiveInventory = ['missile', null, null];
+
+  state.player.position.set(0, 0, 50);
+  state.cursorDir.set(0, 0, -1);
+
+  const enemy = {
+    position: new THREE.Vector3(0, 0, -50),
+    r: 0.5,
+    alive: true,
+    isFriendly: false,
+    takeDamage: mock.fn()
+  };
+  state.enemies.push(enemy);
+
+  useOffensivePower();
+  const fireball = state.effects.find(e => e.type === 'fireball');
+  assert.ok(fireball, 'fireball spawned');
+
+  for (let i = 0; i < 200 && state.effects.includes(fireball); i++) {
+    updateEffects3d(50);
+    updateProjectiles3d(50, 1000, 1000);
+  }
+
+  // Run a few extra frames to process the resulting explosion
+  for (let i = 0; i < 20; i++) {
+    updateEffects3d(50);
+  }
+
+  assert.ok(!state.effects.includes(fireball), 'fireball resolved');
+  assert.ok(enemy.takeDamage.mock.calls.length > 0, 'enemy damaged by explosion');
+});


### PR DESCRIPTION
## Summary
- Launch missile fireball from controller tip toward crosshair and move at VR-tuned speed
- Prevent fireball from updating twice per frame in projectile physics
- Add test covering fireball travel and explosion damage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f9055cc2c83318469f9e14d9c2da6