### PR TITLE
Align game over menu title with original 2D styling

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -63,7 +63,7 @@ function createButton(label, onSelect, width = 0.5, height = 0.1, color = 0x00ff
     return group;
 }
 
-function createModalContainer(width, height, title) {
+function createModalContainer(width, height, title, options = {}) {
     const group = new THREE.Group();
     const bg = new THREE.Mesh(new THREE.PlaneGeometry(width, height), holoMaterial(0x1e1e2f, 0.95));
     const tex = getBgTexture();
@@ -73,7 +73,8 @@ function createModalContainer(width, height, title) {
     group.add(bg, border);
 
     if (title) {
-        const titleSprite = createTextSprite(title, 48);
+        const { titleColor = '#eaf2ff', titleShadowColor = null, titleShadowBlur = 0 } = options;
+        const titleSprite = createTextSprite(title, 48, titleColor, 'center', titleShadowColor, titleShadowBlur);
         titleSprite.position.set(0, height / 2 - 0.1, 0.01);
         titleSprite.userData.isTitle = true; // Mark this as the title sprite
         group.add(titleSprite);
@@ -681,7 +682,11 @@ function createBossInfoModal() {
 function createGameOverModal() {
     // Mirror the horizontal layout of the 2D game's game over menu by making
     // the container wider and arranging the buttons in a single row.
-    const modal = createModalContainer(1.4, 1.0, 'TIMELINE COLLAPSED');
+    const modal = createModalContainer(1.4, 1.0, 'TIMELINE COLLAPSED', {
+        titleColor: '#e74c3c',
+        titleShadowColor: '#e74c3c',
+        titleShadowBlur: 15
+    });
     modal.name = 'modal_gameOver';
 
     const btnWidth = 0.3;

--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -39,7 +39,7 @@ export function holoMaterial(color = 0x1e1e2f, opacity = 0.85) {
   });
 }
 
-export function createTextSprite(text, size = 32, color = '#eaf2ff', align = 'center') {
+export function createTextSprite(text, size = 32, color = '#eaf2ff', align = 'center', shadowColor = null, shadowBlur = 0) {
     const lines = String(text).split('\n');
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
@@ -50,6 +50,13 @@ export function createTextSprite(text, size = 32, color = '#eaf2ff', align = 'ce
     canvas.width = Math.max(1, width);
     canvas.height = size * 1.2 * lines.length;
     ctx.font = `${size}px ${fontStack}`;
+    if (shadowColor) {
+        ctx.shadowColor = shadowColor;
+        ctx.shadowBlur = shadowBlur;
+    } else {
+        ctx.shadowColor = 'transparent';
+        ctx.shadowBlur = 0;
+    }
     ctx.fillStyle = color;
     ctx.textBaseline = 'middle';
     ctx.textAlign = align;
@@ -68,7 +75,7 @@ export function createTextSprite(text, size = 32, color = '#eaf2ff', align = 'ce
     const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), material);
     const scale = 0.001;
     mesh.scale.set(canvas.width * scale, canvas.height * scale, 1);
-    mesh.userData = { text, canvas, ctx, font: `${size}px ${fontStack}`, color, size, align };
+    mesh.userData = { text, canvas, ctx, font: `${size}px ${fontStack}`, color, size, align, shadowColor, shadowBlur };
     return mesh;
 }
 
@@ -76,7 +83,7 @@ export function updateTextSprite(sprite, newText) {
     if (!sprite || !sprite.userData || sprite.userData.text === newText) return; // Don't update if text is the same
 
     sprite.userData.text = newText;
-    const { ctx, canvas, font, color, size, align } = sprite.userData;
+    const { ctx, canvas, font, color, size, align, shadowColor, shadowBlur } = sprite.userData;
     if (!ctx || !canvas) return;
     ctx.font = font;
     const lines = String(newText).split('\n');
@@ -86,6 +93,13 @@ export function updateTextSprite(sprite, newText) {
     canvas.height = size * 1.2 * lines.length;
     ctx.font = font;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (shadowColor) {
+        ctx.shadowColor = shadowColor;
+        ctx.shadowBlur = shadowBlur;
+    } else {
+        ctx.shadowColor = 'transparent';
+        ctx.shadowBlur = 0;
+    }
     ctx.fillStyle = color;
     ctx.textBaseline = 'middle';
     ctx.textAlign = align;

--- a/task_log.md
+++ b/task_log.md
@@ -57,3 +57,4 @@
 * [x] Hardened projectile pooling and coordinate helpers to reset reused objects and validate inputs.
 * [x] Improved inventory overflow handling, projectile pooling cleanup, enemy update skipping of dead entities, stable spherical direction math and optional radius parameter for canvas-to-sphere conversions.
 * [x] Reworked game over menu to mirror the 2D game's horizontal button layout.
+* [x] Matched game over title color and glow to the 2D game's design.


### PR DESCRIPTION
## Summary
- allow text sprites to render with optional shadow/glow
- let modal containers specify custom title colors and shadows
- style game over modal title with red glow to match the 2D game's "TIMELINE COLLAPSED" banner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890e9b003f48331a75c65f057ad22e3