### PR TITLE
refactor: centralize healing logic

### DIFF
--- a/modules/cores.js
+++ b/modules/cores.js
@@ -4,7 +4,7 @@ import * as utils from './utils.js';
 import { bossData } from './bosses.js';
 import { showUnlockNotification } from './UIManager.js';
 import { usePower } from './powers.js';
-import { playerHasCore } from './helpers.js';
+import { playerHasCore, applyPlayerHeal } from './helpers.js';
 import { gameHelpers } from './gameHelpers.js';
 
 const ARENA_RADIUS = 50;
@@ -131,7 +131,7 @@ export function applyCoreTickEffects() {
     // Vampire passive regen
     if (playerHasCore('vampire') && now - state.player.talent_states.phaseMomentum.lastDamageTime > 5000) {
         if (state.player.health < state.player.maxHealth) {
-            state.player.health = Math.min(state.player.maxHealth, state.player.health + (0.02 * state.player.maxHealth / 60)); // Heal per frame
+            applyPlayerHeal(0.02 * state.player.maxHealth / 60); // Heal per frame
         }
     }
 
@@ -332,7 +332,7 @@ export function handleCoreOnDamageDealt(target) {
             lifeEnd: Date.now() + 8000,
             isSeeking: true,
             customApply: () => {
-                state.player.health = Math.min(state.player.maxHealth, state.player.health + (state.player.maxHealth * 0.20));
+                applyPlayerHeal(state.player.maxHealth * 0.20);
                 gameHelpers.play('vampireHeal');
             },
         });

--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -8,6 +8,7 @@ import { AudioManager } from './audio.js';
 import { initGameHelpers } from './gameHelpers.js';
 import { getScene } from './scene.js';
 import { uvToSpherePos } from './utils.js';
+import { applyPlayerHeal } from './helpers.js';
 
 // Import all your new 3D AI agent classes
 import { AethelUmbraAI } from './agents/AethelUmbraAI.js';
@@ -140,7 +141,7 @@ export function addEssence(amount) {
             }
             if (gainedHP > 0) {
                 state.player.maxHealth += gainedHP;
-                state.player.health += gainedHP;
+                applyPlayerHeal(gainedHP);
             }
         }
     }

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -102,6 +102,31 @@ export function applyPlayerDamage(amount, source = null, gameHelpers = {}) {
 }
 
 /**
+ * Clamp a numeric value between a minimum and maximum.
+ *
+ * @param {number} value - The input number to clamp.
+ * @param {number} min - Minimum allowed value.
+ * @param {number} max - Maximum allowed value.
+ * @returns {number} The clamped value.
+ */
+export function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Heal the player by a given amount while respecting max health.
+ * Negative values are allowed and will reduce health.
+ *
+ * @param {number} amount - Amount of health to restore.
+ * @returns {number} The player's updated health.
+ */
+export function applyPlayerHeal(amount) {
+  const newHealth = clamp(state.player.health + amount, 0, state.player.maxHealth);
+  state.player.health = newHealth;
+  return newHealth;
+}
+
+/**
  * Insert line breaks so no line exceeds a maximum length.
  * Existing line breaks are preserved.
  * @param {string} text - Input text to wrap.

--- a/modules/pickupPhysics3d.js
+++ b/modules/pickupPhysics3d.js
@@ -5,6 +5,7 @@ import { gameHelpers } from './gameHelpers.js';
 import * as CoreManager from './CoreManager.js';
 import { createTextSprite } from './UIManager.js';
 import { getScene, getCamera } from './scene.js';
+import { applyPlayerHeal } from './helpers.js';
 
 const ARENA_RADIUS = 50; // Should match arena radius in scene.js
 
@@ -79,7 +80,7 @@ export function updatePickups3d(radius = ARENA_RADIUS){
                 continue;
             }
             if(state.player.purchasedTalents.has('essence-weaving')){
-                state.player.health = Math.min(state.player.maxHealth, state.player.health + state.player.maxHealth * 0.02);
+                applyPlayerHeal(state.player.maxHealth * 0.02);
             }
             CoreManager.onPickup();
             if(p.customApply){

--- a/modules/powers.js
+++ b/modules/powers.js
@@ -3,7 +3,7 @@ import { state } from './state.js';
 import * as utils from './utils.js';
 import * as Cores from './cores.js';
 import { gameHelpers } from './gameHelpers.js';
-import { playerHasCore } from './helpers.js';
+import { playerHasCore, applyPlayerHeal } from './helpers.js';
 import { getPrimaryController } from './scene.js';
 import { VR_PROJECTILE_SPEED_SCALE } from './config.js';
 
@@ -41,7 +41,7 @@ export const powers = {
     }
   },
   heal:{emoji:"❤️",desc:"+30 HP",apply:()=>{
-      state.player.health=Math.min(state.player.maxHealth,state.player.health+30);
+      applyPlayerHeal(30);
       gameHelpers.play('pickupSound');
       const now = Date.now();
       state.effects.push({ type: 'heal_sparkle', position: state.player.position.clone(), startTime: now, endTime: now + 800 });

--- a/task_log.md
+++ b/task_log.md
@@ -43,3 +43,12 @@
 
 * [ ] **Code Review and Refactoring:** Review and refactor all modified code.
 * [ ] **Testing:** Thoroughly test all changes.
+
+## Additional Improvements
+
+* [x] Added `clamp` and `applyPlayerHeal` helpers to centralize healing logic.
+* [x] Updated heal power to use the new `applyPlayerHeal` helper.
+* [x] Refactored essence transmutation health gain in `gameLoop` to use `applyPlayerHeal`.
+* [x] Applied centralized healing to the `essence-weaving` talent in `pickupPhysics3d`.
+* [x] Updated vampire core effects to use `applyPlayerHeal` for life-steal.
+* [x] Added unit tests for `clamp` and `applyPlayerHeal`.

--- a/tests/helpersHeal.test.js
+++ b/tests/helpersHeal.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { clamp, applyPlayerHeal } = await import('../modules/helpers.js');
+const { state } = await import('../modules/state.js');
+
+// Reset player health/max for test isolation
+state.player.maxHealth = 100;
+state.player.health = 50;
+
+
+test('clamp constrains values within range', () => {
+  assert.equal(clamp(5, 0, 10), 5);
+  assert.equal(clamp(-5, 0, 10), 0);
+  assert.equal(clamp(15, 0, 10), 10);
+});
+
+test('applyPlayerHeal respects maximum health and allows reduction', () => {
+  applyPlayerHeal(60);
+  assert.equal(state.player.health, 100);
+  applyPlayerHeal(-30);
+  assert.equal(state.player.health, 70);
+});


### PR DESCRIPTION
## Summary
- add clamp and applyPlayerHeal helpers
- refactor heal power, essence transmutation, pickups, and vampire core to use applyPlayerHeal
- cover new helpers with unit tests and update task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890c9e9dda08331b7fc754805212bd5