### PR TITLE
Refactor spherical movement utilities

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -37,6 +37,7 @@ let gripJustPressed = false;
 const tempMatrix = new THREE.Matrix4();
 let hoveredUi = null;
 const assetManager = new AssetManager();
+let lastUpdateTime = typeof performance !== 'undefined' ? performance.now() : Date.now();
 
 function onSelectStart() {
     if (!triggerDown) triggerJustPressed = true;
@@ -201,7 +202,10 @@ export function updatePlayerController() {
 
     if (!state.isPaused && state.player.stunnedUntil < Date.now()) {
         const speedMult = state.player.talent_states.phaseMomentum.active ? 1.1 : 1.0;
-        moveTowards(avatar.position, targetPoint, state.player.speed * speedMult, radius);
+        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        const delta = now - lastUpdateTime;
+        lastUpdateTime = now;
+        moveTowards(avatar.position, targetPoint, state.player.speed * speedMult, radius, delta);
         state.player.position.copy(avatar.position);
     }
     

--- a/task_log.md
+++ b/task_log.md
@@ -4,6 +4,7 @@
 
 * [x] **Enemy and Boss Tracking:** Fix the bug causing enemies to move towards the poles. — Completed
     * Refined spherical movement calculations to avoid pole drift on antipodal targets.
+    * Consolidated movement utilities with shared UV sanitization and delta-aware stepping for player and enemies.
 * [ ] **Power-up Functionality:**
     * [x] Fix the missile power-up. — Completed
     * [x] Ensure all other power-ups are functional.

--- a/tests/movement3d.test.js
+++ b/tests/movement3d.test.js
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
-import { getSphericalDirection } from '../modules/movement3d.js';
+import {
+  getSphericalDirection,
+  sanitizeUv,
+  UV_EPSILON,
+  moveTowards,
+} from '../modules/movement3d.js';
 
 test('getSphericalDirection returns a tangent unit vector toward target', () => {
   const from = new THREE.Vector3(1, 0, 0);
@@ -19,4 +24,21 @@ test('getSphericalDirection handles antipodal points without instability', () =>
   assert.ok(Number.isFinite(dir.length()), 'direction should be a finite vector');
   assert.ok(Math.abs(dir.length() - 1) < 1e-6, 'direction should be unit length');
   assert.ok(Math.abs(dir.dot(from)) < 1e-2, 'direction should be tangent to from');
+});
+
+test('sanitizeUv keeps coordinates within safe bounds', () => {
+  const { u, v } = sanitizeUv({ u: 1.25, v: 1.5 });
+  assert.ok(u >= 0 && u < 1, 'u should wrap to [0,1)');
+  assert.ok(v >= UV_EPSILON && v <= 1 - UV_EPSILON, 'v should be clamped away from poles');
+});
+
+test('moveTowards respects delta time and stays on sphere', () => {
+  const radius = 1;
+  const start1 = new THREE.Vector3(0, 0, 1);
+  const start2 = start1.clone();
+  const target = new THREE.Vector3(0, 1, 0);
+  moveTowards(start1, target, 1, radius, 16);
+  moveTowards(start2, target, 1, radius, 32);
+  assert.ok(Math.abs(start1.length() - radius) < 1e-6, 'movement should remain on sphere');
+  assert.ok(start2.distanceTo(target) < start1.distanceTo(target), 'larger delta should move farther');
 });


### PR DESCRIPTION
## Summary
- centralize UV sanitization and delta-aware `moveTowards` in `movement3d`
- reuse shared helpers in enemy AI and player controller for stable sphere navigation
- cover movement utilities with unit tests and update task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890cd4bde6c8331913d83d7148fc8d3