### PR TITLE
Run enemy AI updates each frame

### DIFF
--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -277,12 +277,6 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
         enemy.boss = false;
         enemy.isFriendly = false;
         enemy.r = 0.3; // base radius before global scaling
-        enemy.update = function(delta) {
-            if (!this.alive) return;
-            const direction = state.player.position.clone().sub(this.position).normalize();
-            this.position.add(direction.multiplyScalar(this.speed * delta));
-            this.position.normalize().multiplyScalar(ARENA_RADIUS);
-        };
     } else {
         console.error(`AI Class for boss ID "${bossId}" not found!`);
         return null;

--- a/modules/vrGameLoop.js
+++ b/modules/vrGameLoop.js
@@ -114,7 +114,7 @@ export function vrGameLoop(timestamp) {
 
     updatePhaseMomentum();
 
-    updateEnemies3d();
+    updateEnemies3d(undefined, undefined, undefined, delta);
     updateEffects3d(undefined, delta);
     updateProjectiles3d(undefined, undefined, undefined, delta);
     updatePickups3d();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "eternal-momentum-vr",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "eternal-momentum-vr",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/task_log.md
+++ b/task_log.md
@@ -16,8 +16,9 @@
 * [ ] **3D Models and Animations:**
     * [ ] Create 3D spherical models for all bosses and enemies. — In Progress (most enemies now use base spheres)
     * [ ] Implement animations for all bosses, enemies, and power-ups. — In Progress
+        * [x] Enabled delta-based enemy AI updates to support animations.
     * [x] Create a swirling cube animation for the "glitch" enemy. — Completed
-    * [ ] Ensure all animations are interpolated for VR. — In Progress (projectiles and effects use delta timing)
+    * [ ] Ensure all animations are interpolated for VR. — In Progress (projectiles, effects, and enemy AI use delta timing)
 * [x] **Sizing:** Increase the size of the player, bosses, and enemies by 30%. — Completed
 
 ## UI

--- a/tests/enemyUpdateDelta.test.js
+++ b/tests/enemyUpdateDelta.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+import { state } from '../modules/state.js';
+import { updateEnemies3d } from '../modules/enemyAI3d.js';
+
+test('updateEnemies3d calls enemy update with delta', () => {
+  state.enemies.length = 0;
+  state.player.position = new THREE.Vector3(0, 0, 50);
+  const enemy = new THREE.Group();
+  enemy.position.set(50, 0, 0);
+  const start = enemy.position.clone();
+  let called = 0;
+  enemy.update = (d) => { called = d; };
+  enemy.customMovement = true;
+  state.enemies.push(enemy);
+
+  updateEnemies3d(50, undefined, undefined, 32);
+  assert.equal(called, 32);
+  const cross = enemy.position.clone().cross(start);
+  assert.ok(cross.length() < 1e-6);
+});
+
+test('default movement advances enemy when no custom movement', () => {
+  state.enemies.length = 0;
+  state.player.position = new THREE.Vector3(0, 0, 50);
+  const enemy = new THREE.Group();
+  enemy.position.set(50, 0, 0);
+  const start = enemy.position.clone();
+  state.enemies.push(enemy);
+
+  updateEnemies3d(50, undefined, undefined, 32);
+  const cross = enemy.position.clone().cross(start);
+  assert.notEqual(cross.length(), 0);
+  assert.equal(Math.round(enemy.position.length()), 50);
+});


### PR DESCRIPTION
## Summary
- Drive enemy behaviors with a new `updateEnemies3d` routine that accepts delta time, calls each enemy's update function, and applies time-scaled movement.
- Pass frame delta through the VR game loop and streamline minion spawning to rely on centralized movement logic.
- Add unit tests ensuring custom enemy updates receive delta timing while default enemies still move across the sphere.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689044b221dc8331ae1755eadef4d1fd