### PR TITLE
Align VR stage menu with 2D design

### DIFF
--- a/modules/ControllerMenu.js
+++ b/modules/ControllerMenu.js
@@ -59,7 +59,7 @@ export function initControllerMenu() {
   // keeps relative spacing intact while matching the 2D game's footprint.
   menuGroup.scale.setScalar(1.5);
 
-  const stageBtn = createButton('Stages', '🗺️', () => showModal('levelSelect'));
+  const stageBtn = createButton('Stage Select', '🗺️', () => showModal('levelSelect'));
   stageBtn.position.set(0, 0.06, 0);
   menuGroup.add(stageBtn);
 

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -9,10 +9,16 @@ import { purchaseTalent, isTalentVisible, getConstellationColorOfTalent } from '
 import { holoMaterial, createTextSprite, updateTextSprite, getBgTexture } from './UIManager.js';
 import { gameHelpers } from './gameHelpers.js';
 import { disposeGroupChildren, wrapText } from './helpers.js';
+import { STAGE_CONFIG } from './config.js';
 
 let modalGroup;
 const modals = {};
 let confirmCallback;
+
+function getBossesForStage(stageNum) {
+    const stageData = STAGE_CONFIG.find(s => s.stage === stageNum);
+    return stageData ? stageData.bosses : [];
+}
 
 // --- UTILITY FUNCTIONS ---
 
@@ -292,9 +298,9 @@ function createStageSelectModal() {
         disposeGroupChildren(listContainer);
         arenaBtn.visible = state.player.highestStageBeaten >= 30;
         const maxStage = state.player.highestStageBeaten + 1;
-        for (let i = 1; i <= Math.min(maxStage, 30); i++) {
-            const bossIds = bossData.filter(b => b.unlock_level === (i * 5 - 5) + 10).map(b => b.id);
-            if (!bossIds.length) continue;
+        for (let i = 1; i <= maxStage; i++) {
+            const bossIds = getBossesForStage(i);
+            if (!bossIds || bossIds.length === 0) continue;
             const bossNames = bossIds.map(id => {
                 const b = bossData.find(x => x.id === id);
                 return b ? b.name : 'Unknown';
@@ -332,9 +338,9 @@ function createStageSelectModal() {
             });
             row.add(stageText, bossText);
 
-            const mechBtn = createButton('❔', () => showBossInfo(bossIds, 'mechanics'), 0.12, 0.12, 0xf1c40f);
+            const mechBtn = createButton('❔', () => showBossInfo(bossIds, 'mechanics'), 0.12, 0.12, 0xf1c40f, 0xf1c40f, 0xf1c40f, 0.2);
             mechBtn.position.set(0.35, 0.02, 0.01);
-            const loreBtn = createButton('ℹ️', () => showBossInfo(bossIds, 'lore'), 0.12, 0.12, 0x9b59b6);
+            const loreBtn = createButton('ℹ️', () => showBossInfo(bossIds, 'lore'), 0.12, 0.12, 0x9b59b6, 0x9b59b6, 0x9b59b6, 0.2);
             loreBtn.position.set(0.35, -0.04, 0.01);
             row.add(mechBtn, loreBtn);
 

--- a/task_log.md
+++ b/task_log.md
@@ -37,7 +37,8 @@
     * [x] Attach menus to the player's left hand. — Completed
     * [x] Ensure menu verbiage and layout are faithful to the original. — Completed
 * [x] Restore backgrounds and fix scaling issues. — Completed
-* [x] Recreate stage select layout and styling to mirror the 2D game's menu. — Completed
+* [x] Recreate stage select layout and styling to mirror the 2D game's menu.
+    * [x] Reworked stage list to use original stage configuration and match button colors.
 * [x] **HUD:**
     * [x] Fix the bug preventing power-up emojis from displaying in the inventory.
 

--- a/tests/ascensionNexus.test.js
+++ b/tests/ascensionNexus.test.js
@@ -44,7 +44,7 @@ async function setup() {
   });
 
   await mock.module('../modules/gameHelpers.js', {
-    namedExports: { gameHelpers: {} }
+    namedExports: { gameHelpers: {}, initGameHelpers: () => {} }
   });
 
   await mock.module('../modules/UIManager.js', {
@@ -63,7 +63,8 @@ async function setup() {
       },
       updateTextSprite: () => {},
       getBgTexture: () => null,
-      showUnlockNotification: () => {}
+      showUnlockNotification: () => {},
+      showBossBanner: () => {}
     }
   });
 


### PR DESCRIPTION
## Summary
- Rename controller button to "Stage Select" for consistency with the original game
- Populate stage list using original STAGE_CONFIG and restore yellow/purple info buttons
- Log stage menu work in task log and adjust tests for new imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890ef95e270833184de7061a1e758f6