### PR TITLE
Use delta timing for VR effect updates

### DIFF
--- a/modules/vrGameLoop.js
+++ b/modules/vrGameLoop.js
@@ -24,6 +24,7 @@ function updatePhaseMomentum() {
 
 let lastSpawnTime = 0;
 let lastPowerUpTime = 0;
+let lastFrameTime = null;
 
 function handleLevelProgression() {
     const now = Date.now();
@@ -99,7 +100,12 @@ function handlePlayerEnemyCollisions() {
     });
 }
 
-export function vrGameLoop() {
+export function vrGameLoop(timestamp) {
+    if (timestamp === undefined) timestamp = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    if (lastFrameTime === null) lastFrameTime = timestamp;
+    const delta = timestamp - lastFrameTime;
+    lastFrameTime = timestamp;
+
     if (state.gameOver) return;
     if (state.activeModalId) return;
 
@@ -109,15 +115,15 @@ export function vrGameLoop() {
     updatePhaseMomentum();
 
     updateEnemies3d();
-    updateEffects3d();
-    updateProjectiles3d();
+    updateEffects3d(undefined, delta);
+    updateProjectiles3d(undefined, undefined, undefined, delta);
     updatePickups3d();
     handlePlayerEnemyCollisions();
 
     if (state.bossActive) {
         handleBossDefeat();
     }
-    
+
     CoreManager.applyCorePassives(gameHelpers);
 
     if (state.player.health <= 0) {

--- a/task_log.md
+++ b/task_log.md
@@ -14,7 +14,7 @@
     * [ ] Create 3D spherical models for all bosses and enemies. — In Progress (most enemies now use base spheres)
     * [ ] Implement animations for all bosses, enemies, and power-ups. — In Progress
     * [x] Create a swirling cube animation for the "glitch" enemy. — Completed
-    * [ ] Ensure all animations are interpolated for VR.
+    * [ ] Ensure all animations are interpolated for VR. — In Progress (projectiles and effects use delta timing)
 * [x] **Sizing:** Increase the size of the player, bosses, and enemies by 30%. — Completed
 
 ## UI


### PR DESCRIPTION
## Summary
- scale projectile and effect motion by frame time to keep animations smooth across different refresh rates
- compute frame delta in the VR game loop and feed it to projectile/effect updaters
- note interpolation progress in the task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68903968701483318fbf5b5896d7cc5a