### PR TITLE
Refine stage select menu to mirror original UI

### DIFF
--- a/task_log.md
+++ b/task_log.md
@@ -39,6 +39,7 @@
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.
     * [x] Reworked stage list to use original stage configuration and match button colors.
+    * [x] Matched text alignment, long-name scrolling, and initial scroll position to the 2D stage menu.
 * [x] **HUD:**
     * [x] Fix the bug preventing power-up emojis from displaying in the inventory.
 


### PR DESCRIPTION
## Summary
- Add text scrolling helper and extend scrollbar to start at bottom
- Align stage select row content and animate long boss names
- Update task log for stage menu improvements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890f2d985d88331b2c41f5e4b264b7a