### PR TITLE
feat: improve vr menus

### DIFF
--- a/modules/ControllerMenu.js
+++ b/modules/ControllerMenu.js
@@ -3,7 +3,7 @@ import { getSecondaryController } from './scene.js';
 import { showModal } from './ModalManager.js';
 import { AudioManager } from './audio.js';
 import { state } from './state.js';
-import { holoMaterial, createTextSprite, updateTextSprite } from './UIManager.js';
+import { holoMaterial, createTextSprite, updateTextSprite, getBgTexture } from './UIManager.js';
 
 let menuGroup;
 let coreButton, soundBtn;
@@ -12,17 +12,24 @@ let originalUpdateIcon;
 function createButton(label, icon, onSelect) {
   const group = new THREE.Group();
   group.name = `controller_button_${label}`;
-  // Make the background slightly wider to accommodate text and icon
-  const bg = new THREE.Mesh(new THREE.PlaneGeometry(0.2, 0.05), holoMaterial(0x111122, 0.8));
+
+  // Make the background larger and apply the game's hex texture so buttons
+  // resemble their 2D counterparts.
+  const bg = new THREE.Mesh(new THREE.PlaneGeometry(0.24, 0.08), holoMaterial(0x111122, 0.8));
+  const tex = getBgTexture();
+  if (tex) {
+    bg.material.map = tex;
+    bg.material.needsUpdate = true;
+  }
   bg.userData.onSelect = onSelect;
   group.add(bg);
-  
+
   const iconSprite = createTextSprite(icon, 32);
-  iconSprite.position.set(-0.07, 0, 0.01);
+  iconSprite.position.set(-0.09, 0, 0.01);
   group.add(iconSprite);
-  
+
   const textSprite = createTextSprite(label, 24);
-  textSprite.position.set(0.02, 0, 0.01);
+  textSprite.position.set(0.04, 0, 0.01);
   group.add(textSprite);
 
   return group;
@@ -37,6 +44,9 @@ export function initControllerMenu() {
   // Position it to appear attached to the controller
   menuGroup.position.set(0, 0.1, -0.05);
   menuGroup.rotation.x = -0.7; // Angle it for readability
+  // Buttons were tiny compared to the original UI; scaling the whole menu
+  // keeps relative spacing intact while matching the 2D game's footprint.
+  menuGroup.scale.setScalar(1.5);
 
   const stageBtn = createButton('Stages', '🗺️', () => showModal('levelSelect'));
   stageBtn.position.set(0, 0.06, 0);

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -20,10 +20,10 @@ function ensureGroup() {
     if (!modalGroup) {
         modalGroup = new THREE.Group();
         modalGroup.name = 'modalGroup';
-        // Menus were difficult to read because they were tiny. Doubling the
-        // scale here makes every modal roughly twice as large without
-        // altering individual element sizes.
-        modalGroup.scale.setScalar(2);
+        // Menus were difficult to read because they were tiny. Tripling the
+        // scale here makes every modal roughly match the size of the 2D UI
+        // without altering individual element proportions.
+        modalGroup.scale.setScalar(3);
         const scene = getScene();
         if (scene) scene.add(modalGroup);
     }
@@ -662,12 +662,17 @@ function createLoreModal() {
 function createBossInfoModal() {
     const modal = createModalContainer(1.2, 1.0, 'BOSS INFO');
     modal.name = 'modal_bossInfo';
-    const content = createTextSprite('', 28);
-    content.position.set(0, 0.15, 0.01);
+
+    // Left-align wrapped lore text and bump the font size for readability.
+    const content = createTextSprite('', 32, '#eaf2ff', 'left');
+    content.position.set(-0.55, 0.35, 0.01);
+    content.userData.maxWidth = 1.1; // Store for wrapText updates
     modal.add(content);
+
     const closeBtn = createButton('✖', () => hideModal(), 0.12, 0.12, 0xf000ff);
     closeBtn.position.set(0.55, 0.45, 0.02);
     modal.add(closeBtn);
+
     modal.userData.contentSprite = content;
     modal.userData.titleSprite = modal.children.find(c => c.userData.isTitle);
     return modal;
@@ -740,5 +745,12 @@ export function showBossInfo(bossIds, type = 'mechanics') {
         .map(b => wrapText(type === 'lore' ? b.lore : b.mechanics_desc, 60))
         .join('\n\n');
     if (modal.userData.titleSprite) updateTextSprite(modal.userData.titleSprite, title);
-    if (modal.userData.contentSprite) updateTextSprite(modal.userData.contentSprite, content);
+    if (modal.userData.contentSprite) {
+        updateTextSprite(modal.userData.contentSprite, content);
+        const sprite = modal.userData.contentSprite;
+        // Position so text starts at the top-left corner of the modal
+        const width = sprite.scale.x;
+        const height = sprite.scale.y;
+        sprite.position.set(-width / 2, height / 2, sprite.position.z);
+    }
 }

--- a/task_log.md
+++ b/task_log.md
@@ -24,10 +24,11 @@
 
 ## UI
 
-* [x] **Menus:**
+* [ ] **Menus:**
     * [x] Recreate all menus from the 2D game in VR. — Completed
     * [x] Attach menus to the player's left hand. — Completed
     * [x] Ensure menu verbiage and layout are faithful to the original. — Completed
+    * [ ] Restore backgrounds and fix scaling issues. — In Progress
 * [x] **HUD:**
     * [x] Fix the bug preventing power-up emojis from displaying in the inventory.
 


### PR DESCRIPTION
## Summary
- texture and rescale controller buttons for easier VR interaction
- enlarge VR modals and left-align boss lore text for visibility
- update task log for continuing menu polish work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890c197da548331b62b9ad42435e454