### PR TITLE
fix: harden pooling and helpers

### DIFF
--- a/modules/ProjectileManager.js
+++ b/modules/ProjectileManager.js
@@ -4,15 +4,28 @@ const pool = [];
 const active = [];
 
 export function spawnProjectile(props = {}) {
-  const p = pool.pop() || {};
-  p.position = (props.position instanceof THREE.Vector3)
-    ? props.position.clone()
-    : new THREE.Vector3(props.x || 0, props.y || 0, props.z || 0);
-  p.velocity = (props.velocity instanceof THREE.Vector3)
-    ? props.velocity.clone()
-    : new THREE.Vector3(props.dx || 0, props.dy || 0, props.dz || 0);
-  p.r = props.r ?? p.r ?? 0;
-  p.damage = props.damage ?? p.damage ?? 0;
+  const p = pool.pop() || {
+    position: new THREE.Vector3(),
+    velocity: new THREE.Vector3(),
+    r: 0,
+    damage: 0,
+    alive: true,
+  };
+
+  if (props.position instanceof THREE.Vector3) {
+    p.position.copy(props.position);
+  } else {
+    p.position.set(props.x || 0, props.y || 0, props.z || 0);
+  }
+
+  if (props.velocity instanceof THREE.Vector3) {
+    p.velocity.copy(props.velocity);
+  } else {
+    p.velocity.set(props.dx || 0, props.dy || 0, props.dz || 0);
+  }
+
+  p.r = props.r ?? 0;
+  p.damage = props.damage ?? 0;
   p.alive = true;
   active.push(p);
   return p;
@@ -34,7 +47,10 @@ export function updateProjectiles(stepFn, collisionFn) {
 
 export function resetProjectiles() {
   while (active.length) {
-    pool.push(active.pop());
+    const p = active.pop();
+    p.alive = false;
+    if (p.velocity && p.velocity.isVector3) p.velocity.set(0, 0, 0);
+    pool.push(p);
   }
 }
 

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -10,6 +10,7 @@ import * as CoreManager from './CoreManager.js';
  * @returns {boolean} True if the core is active
  */
 export function playerHasCore(coreId){
+  if (!coreId) return false;
   if (state.player.equippedAberrationCore === coreId) return true;
   return state.player.activePantheonBuffs.some(buff => buff.coreId === coreId);
 }
@@ -22,6 +23,9 @@ export function playerHasCore(coreId){
  */
 export function getCanvasPos(obj){
   if (!obj) return { x: 0, y: 0 };
+  if (obj.isVector3) {
+    return toCanvasPos(obj);
+  }
   if (obj.position && obj.position.isVector3){
     return toCanvasPos(obj.position);
   }
@@ -44,8 +48,10 @@ export function getCanvasPos(obj){
 export function setPositionFromCanvas(target, x, y, width = 2048, height = 1024){
   width = width > 0 ? width : 1;
   height = height > 0 ? height : 1;
-  const u = ((x / width) - 0.5 + 1) % 1;
-  const v = y / height;
+  const clampedX = Math.min(width, Math.max(0, x));
+  const clampedY = Math.min(height, Math.max(0, y));
+  const u = ((clampedX / width) - 0.5 + 1) % 1;
+  const v = clampedY / height;
   const vec = uvToSpherePos(u, v, 1);
   if (target && target.isVector3){
     return target.copy(vec);

--- a/task_log.md
+++ b/task_log.md
@@ -54,3 +54,4 @@
 * [x] Updated vampire core effects to use `applyPlayerHeal` for life-steal.
 * [x] Added unit tests for `clamp` and `applyPlayerHeal`.
 * [x] Centralized power-up inventory management in `PowerManager` for reliability.
+* [x] Hardened projectile pooling and coordinate helpers to reset reused objects and validate inputs.

--- a/tests/helpersEdgeCases.test.js
+++ b/tests/helpersEdgeCases.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+const { getCanvasPos, setPositionFromCanvas, playerHasCore } = await import('../modules/helpers.js');
+const { spherePosToUv } = await import('../modules/utils.js');
+const { state } = await import('../modules/state.js');
+
+test('getCanvasPos accepts Vector3 instances', () => {
+  const original = new THREE.Vector3(0.3, -0.2, 0.9).normalize();
+  const { x, y } = getCanvasPos(original);
+  const reconstructed = new THREE.Vector3();
+  setPositionFromCanvas(reconstructed, x, y);
+  assert.ok(reconstructed.distanceTo(original) < 1e-6);
+});
+
+test('setPositionFromCanvas clamps out-of-range coordinates', () => {
+  const vec = new THREE.Vector3();
+  setPositionFromCanvas(vec, -50, 5000, 100, 100);
+  const uv = spherePosToUv(vec);
+  assert.ok(uv.u >= 0 && uv.u <= 1);
+  assert.ok(uv.v >= 0 && uv.v <= 1);
+});
+
+test('playerHasCore returns false for falsy ids', () => {
+  state.player.equippedAberrationCore = null;
+  state.player.activePantheonBuffs = [];
+  assert.equal(playerHasCore(null), false);
+});

--- a/tests/projectileManager.test.js
+++ b/tests/projectileManager.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+const {
+  spawnProjectile,
+  resetProjectiles,
+  getActiveProjectiles,
+} = await import('../modules/ProjectileManager.js');
+
+// Helper to clear state between tests
+function clearProjectiles() {
+  resetProjectiles();
+}
+
+test('pooled projectiles reset core properties', () => {
+  clearProjectiles();
+  const first = spawnProjectile({ r: 2, damage: 5, velocity: new THREE.Vector3(1,0,0) });
+  // Simulate cleanup
+  resetProjectiles();
+  const second = spawnProjectile();
+  assert.equal(second.r, 0);
+  assert.equal(second.damage, 0);
+  assert.ok(second.velocity.lengthSq() === 0);
+  clearProjectiles();
+});
+
+test('resetProjectiles clears active array and marks projectiles dead', () => {
+  clearProjectiles();
+  const p = spawnProjectile({ velocity: new THREE.Vector3(1,2,3) });
+  resetProjectiles();
+  assert.equal(getActiveProjectiles().length, 0);
+  const recycled = spawnProjectile();
+  assert.ok(recycled.alive);
+  assert.ok(recycled.velocity.lengthSq() === 0);
+  clearProjectiles();
+});


### PR DESCRIPTION
## Summary
- ensure projectile pooling resets properties and zeroes velocity
- guard core checks and improve canvas coordinate conversions
- add unit tests for projectile manager and helper edge cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890de250b5083319ca569583e4b0a35