### PR TITLE
Use 3D state for player canvas rendering

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -461,3 +461,9 @@ Verification: node scripts/checkAssetUsage.js
 2025-10-27 – FR-07 – Canvas position helpers
 Summary: Added setPositionFromCanvas helper to convert canvas coordinates into 3D vectors and updated bosses.js to use centralized get/set functions for player position. Introduced unit test verifying round-trip conversion.
 Verification: npm test – all suites pass.
+2025-10-28 – FR-07 – drawPlayer uses 3D state
+Summary: Updated utils.drawPlayer to project the player's THREE.Vector3 position onto the canvas via toCanvasPos, removing last 2D coordinate dependency. Added drawPlayer3d test verifying canvas conversion.
+Verification: npm test – all suites pass.
+2025-10-28 – FR-07 – drawPlayer3d edge cases
+Summary: Expanded drawPlayer3d tests with negative and corner positions to ensure 3D projections map correctly to canvas coordinates.
+Verification: npm test – all suites pass.

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -38,12 +38,26 @@ export function drawCrystal(ctx, x, y, size, color) {
 }
 
 /**
- * Draws a player‑shaped circle.  Used for echoes and shadow copies.
+ * Draws a player‑shaped circle on a 2D canvas using the player's 3D position.
+ *
+ * The player's {@link THREE.Vector3} `position` is projected onto the canvas
+ * via {@link toCanvasPos} to ensure all rendering originates from the
+ * canonical 3D state.
+ *
+ * @param {CanvasRenderingContext2D} ctx - Rendering context.
+ * @param {{position:THREE.Vector3,r:number}} player - Player object with
+ *   world-space position and radius.
+ * @param {string} color - Fill style for the player representation.
  */
 export function drawPlayer(ctx, player, color) {
+  const { x, y } = toCanvasPos(
+    player.position,
+    ctx.canvas.width,
+    ctx.canvas.height
+  );
   ctx.fillStyle = color;
   ctx.beginPath();
-  ctx.arc(player.x, player.y, player.r, 0, 2 * Math.PI);
+  ctx.arc(x, y, player.r, 0, 2 * Math.PI);
   ctx.fill();
 }
 

--- a/tests/drawPlayer3d.test.js
+++ b/tests/drawPlayer3d.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+import { drawPlayer, toCanvasPos } from '../modules/utils.js';
+
+function createCtx() {
+  const calls = [];
+  const ctx = {
+    canvas: { width: 2048, height: 1024 },
+    beginPath() { calls.push('beginPath'); },
+    arc(x, y, r) { calls.push({ x, y, r }); },
+    fill() { calls.push('fill'); },
+    set fillStyle(_) { /* ignore */ },
+    get fillStyle() { return null; }
+  };
+  return { ctx, calls };
+}
+
+test('drawPlayer projects 3D position to canvas coords', () => {
+  const { ctx, calls } = createCtx();
+
+  const player = {
+    position: new THREE.Vector3(0, 1, 0),
+    r: 10
+  };
+
+  drawPlayer(ctx, player, '#fff');
+  const arcCall = calls.find(c => typeof c === 'object');
+  assert.deepEqual(arcCall, { x: 1024, y: 0, r: 10 });
+});
+
+test('drawPlayer projects negative X coordinate', () => {
+  const { ctx, calls } = createCtx();
+  const player = {
+    position: new THREE.Vector3(-1, 0, 0),
+    r: 10
+  };
+  drawPlayer(ctx, player, '#fff');
+  const arcCall = calls.find(c => typeof c === 'object');
+  assert.deepEqual(arcCall, { x: 2048, y: 512, r: 10 });
+});
+
+test('drawPlayer projects corner of view frustum', () => {
+  const { ctx, calls } = createCtx();
+  const player = {
+    position: new THREE.Vector3(-1, -1, 1),
+    r: 10
+  };
+  drawPlayer(ctx, player, '#fff');
+  const arcCall = calls.find(c => typeof c === 'object');
+  const { x, y } = toCanvasPos(player.position, ctx.canvas.width, ctx.canvas.height);
+  assert.deepEqual(arcCall, { x, y, r: 10 });
+});


### PR DESCRIPTION
## Summary
- project player's THREE.Vector3 position onto 2D canvas in `drawPlayer`
- cover projection logic with new `drawPlayer3d` unit test
- expand `drawPlayer3d` tests with negative and frustum corner positions
- log work in TASK_LOG

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff4ae23488331a25b0ea6c77de918