### PR TITLE
Aim missile power-up with VR controller direction

### DIFF
--- a/modules/powers.js
+++ b/modules/powers.js
@@ -65,16 +65,19 @@ export const powers = {
 
       const controller = getPrimaryController();
       const startPos = new THREE.Vector3();
-      if(controller){
+      const aimDir = new THREE.Vector3();
+
+      if (controller) {
           controller.getWorldPosition(startPos);
+          controller.getWorldDirection(aimDir);
           // Offset forward so the fireball spawns at the pointer tip
-          const dir = new THREE.Vector3();
-          controller.getWorldDirection(dir);
-          startPos.add(dir.multiplyScalar(0.1));
+          startPos.add(aimDir.clone().multiplyScalar(0.1));
       } else {
           startPos.copy(origin.position);
+          aimDir.copy(state.cursorDir);
       }
-      const targetPos = state.cursorDir.clone().multiplyScalar(ARENA_RADIUS);
+
+      const targetPos = aimDir.clone().multiplyScalar(ARENA_RADIUS);
       const velocity = targetPos.clone().sub(startPos).normalize().multiplyScalar(VR_PROJECTILE_SPEED_SCALE);
 
       state.effects.push({

--- a/task_log.md
+++ b/task_log.md
@@ -4,7 +4,7 @@
 
 * [ ] **Enemy and Boss Tracking:** Fix the bug causing enemies to move towards the poles.
 * [ ] **Power-up Functionality:**
-    * [ ] Fix the missile power-up.
+    * [x] Fix the missile power-up. — Completed
     * [ ] Ensure all other power-ups are functional.
     * [ ] Implement correct power-up controls for VR controllers.
 

--- a/tests/missileFireball.test.js
+++ b/tests/missileFireball.test.js
@@ -37,7 +37,8 @@ test('missile launches fireball that explodes on target', () => {
   state.offensiveInventory = ['missile', null, null];
 
   state.player.position.set(0, 0, 50);
-  state.cursorDir.set(0, 0, -1);
+  // Intentionally misalign cursor direction; controller orientation should be used
+  state.cursorDir.set(1, 0, 0);
 
   const enemy = {
     position: new THREE.Vector3(0, 0, -50),


### PR DESCRIPTION
## Summary
- Use VR controller orientation to aim missile power-up, ensuring fireball travels where player points
- Cover controller-based aiming with updated missileFireball test
- Update task log to mark missile power-up fix complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689032b624548331b15574d5a6b40c86