### PR TITLE
Add 3D shockwave visual effect

### DIFF
--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -212,9 +212,34 @@ export function updateEffects3d(radius = 50, deltaMs = 16){
         break;
       }
       case 'shockwave':{
+        if(!ef.mesh){
+          const geom = new THREE.SphereGeometry(1, 16, 16);
+          const mat = new THREE.MeshBasicMaterial({
+            color: ef.color || 0xffffff,
+            transparent: true,
+            opacity: 0.3,
+            wireframe: true
+          });
+          ef.mesh = new THREE.Mesh(geom, mat);
+          if(projectileGroup) projectileGroup.add(ef.mesh);
+        }
+
         ef.radius += ef.speed * 0.05 * deltaFactor;
+        if(ef.mesh){
+          ef.mesh.position.copy(ef.position);
+          ef.mesh.scale.setScalar(Math.max(ef.radius, 0.001));
+        }
+
         state.enemies.forEach(e=>{ if(e.alive && !ef.hitEnemies.has(e) && e.position.distanceTo(ef.position) < ef.radius + (e.r||0.5)){ if(canDamage(ef.caster, e)){ e.takeDamage(ef.damage, ef.caster===state.player); } const dir = e.position.clone().sub(ef.position).normalize(); e.position.add(dir.multiplyScalar(0.5)); ef.hitEnemies.add(e); }});
-        if(ef.radius >= ef.maxRadius){ state.effects.splice(i,1); }
+
+        if(ef.radius >= ef.maxRadius){
+          if(ef.mesh){
+            if(projectileGroup) projectileGroup.remove(ef.mesh);
+            ef.mesh.geometry.dispose();
+            ef.mesh.material.dispose();
+          }
+          state.effects.splice(i,1);
+        }
         break;
       }
       case 'black_hole':{

--- a/task_log.md
+++ b/task_log.md
@@ -17,6 +17,7 @@
     * [ ] Create 3D spherical models for all bosses and enemies. — In Progress (most enemies now use base spheres)
     * [ ] Implement animations for all bosses, enemies, and power-ups. — In Progress
         * [x] Enabled delta-based enemy AI updates to support animations.
+        * [x] Added expanding sphere visual for the `shockwave` power-up.
     * [x] Create a swirling cube animation for the "glitch" enemy. — Completed
     * [ ] Ensure all animations are interpolated for VR. — In Progress (projectiles, effects, and enemy AI use delta timing)
 * [x] **Sizing:** Increase the size of the player, bosses, and enemies by 30%. — Completed

--- a/tests/shockwaveVisual.test.js
+++ b/tests/shockwaveVisual.test.js
@@ -1,0 +1,64 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+await mock.module('../modules/UIManager.js', {
+  namedExports: { createTextSprite: () => new THREE.Object3D() }
+});
+await mock.module('../modules/scene.js', {
+  namedExports: {
+    getScene: () => null,
+    getCamera: () => null,
+    getRenderer: () => ({}),
+    getPrimaryController: () => null,
+    getSecondaryController: () => null
+  }
+});
+await mock.module('../modules/cores.js', {
+  namedExports: {
+    handleCoreOnDefensivePower: () => {},
+    handleCoreOnPlayerDamage: () => {}
+  }
+});
+await mock.module('../modules/CoreManager.js', {
+  namedExports: {
+    onPickup: () => {},
+    applyCorePassives: () => {},
+    onCollision: () => {}
+  }
+});
+
+const { state } = await import('../modules/state.js');
+const { updateEffects3d, setProjectileGroup } = await import('../modules/projectilePhysics3d.js');
+const { initGameHelpers } = await import('../modules/gameHelpers.js');
+
+const ARENA_RADIUS = 50;
+
+test('shockwave adds and removes visual mesh', () => {
+  initGameHelpers({ play: () => {}, pulseControllers: () => {}, addStatusEffect: () => {} });
+
+  const group = new THREE.Group();
+  setProjectileGroup(group);
+
+  state.effects.length = 0;
+  const effect = {
+    type: 'shockwave',
+    caster: state.player,
+    position: new THREE.Vector3(),
+    radius: 0,
+    maxRadius: 1,
+    speed: 1,
+    startTime: Date.now(),
+    hitEnemies: new Set(),
+    damage: 0
+  };
+  state.effects.push(effect);
+
+  updateEffects3d(ARENA_RADIUS);
+  assert.equal(group.children.length, 1, 'shockwave mesh added');
+
+  effect.radius = effect.maxRadius;
+  updateEffects3d(ARENA_RADIUS);
+  assert.equal(group.children.length, 0, 'shockwave mesh removed');
+  assert.ok(!state.effects.includes(effect), 'effect removed');
+});


### PR DESCRIPTION
## Summary
- Render shockwave power-ups as expanding wireframe spheres in VR
- Cover shockwave mesh lifecycle with a unit test
- Log progress on 3D animation work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890490fbd10833180a6d95565f6121b