### PR TITLE
Refine stage select to mirror 2D menu

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -381,9 +381,9 @@ function createStageSelectModal() {
             if (row.children[2]) row.children[2].visible = false; // hide default label
 
             const stageText = createTextSprite(`STAGE ${i}`, 32, '#00ffff', 'left');
-            stageText.position.set(-0.42, 0.02, 0.01);
+            stageText.position.set(-0.43, 0.02, 0.01);
             const bossText = createTextSprite(bossNames, 24, '#eaf2ff', 'left');
-            bossText.position.set(-0.42, -0.04, 0.01);
+            bossText.position.set(-0.43, -0.04, 0.01);
             enableTextScroll(bossText, 0.6);
 
             const handleHover = hovered => {
@@ -401,10 +401,19 @@ function createStageSelectModal() {
 
             row.add(stageText, bossText);
 
-            const mechBtn = createButton('❔', () => showBossInfo(bossIds, 'mechanics'), 0.12, 0.12, 0xf1c40f, 0xf1c40f, 0xf1c40f, 0.2, 'circle');
-            mechBtn.position.set(0.25, 0, 0.01);
-            const loreBtn = createButton('ℹ️', () => showBossInfo(bossIds, 'lore'), 0.12, 0.12, 0x9b59b6, 0x9b59b6, 0x9b59b6, 0.2, 'circle');
-            loreBtn.position.set(0.39, 0, 0.01);
+            const mechBtn = createButton('❔', () => showBossInfo(bossIds, 'mechanics'), 0.12, 0.12, 0xf1c40f, 0xf1c40f, 0xffffff, 0.2, 'circle');
+            const loreBtn = createButton('ℹ️', () => showBossInfo(bossIds, 'lore'), 0.12, 0.12, 0x9b59b6, 0x9b59b6, 0xffffff, 0.2, 'circle');
+            const setupInfoBtnHover = (btn) => {
+                const btnBg = btn.children[0];
+                btn.userData.onHover = hovered => {
+                    btnBg.material.opacity = hovered ? 0.4 : 0.2;
+                    handleHover(hovered);
+                };
+            };
+            mechBtn.position.set(0.19, 0, 0.01);
+            loreBtn.position.set(0.34, 0, 0.01);
+            setupInfoBtnHover(mechBtn);
+            setupInfoBtnHover(loreBtn);
             row.add(mechBtn, loreBtn);
 
             row.position.y = 0.4 - (i - 1) * 0.15;

--- a/task_log.md
+++ b/task_log.md
@@ -41,6 +41,7 @@
     * [x] Reworked stage list to use original stage configuration and match button colors.
     * [x] Matched text alignment, long-name scrolling, and initial scroll position to the 2D stage menu.
     * [x] Aligned mechanics and lore buttons horizontally with circular styling to match the 2D stage menu.
+    * [x] Synced row highlight with info button hover and matched button placement/opacity to the 2D version.
 * [x] **HUD:**
     * [x] Fix the bug preventing power-up emojis from displaying in the inventory.
 

--- a/tests/vrMain.test.js
+++ b/tests/vrMain.test.js
@@ -84,14 +84,16 @@ async function setupLaunch() {
 
 test('desktop fallback displays HUD without XR button', async (t) => {
   mock.reset();
-  global.navigator = {};
+  Object.defineProperty(global, 'navigator', { value: {}, writable: true, configurable: true });
   const { launchVR, showHud, bodyAppend, createButton } = await setupLaunch();
+
+  const setNavigator = (val) => Object.defineProperty(global, 'navigator', { value: val, writable: true, configurable: true });
 
   await t.test('when navigator.xr is missing', async () => {
     showHud.mock.resetCalls();
     bodyAppend.mock.resetCalls();
     createButton.mock.resetCalls();
-    global.navigator = {};
+    setNavigator({});
     await launchVR();
     assert.equal(showHud.mock.calls.length, 1);
     assert.equal(bodyAppend.mock.calls.length, 0);
@@ -102,7 +104,7 @@ test('desktop fallback displays HUD without XR button', async (t) => {
     showHud.mock.resetCalls();
     bodyAppend.mock.resetCalls();
     createButton.mock.resetCalls();
-    global.navigator = { xr: { isSessionSupported: async () => false } };
+    setNavigator({ xr: { isSessionSupported: async () => false } });
     await launchVR();
     assert.equal(showHud.mock.calls.length, 1);
     assert.equal(bodyAppend.mock.calls.length, 0);


### PR DESCRIPTION
## Summary
- Align stage select text and info buttons with the 2D game's layout, including synced hover highlighting and button opacity
- Update task log for refined stage select work
- Stabilize VR launch test by defining navigator property

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890f74b9df08331b7bb870348d2c54e