### PR TITLE
feat: render shield power effect

### DIFF
--- a/TASK_LOG.md
+++ b/TASK_LOG.md
@@ -471,3 +471,7 @@ Verification: npm test – all suites pass.
 2025-10-29 – FR-05 – Temporal Paradox echo
 Summary: Added processing for `paradox_player_echo` effects so the Temporal Paradox core replays the last offensive power from the stored position after 1 s at half damage. Introduced unit test `paradoxEcho.test.js` verifying the replay and cursor restoration.
 Verification: npm test – all suites pass.
+
+2025-10-30 – FR-05 – Shield visual effect
+Summary: Implemented a glowing sphere visual for the Shield power. `updateEffects3d` now renders `shield_activation` effects that follow the player and fade as the shield expires. Added unit test `shieldEffect.test.js` verifying mesh lifecycle and updated powers.js to enqueue timed shield effects.
+Verification: npm test – all suites pass.

--- a/modules/powers.js
+++ b/modules/powers.js
@@ -20,13 +20,14 @@ export const powers = {
           duration += talentRank * 1500;
       }
 
-      const shieldEndTime = Date.now() + duration;
+      const startTime = Date.now();
+      const shieldEndTime = startTime + duration;
       state.player.shield = true;
       state.player.shield_end_time = shieldEndTime;
       gameHelpers.addStatusEffect('Shield', '🛡️', duration);
-      
-      // Effect for visuals will be handled in a dedicated rendering loop
-      state.effects.push({ type: 'shield_activation', position: state.player.position.clone() });
+
+      // Queue a visual effect handled by updateEffects3d()
+      state.effects.push({ type: 'shield_activation', startTime, endTime: shieldEndTime });
 
       setTimeout(()=> {
           if(state.player.shield_end_time <= shieldEndTime){

--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -220,6 +220,29 @@ export function updateEffects3d(radius = 50){
         if(now > ef.endTime){ state.effects.splice(i,1); if(state.player.purchasedTalents.has('unstable-singularity')) state.effects.push({ type:'shockwave', caster: ef.caster, position: ef.position.clone(), radius:0, maxRadius:10, speed:30, startTime: now, hitEnemies:new Set(), damage:25*state.player.talent_modifiers.damage_multiplier }); }
         break;
       }
+      case 'shield_activation':{
+        if(!ef.mesh){
+          const geom = new THREE.SphereGeometry(state.player.r * 1.4, 16, 16);
+          const mat = new THREE.MeshBasicMaterial({ color: 0xffff00, transparent: true, opacity: 0.4 });
+          ef.mesh = new THREE.Mesh(geom, mat);
+          if(projectileGroup) projectileGroup.add(ef.mesh);
+        }
+        if(ef.mesh){
+          ef.mesh.position.copy(state.player.position);
+          const total = ef.endTime - ef.startTime;
+          const progress = total > 0 ? (now - ef.startTime) / total : 1;
+          ef.mesh.material.opacity = 0.4 * Math.max(0, 1 - progress);
+        }
+        if(now > ef.endTime || !state.player.shield){
+          if(ef.mesh){
+            if(projectileGroup) projectileGroup.remove(ef.mesh);
+            ef.mesh.geometry.dispose();
+            ef.mesh.material.dispose();
+          }
+          state.effects.splice(i,1);
+        }
+        break;
+      }
       case 'paradox_player_echo':{
         if(now - ef.startTime >= 1000){
           const prevDir = state.cursorDir.clone();

--- a/tests/shieldEffect.test.js
+++ b/tests/shieldEffect.test.js
@@ -1,0 +1,55 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+await mock.module('../modules/UIManager.js', {
+  namedExports: { createTextSprite: () => new THREE.Object3D() }
+});
+await mock.module('../modules/scene.js', {
+  namedExports: {
+    getScene: () => null,
+    getCamera: () => null,
+    getRenderer: () => ({}),
+    getPrimaryController: () => null,
+    getSecondaryController: () => null
+  }
+});
+await mock.module('../modules/cores.js', {
+  namedExports: {
+    handleCoreOnDefensivePower: () => {},
+    handleCoreOnPlayerDamage: () => {}
+  }
+});
+await mock.module('../modules/CoreManager.js', {
+  namedExports: {
+    onPickup: () => {},
+    applyCorePassives: () => {},
+    onCollision: () => {}
+  }
+});
+
+const { state } = await import('../modules/state.js');
+const { updateEffects3d, setProjectileGroup } = await import('../modules/projectilePhysics3d.js');
+const { initGameHelpers } = await import('../modules/gameHelpers.js');
+
+test('shield effect adds and removes mesh', () => {
+  initGameHelpers({ play: () => {}, pulseControllers: () => {}, addStatusEffect: () => {} });
+
+  const group = new THREE.Group();
+  setProjectileGroup(group);
+
+  state.effects.length = 0;
+  state.player.shield = true;
+
+  const start = Date.now();
+  const effect = { type: 'shield_activation', startTime: start, endTime: start + 100 };
+  state.effects.push(effect);
+
+  updateEffects3d(50);
+  assert.equal(group.children.length, 1, 'shield mesh added');
+
+  effect.endTime = Date.now() - 1;
+  updateEffects3d(50);
+  assert.equal(group.children.length, 0, 'shield mesh removed after expiry');
+  assert.ok(!state.effects.includes(effect), 'effect removed');
+});


### PR DESCRIPTION
## Summary
- render shield power as a glowing sphere that fades with its duration
- queue timed shield_activation effect from shield power
- test shield visual effect lifecycle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890029b19288331aa5bd8ddf753149c