### PR TITLE
feat: add temporal paradox echo effect

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -467,3 +467,7 @@ Verification: npm test – all suites pass.
 2025-10-28 – FR-07 – drawPlayer3d edge cases
 Summary: Expanded drawPlayer3d tests with negative and corner positions to ensure 3D projections map correctly to canvas coordinates.
 Verification: npm test – all suites pass.
+
+2025-10-29 – FR-05 – Temporal Paradox echo
+Summary: Added processing for `paradox_player_echo` effects so the Temporal Paradox core replays the last offensive power from the stored position after 1 s at half damage. Introduced unit test `paradoxEcho.test.js` verifying the replay and cursor restoration.
+Verification: npm test – all suites pass.

--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -5,6 +5,8 @@ import { state } from './state.js';
 import { uvToSpherePos, spherePosToUv } from './utils.js';
 import { getRenderer } from './scene.js';
 import { VR_PROJECTILE_SPEED_SCALE } from './config.js';
+import { usePower } from './powers.js';
+import { gameHelpers } from './gameHelpers.js';
 
 let projectileGroup = null;
 
@@ -216,6 +218,18 @@ export function updateEffects3d(radius = 50){
         const pullRadius = ef.maxRadius * progress;
         state.enemies.forEach(e=>{ if(!e.alive) return; const d = e.position.distanceTo(ef.position); if(d < pullRadius){ const pull = e.boss ? 0.02 : 0.05; e.position.add(ef.position.clone().sub(e.position).multiplyScalar(pull)); if(state.player.purchasedTalents.has('unstable-singularity') && d < ef.radius && now - (ef.lastDamage.get(e)||0) > ef.damageRate){ if(canDamage(ef.caster, e)){ e.takeDamage(ef.damage, ef.caster===state.player); } ef.lastDamage.set(e, now); } }});
         if(now > ef.endTime){ state.effects.splice(i,1); if(state.player.purchasedTalents.has('unstable-singularity')) state.effects.push({ type:'shockwave', caster: ef.caster, position: ef.position.clone(), radius:0, maxRadius:10, speed:30, startTime: now, hitEnemies:new Set(), damage:25*state.player.talent_modifiers.damage_multiplier }); }
+        break;
+      }
+      case 'paradox_player_echo':{
+        if(now - ef.startTime >= 1000){
+          const prevDir = state.cursorDir.clone();
+          state.cursorDir.copy(ef.cursorDir);
+          const origin = { position: ef.position.clone() };
+          usePower(ef.powerKey, true, { origin, damageModifier: 0.5 });
+          state.cursorDir.copy(prevDir);
+          gameHelpers.play && gameHelpers.play('mirrorSwap');
+          state.effects.splice(i,1);
+        }
         break;
       }
       case 'chain_lightning':{

--- a/tests/paradoxEcho.test.js
+++ b/tests/paradoxEcho.test.js
@@ -1,0 +1,51 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+await mock.module('../modules/UIManager.js', {
+  namedExports: { createTextSprite: () => new THREE.Object3D() }
+});
+await mock.module('../modules/scene.js', {
+  namedExports: {
+    getScene: () => null,
+    getCamera: () => null,
+    getRenderer: () => ({}),
+    getPrimaryController: () => null,
+    getSecondaryController: () => null
+  }
+});
+await mock.module('../modules/cores.js', {
+  namedExports: { handleCoreOnDefensivePower: () => {} }
+});
+await mock.module('../modules/CoreManager.js', {
+  namedExports: { onPickup: () => {} }
+});
+
+const { state } = await import('../modules/state.js');
+const { updateEffects3d } = await import('../modules/projectilePhysics3d.js');
+const { initGameHelpers } = await import('../modules/gameHelpers.js');
+
+test('paradox echo replays power after delay', () => {
+  initGameHelpers({ play: () => {}, pulseControllers: () => {}, addStatusEffect: () => {} });
+
+  state.effects.length = 0;
+  state.cursorDir.set(0, 1, 0);
+  const originalDir = state.cursorDir.clone();
+
+  const echo = {
+    type: 'paradox_player_echo',
+    powerKey: 'shockwave',
+    position: new THREE.Vector3(1, 0, 0),
+    cursorDir: new THREE.Vector3(0, 0, -1),
+    startTime: Date.now() - 1000
+  };
+  state.effects.push(echo);
+
+  updateEffects3d(50);
+
+  assert.ok(!state.effects.includes(echo), 'echo effect consumed');
+  const sw = state.effects.find(e => e.type === 'shockwave');
+  assert.ok(sw, 'shockwave spawned');
+  assert.ok(sw.position.distanceTo(new THREE.Vector3(1,0,0)) < 1e-6, 'shockwave at echo position');
+  assert.ok(state.cursorDir.equals(originalDir), 'cursorDir restored');
+});


### PR DESCRIPTION
## Summary
- replay temporal paradox core power after delay
- cover temporal paradox echo with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689000a28ec8833185460fbba6e0b73a