### PR TITLE
Refactor power-up inventory handling for reliability

### DIFF
--- a/modules/PowerManager.js
+++ b/modules/PowerManager.js
@@ -1,33 +1,86 @@
 // modules/PowerManager.js
 //
-// Central manager for triggering offensive and defensive powers.
-// Exposes simple wrapper functions used by the PlayerController
-// so input handling doesn't need to know about inventory slots.
+// Centralized management for power-up inventory and usage.
+// Handles adding powers, consuming them, and applying associated effects.
 
 import { state } from './state.js';
-import { usePower } from './powers.js';
+import { usePower, offensivePowers, powers } from './powers.js';
 import { gameHelpers } from './gameHelpers.js';
+import { playerHasCore } from './helpers.js';
+
+function consumeFirstSlot(inventory) {
+  inventory.shift();
+  inventory.push(null);
+}
+
+/**
+ * Attempt to add a power-up to the appropriate inventory queue.
+ * If the queue is full and the player has the overload-protocol talent,
+ * the power is automatically used as a free cast.
+ * @param {string} powerKey
+ * @returns {boolean} true if the power was added or auto-used
+ */
+export function addPowerToInventory(powerKey) {
+  const isOffensive = offensivePowers.includes(powerKey);
+  const inv = isOffensive ? state.offensiveInventory : state.defensiveInventory;
+  const max = isOffensive ? state.player.unlockedOffensiveSlots : state.player.unlockedDefensiveSlots;
+  const idx = inv.indexOf(null);
+
+  if (idx !== -1 && idx < max) {
+    inv[idx] = powerKey;
+    if (gameHelpers.updateHud) gameHelpers.updateHud();
+    return true;
+  }
+
+  if (state.player.purchasedTalents.has('overload-protocol')) {
+    gameHelpers.addStatusEffect?.('Auto-Used', powers[powerKey]?.emoji || '?', 2000);
+    usePower(powerKey, true);
+    return true;
+  }
+
+  return false;
+}
+
+function useFromInventory(inventory, powerKey, options = {}) {
+  let consumed = true;
+  if (state.player.purchasedTalents.has('energetic-recycling') && Math.random() < 0.20) {
+    consumed = false;
+  }
+  if (playerHasCore('singularity') && Math.random() < 0.15) {
+    consumed = false;
+  }
+  if (!consumed) {
+    gameHelpers.addStatusEffect?.('Recycled', '♻️', 2000);
+  }
+
+  usePower(powerKey, !consumed, options);
+
+  if (consumed) {
+    consumeFirstSlot(inventory);
+  }
+
+  if (gameHelpers.updateHud) gameHelpers.updateHud();
+}
 
 /**
  * Use the offensive power in the first inventory slot.
- * @param {object} [options] optional parameters passed to the power
+ * @param {object} [options]
  */
 export function useOffensivePower(options = {}) {
   const key = state.offensiveInventory[0];
   if (key) {
-    usePower(key, false, options);
-    if (gameHelpers.updateHud) gameHelpers.updateHud();
+    useFromInventory(state.offensiveInventory, key, options);
   }
 }
 
 /**
  * Use the defensive power in the first inventory slot.
- * @param {object} [options] optional parameters passed to the power
+ * @param {object} [options]
  */
 export function useDefensivePower(options = {}) {
   const key = state.defensiveInventory[0];
   if (key) {
-    usePower(key, false, options);
-    if (gameHelpers.updateHud) gameHelpers.updateHud();
+    useFromInventory(state.defensiveInventory, key, options);
   }
 }
+

--- a/modules/pickupPhysics3d.js
+++ b/modules/pickupPhysics3d.js
@@ -1,8 +1,9 @@
 import * as THREE from '../vendor/three.module.js';
 import { state } from './state.js';
-import { offensivePowers, powers, usePower } from './powers.js';
+import { powers } from './powers.js';
 import { gameHelpers } from './gameHelpers.js';
 import * as CoreManager from './CoreManager.js';
+import { addPowerToInventory } from './PowerManager.js';
 import { createTextSprite } from './UIManager.js';
 import { getScene, getCamera } from './scene.js';
 import { applyPlayerHeal } from './helpers.js';
@@ -86,17 +87,7 @@ export function updatePickups3d(radius = ARENA_RADIUS){
             if(p.customApply){
                 p.customApply();
             }else{
-                const isOff = offensivePowers.includes(p.type);
-                const inv = isOff ? state.offensiveInventory : state.defensiveInventory;
-                const maxSlots = isOff ? state.player.unlockedOffensiveSlots : state.player.unlockedDefensiveSlots;
-                const idx = inv.indexOf(null);
-                if(idx !== -1 && idx < maxSlots){
-                    inv[idx] = p.type;
-                    if(gameHelpers.updateHud) gameHelpers.updateHud();
-                }else if(state.player.purchasedTalents.has('overload-protocol')){
-                    gameHelpers.addStatusEffect('Auto-Used', powers[p.type]?.emoji || '?', 2000);
-                    usePower(p.type, true);
-                }
+                addPowerToInventory(p.type);
             }
             removeMesh(p);
             state.pickups.splice(i,1);

--- a/modules/powers.js
+++ b/modules/powers.js
@@ -291,31 +291,10 @@ export const offensivePowers = ['shockwave', 'missile', 'chain', 'orbitalStrike'
 export function usePower(powerKey, isFreeCast = false, options = {}){
   const power = powers[powerKey];
   if (!power) return;
-  
+
   const { play, addStatusEffect } = gameHelpers;
   const queueType = offensivePowers.includes(powerKey) ? 'offensive' : 'defensive';
-  let consumed = !isFreeCast;
 
-  if (consumed) {
-      let recycled = false;
-      if (state.player.purchasedTalents.has('energetic-recycling') && Math.random() < 0.20) {
-          recycled = true;
-      }
-      if (playerHasCore('singularity') && Math.random() < 0.15) {
-          recycled = true;
-      }
-      if (recycled) {
-          addStatusEffect('Recycled', '♻️', 2000);
-          consumed = false;
-      }
-  }
-
-  if (consumed) {
-      const inventory = queueType === 'offensive' ? state.offensiveInventory : state.defensiveInventory;
-      inventory.shift();
-      inventory.push(null);
-  }
-  
   const applyArgs = [options];
   
   if (queueType === 'offensive' && playerHasCore('temporal_paradox')) {

--- a/task_log.md
+++ b/task_log.md
@@ -53,3 +53,4 @@
 * [x] Applied centralized healing to the `essence-weaving` talent in `pickupPhysics3d`.
 * [x] Updated vampire core effects to use `applyPlayerHeal` for life-steal.
 * [x] Added unit tests for `clamp` and `applyPlayerHeal`.
+* [x] Centralized power-up inventory management in `PowerManager` for reliability.

--- a/tests/powerManager.test.js
+++ b/tests/powerManager.test.js
@@ -1,0 +1,51 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+// Mock UI and scene dependencies to avoid DOM and WebXR
+await mock.module('../modules/UIManager.js', {
+  namedExports: { createTextSprite: () => new THREE.Object3D() }
+});
+await mock.module('../modules/scene.js', {
+  namedExports: {
+    getScene: () => null,
+    getCamera: () => null,
+    getRenderer: () => ({}),
+    getPrimaryController: () => null
+  }
+});
+await mock.module('../modules/cores.js', {
+  namedExports: { handleCoreOnDefensivePower: () => {} }
+});
+await mock.module('../modules/CoreManager.js', {
+  namedExports: { onPickup: () => {} }
+});
+
+const { state } = await import('../modules/state.js');
+const { addPowerToInventory, useOffensivePower } = await import('../modules/PowerManager.js');
+const { initGameHelpers } = await import('../modules/gameHelpers.js');
+
+test('adding power and recycling does not consume inventory', () => {
+  const updateHud = mock.fn();
+  const addStatusEffect = mock.fn();
+  initGameHelpers({ play: () => {}, updateHud, addStatusEffect });
+
+  state.offensiveInventory = [null, null, null];
+  state.player.unlockedOffensiveSlots = 3;
+  state.player.purchasedTalents = new Map();
+
+  addPowerToInventory('missile');
+  assert.equal(state.offensiveInventory[0], 'missile');
+  assert.equal(updateHud.mock.calls.length, 1);
+
+  state.player.purchasedTalents.set('energetic-recycling', 1);
+  const originalRandom = Math.random;
+  Math.random = () => 0; // Ensure recycling triggers
+  useOffensivePower();
+  Math.random = originalRandom;
+
+  assert.equal(state.offensiveInventory[0], 'missile');
+  assert.equal(addStatusEffect.mock.calls[0].arguments[0], 'Recycled');
+  assert.equal(updateHud.mock.calls.length, 2);
+});
+


### PR DESCRIPTION
## Summary
- centralize power-up inventory logic with new PowerManager helpers
- simplify `usePower` to focus on applying effects
- delegate pickup collection to PowerManager and add recycling test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890da0e505c8331a158ab38e32ea363