### PR TITLE
Fix power-up pickup detection

### DIFF
--- a/modules/state.js
+++ b/modules/state.js
@@ -1,6 +1,8 @@
 import * as THREE from '../vendor/three.module.js';
 import { LEVELING_CONFIG, MODEL_SCALE } from './config.js';
 
+const ARENA_RADIUS = 50; // Should match arena radius in scene.js
+
 // The central state object. All game logic reads from and writes to this.
 export const state = {
     // Player and input state
@@ -132,7 +134,7 @@ export function resetGame(bossData) { // Now accepts bossData to avoid circular 
         }
     }
 
-    state.player.position.set(0, 0, 0);
+    state.player.position.set(0, 0, ARENA_RADIUS);
     state.player.health = state.player.maxHealth;
     state.player.statusEffects = [];
     state.player.activePantheonBuffs = [];

--- a/task_log.md
+++ b/task_log.md
@@ -8,6 +8,7 @@
     * [ ] Ensure all other power-ups are functional.
         * [x] Chain lightning power adapted with 3D beam effect.
     * [ ] Implement correct power-up controls for VR controllers.
+    * [x] Fix bug preventing power-ups from being collected. — Completed
 
 ## 3D Assets and Animations
 

--- a/tests/pickupAfterReset.test.js
+++ b/tests/pickupAfterReset.test.js
@@ -1,0 +1,38 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+// Mock UI and scene dependencies to avoid DOM and WebXR
+await mock.module('../modules/UIManager.js', {
+  namedExports: { createTextSprite: () => new THREE.Object3D() }
+});
+await mock.module('../modules/scene.js', {
+  namedExports: {
+    getScene: () => null,
+    getCamera: () => null,
+    getRenderer: () => ({}),
+    getPrimaryController: () => null
+  }
+});
+await mock.module('../modules/cores.js', {
+  namedExports: { handleCoreOnDefensivePower: () => {} }
+});
+await mock.module('../modules/CoreManager.js', {
+  namedExports: { onPickup: () => {} }
+});
+
+const { state, resetGame } = await import('../modules/state.js');
+const { updatePickups3d } = await import('../modules/pickupPhysics3d.js');
+const { initGameHelpers } = await import('../modules/gameHelpers.js');
+
+test('player collects pickup after resetGame without movement update', () => {
+  const updateHud = mock.fn();
+  initGameHelpers({ play: () => {}, updateHud });
+
+  resetGame();
+  state.cursorDir.set(0, 0, 1);
+  state.pickups.push({ position: new THREE.Vector3(0, 0, 50), r: 0.5, type: 'missile' });
+
+  updatePickups3d(50);
+  assert.equal(state.offensiveInventory[0], 'missile');
+});


### PR DESCRIPTION
## Summary
- Reset player position to the arena surface so power-up collision checks work again
- Add regression test ensuring pickups can be collected after a reset
- Log task completion for fixing power-up collection bug

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68904007d4788331aa742e3b5025a426