### PR TITLE
feat: add base spherical models for enemies

### DIFF
--- a/modules/BaseAgent.js
+++ b/modules/BaseAgent.js
@@ -6,11 +6,23 @@ import * as CoreManager from './CoreManager.js';
 export class BaseAgent extends THREE.Group {
   constructor(options = {}) {
     super();
-    const { health = 1, model = null } = options;
+    const { health = 1, model = null, color = null, radius = 0.65 } = options;
     this.maxHealth = health;
     this.health = health;
     this.alive = true;
-    if (model) this.add(model);
+    if (model) {
+      this.add(model);
+      this.model = model;
+    } else if (color !== null) {
+      const material = new THREE.MeshStandardMaterial({
+        color,
+        emissive: color,
+        emissiveIntensity: 0.5,
+      });
+      const geometry = new THREE.SphereGeometry(radius, 32, 16);
+      this.model = new THREE.Mesh(geometry, material);
+      this.add(this.model);
+    }
   }
 
   update(/* delta, player */) {

--- a/modules/agents/AnnihilatorAI.js
+++ b/modules/agents/AnnihilatorAI.js
@@ -9,13 +9,7 @@ const ARENA_RADIUS = 50;
 
 export class AnnihilatorAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.CylinderGeometry(0.5, 1, 2, 8);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xd63031,
-        emissive: 0xd63031,
-        emissiveIntensity: 0.4
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0xd63031 });
 
     const bossData = { id: "annihilator", name: "The Annihilator", maxHP: 480 };
     this.kind = bossData.id;

--- a/modules/agents/ArchitectAI.js
+++ b/modules/agents/ArchitectAI.js
@@ -7,13 +7,7 @@ const ARENA_RADIUS = 50;
 
 export class ArchitectAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.BoxGeometry(1.2, 1.2, 1.2);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0x7f8c8d,
-        emissive: 0x7f8c8d,
-        emissiveIntensity: 0.2
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0x7f8c8d });
 
     const bossData = { id: "architect", name: "The Architect", maxHP: 280 };
     this.kind = bossData.id;

--- a/modules/agents/CenturionAI.js
+++ b/modules/agents/CenturionAI.js
@@ -7,13 +7,7 @@ const ARENA_RADIUS = 50;
 
 export class CenturionAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.BoxGeometry(1, 1, 1);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xd35400,
-        emissive: 0xd35400,
-        emissiveIntensity: 0.5
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0xd35400 });
 
     const bossData = { id: "centurion", name: "The Centurion", maxHP: 480 };
     this.kind = bossData.id;

--- a/modules/agents/EMPOverloadAI.js
+++ b/modules/agents/EMPOverloadAI.js
@@ -5,13 +5,7 @@ import { gameHelpers } from '../gameHelpers.js';
 
 export class EMPOverloadAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.TorusGeometry(0.8, 0.2, 16, 32);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0x3498db,
-        emissive: 0x3498db,
-        emissiveIntensity: 0.6
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0x3498db });
 
     const bossData = { id: "emp", name: "EMP Overload", maxHP: 260 };
     this.kind = bossData.id;

--- a/modules/agents/EpochEnderAI.js
+++ b/modules/agents/EpochEnderAI.js
@@ -5,15 +5,7 @@ import { gameHelpers } from '../gameHelpers.js';
 
 export class EpochEnderAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.SphereGeometry(0.8, 16, 16);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xbdc3c7,
-        emissive: 0xbdc3c7,
-        emissiveIntensity: 0.2,
-        metalness: 0.9,
-        roughness: 0.4
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0xbdc3c7 });
 
     const bossData = { id: "epoch_ender", name: "The Epoch-Ender", maxHP: 550 };
     this.kind = bossData.id;

--- a/modules/agents/FractalHorrorAI.js
+++ b/modules/agents/FractalHorrorAI.js
@@ -6,13 +6,7 @@ import { gameHelpers } from '../gameHelpers.js';
 export class FractalHorrorAI extends BaseAgent {
   constructor(generation = 1) {
     const size = 1.2 / generation;
-    const geometry = new THREE.DodecahedronGeometry(size, 0);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xbe2edd,
-        emissive: 0xbe2edd,
-        emissiveIntensity: 0.5
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0xbe2edd });
     
     if (generation === 1) {
         const bossData = { id: "fractal_horror", name: "The Fractal Horror", maxHP: 10000 };

--- a/modules/agents/GravityAI.js
+++ b/modules/agents/GravityAI.js
@@ -6,13 +6,7 @@ const ARENA_RADIUS = 50;
 
 export class GravityAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.TorusKnotGeometry(0.7, 0.2, 64, 8);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0x9b59b6,
-        emissive: 0x9b59b6,
-        emissiveIntensity: 0.5
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0x9b59b6 });
 
     const bossData = { id: "gravity", name: "Gravity Tyrant", maxHP: 168 };
     this.kind = bossData.id;

--- a/modules/agents/JuggernautAI.js
+++ b/modules/agents/JuggernautAI.js
@@ -8,15 +8,7 @@ const ARENA_RADIUS = 50;
 
 export class JuggernautAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.CapsuleGeometry(0.8, 1.0, 4, 8);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0x636e72,
-        emissive: 0x636e72,
-        emissiveIntensity: 0.2,
-        metalness: 0.8,
-        roughness: 0.3
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0x636e72 });
 
     const bossData = { id: "juggernaut", name: "The Juggernaut", maxHP: 360 };
     this.kind = bossData.id;

--- a/modules/agents/LoopingEyeAI.js
+++ b/modules/agents/LoopingEyeAI.js
@@ -7,13 +7,7 @@ const ARENA_RADIUS = 50;
 
 export class LoopingEyeAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.SphereGeometry(0.7, 32, 16);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xecf0f1,
-        emissive: 0xecf0f1,
-        emissiveIntensity: 0.8
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0xecf0f1 });
 
     const bossData = { id: "looper", name: "Looping Eye", maxHP: 320 };
     this.kind = bossData.id;

--- a/modules/agents/MiasmaAI.js
+++ b/modules/agents/MiasmaAI.js
@@ -7,13 +7,7 @@ const ARENA_RADIUS = 50;
 
 export class MiasmaAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.TorusKnotGeometry(0.8, 0.2, 100, 12);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0x6ab04c,
-        emissive: 0x6ab04c,
-        emissiveIntensity: 0.4
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0x6ab04c });
 
     const bossData = { id: "miasma", name: "The Miasma", maxHP: 400 };
     this.kind = bossData.id;

--- a/modules/agents/ObeliskAI.js
+++ b/modules/agents/ObeliskAI.js
@@ -8,13 +8,7 @@ const ARENA_RADIUS = 50;
 // The Conduit minions need to be defined as their own class
 export class ObeliskConduitAI extends BaseAgent {
     constructor(parentObelisk, conduitType, color, initialAngle) {
-        const geometry = new THREE.IcosahedronGeometry(0.6, 1);
-        const material = new THREE.MeshStandardMaterial({
-            color: color,
-            emissive: color,
-            emissiveIntensity: 0.7
-        });
-        super({ model: new THREE.Mesh(geometry, material) });
+        super({ color: 0x2c3e50 });
 
         this.maxHP = 250;
         this.health = this.maxHP;

--- a/modules/agents/PantheonAI.js
+++ b/modules/agents/PantheonAI.js
@@ -10,15 +10,7 @@ import { AnnihilatorAI } from './AnnihilatorAI.js';
 
 export class PantheonAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.IcosahedronGeometry(1.2, 1);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xecf0f1,
-        emissive: 0xffffff,
-        emissiveIntensity: 0.2,
-        metalness: 1.0,
-        roughness: 0.1
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0xecf0f1 });
 
     const bossData = { id: "pantheon", name: "The Pantheon", maxHP: 3000 };
     this.kind = bossData.id;

--- a/modules/agents/PuppeteerAI.js
+++ b/modules/agents/PuppeteerAI.js
@@ -5,13 +5,7 @@ import { gameHelpers } from '../gameHelpers.js';
 
 export class PuppeteerAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.SphereGeometry(0.7, 12, 12);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xa29bfe,
-        emissive: 0xa29bfe,
-        emissiveIntensity: 0.6
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0xa29bfe });
     
     const bossData = { id: "puppeteer", name: "The Puppeteer", maxHP: 320 };
     this.kind = bossData.id;

--- a/modules/agents/QuantumShadowAI.js
+++ b/modules/agents/QuantumShadowAI.js
@@ -7,15 +7,7 @@ const ARENA_RADIUS = 50;
 
 export class QuantumShadowAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.SphereGeometry(0.7, 32, 16);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0x81ecec,
-        emissive: 0x81ecec,
-        emissiveIntensity: 0.7,
-        transparent: true,
-        opacity: 1.0
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0x81ecec });
 
     const bossData = { id: "quantum_shadow", name: "Quantum Shadow", maxHP: 360 };
     this.kind = bossData.id;

--- a/modules/agents/SentinelPairAI.js
+++ b/modules/agents/SentinelPairAI.js
@@ -9,13 +9,7 @@ const ARENA_RADIUS = 50;
 
 export class SentinelPairAI extends BaseAgent {
   constructor(partner = null) {
-    const geometry = new THREE.OctahedronGeometry(0.7, 0);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xf1c40f,
-        emissive: 0xf1c40f,
-        emissiveIntensity: 0.6
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0xf1c40f });
     
     const bossData = { id: "sentinel_pair", name: "Sentinel Pair", maxHP: 400 };
     this.kind = bossData.id;

--- a/modules/agents/ShaperOfFateAI.js
+++ b/modules/agents/ShaperOfFateAI.js
@@ -7,13 +7,7 @@ const ARENA_RADIUS = 50;
 
 export class ShaperOfFateAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.OctahedronGeometry(0.9, 1);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xf1c40f,
-        emissive: 0xf1c40f,
-        emissiveIntensity: 0.6
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0xf1c40f });
 
     const bossData = { id: "shaper_of_fate", name: "The Shaper of Fate", maxHP: 600 };
     this.kind = bossData.id;

--- a/modules/agents/SingularityAI.js
+++ b/modules/agents/SingularityAI.js
@@ -7,13 +7,7 @@ const ARENA_RADIUS = 50;
 
 export class SingularityAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.IcosahedronGeometry(1.0, 2);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0x000000,
-        metalness: 0.9,
-        roughness: 0.1
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0x000000 });
 
     const bossData = { id: "singularity", name: "The Singularity", maxHP: 600 };
     this.kind = bossData.id;

--- a/modules/agents/SyphonAI.js
+++ b/modules/agents/SyphonAI.js
@@ -5,13 +5,7 @@ import { gameHelpers } from '../gameHelpers.js';
 
 export class SyphonAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.ConeGeometry(0.6, 1.2, 16);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0x9b59b6,
-        emissive: 0x9b59b6,
-        emissiveIntensity: 0.5
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0x9b59b6 });
 
     const bossData = { id: "syphon", name: "The Syphon", maxHP: 450 };
     this.kind = bossData.id;

--- a/modules/agents/TimeEaterAI.js
+++ b/modules/agents/TimeEaterAI.js
@@ -7,13 +7,7 @@ const ARENA_RADIUS = 50;
 
 export class TimeEaterAI extends BaseAgent {
   constructor() {
-    const geometry = new THREE.TorusGeometry(0.8, 0.3, 16, 32);
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xdfe6e9,
-        emissive: 0xdfe6e9,
-        emissiveIntensity: 0.1
-    });
-    super({ model: new THREE.Mesh(geometry, material) });
+    super({ color: 0xdfe6e9 });
 
     const bossData = { id: "time_eater", name: "Time Eater", maxHP: 440 };
     this.kind = bossData.id;

--- a/task_log.md
+++ b/task_log.md
@@ -11,7 +11,7 @@
 ## 3D Assets and Animations
 
 * [ ] **3D Models and Animations:**
-    * [ ] Create 3D spherical models for all bosses and enemies.
+    * [ ] Create 3D spherical models for all bosses and enemies. — In Progress (most enemies now use base spheres)
     * [ ] Implement animations for all bosses, enemies, and power-ups. — In Progress
     * [x] Create a swirling cube animation for the "glitch" enemy. — Completed
     * [ ] Ensure all animations are interpolated for VR.


### PR DESCRIPTION
## Summary
- add automatic spherical mesh creation in BaseAgent for color-coded enemies
- convert numerous enemy AI classes to use the new spherical model
- note progress on spherical models in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689036ac71e88331897f3a967d393f86