### PR TITLE
Scale core models by 30 percent

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -9,6 +9,7 @@ import { getModalObjects } from './ModalManager.js';
 import { getControllerMenuObjects } from './ControllerMenu.js';
 import { gameHelpers } from './gameHelpers.js';
 import { AssetManager } from './AssetManager.js';
+import { MODEL_SCALE } from './config.js';
 
 let avatar;
 let targetPoint = new THREE.Vector3();
@@ -78,7 +79,7 @@ export async function initPlayerController() {
     const radius = arena.geometry.parameters.radius;
     
     avatar = new THREE.Mesh(
-        new THREE.SphereGeometry(0.5, 16, 16),
+        new THREE.SphereGeometry(0.5 * MODEL_SCALE, 16, 16),
         new THREE.MeshStandardMaterial({ color: 0x3498db, emissive: 0x3498db })
     );
     avatar.name = 'playerAvatar';

--- a/modules/config.js
+++ b/modules/config.js
@@ -97,3 +97,8 @@ export const STAGE_CONFIG = [
 // Scale factor applied to all enemy projectile velocities. Can be tweaked for
 // comfort as the VR movement speed is refined.
 export const VR_PROJECTILE_SPEED_SCALE = 0.85;
+
+// Global scale factor for 3D models. Increasing this value uniformly sizes
+// the player avatar and all spawned enemies to better match the intended VR
+// proportions compared to the legacy 2D game.
+export const MODEL_SCALE = 1.3;

--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -1,6 +1,6 @@
 import * as THREE from '../vendor/three.module.js';
 import { state, savePlayerState } from './state.js';
-import { LEVELING_CONFIG, THEMATIC_UNLOCKS, SPAWN_WEIGHTS, STAGE_CONFIG } from './config.js';
+import { LEVELING_CONFIG, THEMATIC_UNLOCKS, SPAWN_WEIGHTS, STAGE_CONFIG, MODEL_SCALE } from './config.js';
 import { powers } from './powers.js';
 import { bossData } from './bosses.js';
 import { showUnlockNotification, showBossBanner, updateHud } from './UIManager.js';
@@ -210,6 +210,8 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
             const partnerA = new AethelUmbraAI('Aethel');
             partnerA.boss = true;
             partnerA.position.copy(getSafeSpawnLocation());
+            partnerA.scale.multiplyScalar(MODEL_SCALE);
+            partnerA.r = (partnerA.r || 1) * MODEL_SCALE;
             state.enemies.push(partnerA);
             scene.add(partnerA);
 
@@ -218,6 +220,8 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
             partnerA.partner = partnerB;
             partnerB.partner = partnerA;
             partnerB.position.copy(getSafeSpawnLocation());
+            partnerB.scale.multiplyScalar(MODEL_SCALE);
+            partnerB.r = (partnerB.r || 1) * MODEL_SCALE;
             state.enemies.push(partnerB);
             scene.add(partnerB);
             return partnerA;
@@ -226,6 +230,8 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
             const sentinelA = new SentinelPairAI();
             sentinelA.boss = true;
             sentinelA.position.copy(getSafeSpawnLocation());
+            sentinelA.scale.multiplyScalar(MODEL_SCALE);
+            sentinelA.r = (sentinelA.r || 1) * MODEL_SCALE;
             state.enemies.push(sentinelA);
             scene.add(sentinelA);
 
@@ -234,6 +240,8 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
             sentinelB.position.copy(getSafeSpawnLocation());
             sentinelA.partner = sentinelB;
             sentinelB.partner = sentinelA;
+            sentinelB.scale.multiplyScalar(MODEL_SCALE);
+            sentinelB.r = (sentinelB.r || 1) * MODEL_SCALE;
             state.enemies.push(sentinelB);
             scene.add(sentinelB);
             return sentinelA;
@@ -241,12 +249,16 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
         if (bossId === 'obelisk') {
             const obelisk = new ObeliskAI();
             obelisk.boss = true;
+            obelisk.scale.multiplyScalar(MODEL_SCALE);
+            obelisk.r = (obelisk.r || 1) * MODEL_SCALE;
             state.enemies.push(obelisk);
             scene.add(obelisk); // Add Obelisk to scene
             const conduitTypes = [{ type: 'gravity', color: 0x9b59b6 }, { type: 'explosion', color: 0xe74c3c }, { type: 'lightning', color: 0xf1c40f }];
             for(let i = 0; i < 3; i++) {
                 const conduit = new ObeliskConduitAI(obelisk, conduitTypes[i].type, conduitTypes[i].color, (i / 3) * Math.PI * 2);
                 conduit.boss = true;
+                conduit.scale.multiplyScalar(MODEL_SCALE);
+                conduit.r = (conduit.r || 1) * MODEL_SCALE;
                 state.enemies.push(conduit);
                 scene.add(conduit); // Add EACH conduit to scene
             }
@@ -264,6 +276,7 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
         enemy.speed = 2.0;
         enemy.boss = false;
         enemy.isFriendly = false;
+        enemy.r = 0.3; // base radius before global scaling
         enemy.update = function(delta) {
             if (!this.alive) return;
             const direction = state.player.position.clone().sub(this.position).normalize();
@@ -287,6 +300,13 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
     }
 
     enemy.position.copy(spawnPos);
+    // Uniformly scale enemy models and their collision radii
+    enemy.scale.multiplyScalar(MODEL_SCALE);
+    if (enemy.r !== undefined) {
+        enemy.r *= MODEL_SCALE;
+    } else {
+        enemy.r = MODEL_SCALE;
+    }
     state.enemies.push(enemy);
     scene.add(enemy); // ** THE CRITICAL FIX: Add the enemy's 3D object to the scene **
     return enemy;

--- a/modules/state.js
+++ b/modules/state.js
@@ -1,12 +1,12 @@
 import * as THREE from '../vendor/three.module.js';
-import { LEVELING_CONFIG } from './config.js';
+import { LEVELING_CONFIG, MODEL_SCALE } from './config.js';
 
 // The central state object. All game logic reads from and writes to this.
 export const state = {
     // Player and input state
     player: {
         position: new THREE.Vector3(0, 1.6, 0), // Player's 3D position
-        r: 0.5, // Player's 3D radius
+        r: 0.5 * MODEL_SCALE, // Player's 3D radius
         speed: 1.0,
         baseMaxHealth: 100,
         maxHealth: 100,

--- a/task_log.md
+++ b/task_log.md
@@ -15,7 +15,7 @@
     * [ ] Implement animations for all bosses, enemies, and power-ups.
     * [ ] Create a swirling cube animation for the "glitch" enemy.
     * [ ] Ensure all animations are interpolated for VR.
-* [ ] **Sizing:** Increase the size of the player, bosses, and enemies by 30%.
+* [x] **Sizing:** Increase the size of the player, bosses, and enemies by 30%. — Completed
 
 ## UI
 


### PR DESCRIPTION
## Summary
- add a global MODEL_SCALE constant for consistent VR sizing
- enlarge player avatar by 30% and apply same factor when spawning enemies and bosses
- update task log to mark sizing complete

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68902faec8d883319f907e6ebf132f3c