### PR TITLE
style: mirror 2d ascension menu styling

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -596,10 +596,12 @@ function createAscensionModal() {
 
     function createApDisplay() {
         const group = new THREE.Group();
-        const bg = new THREE.Mesh(new THREE.PlaneGeometry(0.5, 0.15), holoMaterial(0x111122, 0.95));
-        const border = new THREE.Mesh(new THREE.PlaneGeometry(0.52, 0.17), holoMaterial(0x00ffff, 0.5));
+        // Match the 2D game's semi-transparent header box and cyan border.
+        const bg = new THREE.Mesh(new THREE.PlaneGeometry(0.5, 0.15), holoMaterial(0x000000, 0.3));
+        const border = new THREE.Mesh(new THREE.PlaneGeometry(0.52, 0.17), holoMaterial(0x00ffff, 0.4));
         border.position.z = -0.001;
-        const label = createTextSprite('ASCENSION POINTS', 24, '#ffffff');
+        // The label text uses a dimmer white to simulate 70% opacity.
+        const label = createTextSprite('ASCENSION POINTS', 24, '#cccccc');
         label.position.set(0, 0.035, 0.01);
         const value = createTextSprite(`${state.player.ascensionPoints}`, 32, '#00ffff');
         value.position.set(0, -0.045, 0.01);
@@ -611,6 +613,17 @@ function createAscensionModal() {
     const apDisplay = createApDisplay();
     apDisplay.position.set(0.55, 0.58, 0.01);
     modal.add(apDisplay);
+
+    // Divider lines to mirror the 2D modal's header and footer borders.
+    const headerDivider = new THREE.Mesh(new THREE.PlaneGeometry(1.55, 0.01), holoMaterial(0x00ffff, 0.4));
+    headerDivider.position.set(0, 0.45, 0.02);
+    headerDivider.name = 'ascension_header_divider';
+    modal.add(headerDivider);
+
+    const footerDivider = new THREE.Mesh(new THREE.PlaneGeometry(1.55, 0.01), holoMaterial(0x00ffff, 0.4));
+    footerDivider.position.set(0, -0.45, 0.02);
+    footerDivider.name = 'ascension_footer_divider';
+    modal.add(footerDivider);
 
     let tooltip;
     function createTalentTooltip() {
@@ -752,7 +765,7 @@ function createAscensionModal() {
         updateTextSprite(apDisplay.userData.value, `${state.player.ascensionPoints}`);
     };
 
-    const closeBtn = createButton('CLOSE', () => hideModal(), 0.6, 0.1, 0xf000ff);
+    const closeBtn = createButton('CLOSE', () => hideModal(), 0.6, 0.1, 0xf000ff, 0xf000ff, 0xffffff);
     closeBtn.position.set(0.45, -0.6, 0.01);
     modal.add(closeBtn);
 
@@ -765,7 +778,7 @@ function createAscensionModal() {
                 window.location.reload();
             }
         );
-    }, 0.6, 0.1, 0xe74c3c);
+    }, 0.6, 0.1, 0xe74c3c, 0xc0392b, 0xffffff);
     clearBtn.position.set(-0.45, -0.6, 0.01);
     modal.add(clearBtn);
 

--- a/task_log.md
+++ b/task_log.md
@@ -36,6 +36,7 @@
     * [x] Recreate all menus from the 2D game in VR. — Completed
     * [x] Attach menus to the player's left hand. — Completed
     * [x] Ensure menu verbiage and layout are faithful to the original. — Completed
+    * [x] Refined Ascension Conduit menu with header/footer dividers and button colors matching the 2D game.
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.
     * [x] Reworked stage list to use original stage configuration and match button colors.

--- a/tests/ascensionNexus.test.js
+++ b/tests/ascensionNexus.test.js
@@ -54,11 +54,12 @@ async function setup() {
         emissive: new THREE.Color(color),
         emissiveIntensity: 1,
         transparent: true,
-        opacity
+        opacity,
+        dispose: () => {}
       }),
       createTextSprite: () => {
         const obj = new THREE.Object3D();
-        obj.material = { color: new THREE.Color(0xffffff) };
+        obj.material = { color: new THREE.Color(0xffffff), dispose: () => {} };
         return obj;
       },
       updateTextSprite: () => {},
@@ -68,20 +69,48 @@ async function setup() {
     }
   });
 
-  const { initModals, showModal } = await import('../modules/ModalManager.js');
-  return { scene, initModals, showModal };
+  const { initModals, showModal, getModalObjects } = await import('../modules/ModalManager.js');
+  return { scene, initModals, showModal, getModalObjects };
 }
 
 test('nexus talents use green border color', async () => {
-  const { scene, initModals, showModal } = await setup();
+  const { initModals, showModal, getModalObjects } = await setup();
   initModals();
   showModal('ascension');
-  const modalGroup = scene.children[0];
-  const ascensionModal = modalGroup.children.find(c => c.name === 'modal_ascension');
+  const ascensionModal = getModalObjects().find(m => m.name === 'modal_ascension');
   assert.ok(ascensionModal);
   const grid = ascensionModal.children.find(c => c.position && c.position.y === -0.1);
   const nexusButton = grid.children.find(c => c.userData && c.userData.talentId === 'core-nexus');
   assert.ok(nexusButton, 'core nexus button should exist');
   const border = nexusButton.children[1];
   assert.equal(border.material.color.getHex(), 0x00ff00);
+});
+
+test('ascension modal buttons mirror 2D colors', async () => {
+  const { initModals, showModal, getModalObjects } = await setup();
+  initModals();
+  showModal('ascension');
+  const ascensionModal = getModalObjects().find(m => m.name === 'modal_ascension');
+  assert.ok(ascensionModal);
+
+  const closeBtn = ascensionModal.children.find(c => c.name === 'button_CLOSE');
+  assert.ok(closeBtn, 'close button should exist');
+  const closeBg = closeBtn.children[0];
+  const closeText = closeBtn.children[2];
+  assert.equal(closeBg.material.color.getHex(), 0xf000ff);
+  assert.equal(closeText.material.color.getHex(), 0xffffff);
+
+  const clearBtn = ascensionModal.children.find(c => c.name === 'button_ERASE_TIMELINE');
+  assert.ok(clearBtn, 'clear button should exist');
+  const clearBg = clearBtn.children[0];
+  const clearText = clearBtn.children[2];
+  assert.equal(clearBg.material.color.getHex(), 0xc0392b);
+  assert.equal(clearText.material.color.getHex(), 0xffffff);
+
+  const headerLine = ascensionModal.children.find(c => c.name === 'ascension_header_divider');
+  const footerLine = ascensionModal.children.find(c => c.name === 'ascension_footer_divider');
+  assert.ok(headerLine);
+  assert.ok(footerLine);
+  assert.equal(headerLine.material.color.getHex(), 0x00ffff);
+  assert.equal(footerLine.material.color.getHex(), 0x00ffff);
 });


### PR DESCRIPTION
## Summary
- Style the VR Ascension Conduit menu like the 2D original: cyan dividers, semi-transparent AP box, and button colors that match legacy UI
- Update close/erase buttons to use magenta/red backgrounds with white text
- Expand unit tests to verify ascension menu color scheme and dividers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68910af24b988331b3e04397dd07792f