### PR TITLE
Implement syphon cone effect for VR adaptation

### DIFF
--- a/modules/agents/SyphonAI.js
+++ b/modules/agents/SyphonAI.js
@@ -31,23 +31,24 @@ export class SyphonAI extends BaseAgent {
       this.isCharging = true;
       gameHelpers.play('chargeUpSound');
 
-      const targetDirection = state.player.position.clone().sub(this.position).normalize();
-
-      // Create a warning cone effect
-      state.effects.push({
+      const effect = {
         type: 'syphon_cone',
         source: this,
-        direction: targetDirection,
+        direction: state.player.position.clone().sub(this.position).normalize(),
+        startTime: now,
         endTime: now + 2500,
-      });
+      };
+
+      // Create a warning cone effect that can track the player
+      state.effects.push(effect);
 
       setTimeout(() => {
         if (!this.alive) return;
 
         const playerDirection = state.player.position.clone().sub(this.position).normalize();
-        const angle = playerDirection.angleTo(targetDirection);
+        const angle = playerDirection.angleTo(effect.direction);
 
-        if (angle < Math.PI / 8) { // Check if player is within the cone's angle
+        if (angle < Math.PI / 8) {
           const stolenPower = state.offensiveInventory[0];
           if (stolenPower) {
             gameHelpers.play('powerAbsorb');
@@ -56,7 +57,7 @@ export class SyphonAI extends BaseAgent {
             // In a fuller implementation, the boss would use the stolen power here
           }
         }
-        
+
         this.isCharging = false;
         this.lastSyphonTime = now + 2500;
       }, 2500);

--- a/tests/syphonConeEffect.test.js
+++ b/tests/syphonConeEffect.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+import { state } from '../modules/state.js';
+import { updateEffects3d } from '../modules/projectilePhysics3d.js';
+
+const ARENA_RADIUS = 50;
+
+test('syphon core effect pulls nearby pickups', () => {
+  // Reset state
+  state.pickups = [{ position: new THREE.Vector3(0, 0, 10), r: 0.5 }];
+  state.effects = [{
+    type: 'syphon_cone',
+    source: state.player,
+    direction: new THREE.Vector3(0, 0, 1),
+    startTime: Date.now() - 1000,
+    endTime: Date.now() - 1,
+  }];
+  state.player.position = new THREE.Vector3(0, 0, 0);
+
+  updateEffects3d(ARENA_RADIUS);
+
+  assert.equal(state.effects.length, 0);
+  assert.equal(state.pickups[0].isSeeking, true);
+});
+
+test('syphon cone from boss tracks player direction', () => {
+  const boss = { position: new THREE.Vector3(0, 0, 0), boss: true };
+  state.player.position = new THREE.Vector3(0, 0, -10);
+  const effect = {
+    type: 'syphon_cone',
+    source: boss,
+    direction: new THREE.Vector3(0, 0, 1),
+    startTime: Date.now(),
+    endTime: Date.now() + 1000,
+  };
+  state.effects = [effect];
+
+  updateEffects3d(ARENA_RADIUS);
+
+  const expected = state.player.position.clone().sub(boss.position).normalize();
+  assert.ok(effect.direction.angleTo(expected) < 1e-6);
+});


### PR DESCRIPTION
## Summary
- Implement syphon cone visual/logic to track the player and pull pickups when triggered by the Syphon core
- Update Syphon boss to emit trackable cone effect for power-stealing attack
- Add unit tests for core pickup pull and boss cone tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689008afcf80833195368b7219b88625