### PR TITLE
Mirror Ascension Conduit menu to 2D design

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -592,10 +592,21 @@ export function getModalByName(id) {
 }
 
 function createAscensionModal() {
-    const modal = createModalContainer(1.6, 1.4, 'ASCENSION CONDUIT');
+    // The 2D menu uses `--primary-glow` (#00ffff) with a 10px text-shadow
+    // on the "ASCENSION CONDUIT" header. Recreate that neon title here so
+    // editors know the color and blur come from the original design.
+    const modal = createModalContainer(1.6, 1.4, 'ASCENSION CONDUIT', {
+        titleColor: '#00ffff',
+        titleShadowColor: '#00ffff',
+        titleShadowBlur: 10
+    });
     modal.name = 'modal_ascension';
+
+    // In the 2D layout the `ascension-content` div is centered with
+    // `margin:auto` and given an `aspect-ratio:16/9`. Leaving this group at
+    // the modal origin centers the grid the same way in 3D.
     const grid = new THREE.Group();
-    grid.position.y = -0.1;
+    grid.name = 'ascension_grid';
     modal.add(grid);
 
     const lines = new THREE.Group();
@@ -618,10 +629,11 @@ function createAscensionModal() {
     }
 
     const apDisplay = createApDisplay();
-    apDisplay.position.set(0.55, 0.58, 0.01);
+    apDisplay.position.set(0.55, 0.55, 0.01);
     modal.add(apDisplay);
 
-    // Divider lines to mirror the 2D modal's header and footer borders.
+    // Divider lines mirror the 1px cyan borders (`--border-color` =
+    // rgba(0,255,255,0.4)) that sit above and below the 2D modal content.
     const headerDivider = new THREE.Mesh(new THREE.PlaneGeometry(1.55, 0.01), holoMaterial(0x00ffff, 0.4));
     headerDivider.position.set(0, 0.45, 0.02);
     headerDivider.name = 'ascension_header_divider';
@@ -665,7 +677,15 @@ function createAscensionModal() {
                 if (key === 'color') return;
                 const t = con[key];
                 allTalents[key] = t;
-                positions[t.id] = new THREE.Vector3((t.position.x / 50 - 1) * 0.7, (1 - t.position.y / 50) * 0.6, 0.01);
+                // The 2D grid stores talent positions on a 0–100 x/y canvas
+                // that sits inside a 1920×1080 (16:9) panel. Dividing by 50
+                // recenters those coordinates around 0, then scaling to
+                // 1.6×0.9 meters preserves the original 16:9 framing.
+                positions[t.id] = new THREE.Vector3(
+                    (t.position.x / 50 - 1) * 0.8,
+                    (1 - t.position.y / 50) * 0.45,
+                    0.01
+                );
             });
         });
 
@@ -718,11 +738,11 @@ function createAscensionModal() {
                                 `Rank: ${purchased}/${t.isInfinite ? '∞' : t.maxRanks}  Cost: ${displayCost}`
                             );
                             const basePos = positions[t.id];
-                            let offsetX = 0.25;
-                            if (basePos.x > 0.35) offsetX = -0.25;
-                            else if (basePos.x < -0.35) offsetX = 0.25;
-                            let offsetY = 0.15;
-                            if (basePos.y > 0.3) offsetY = -0.15;
+                            let offsetX = 0.3;
+                            if (basePos.x > 0.4) offsetX = -0.3;
+                            else if (basePos.x < -0.4) offsetX = 0.3;
+                            let offsetY = 0.12;
+                            if (basePos.y > 0.25) offsetY = -0.12;
                             tooltip.position.copy(basePos).add(new THREE.Vector3(offsetX, offsetY, 0));
                             tooltip.visible = true;
                         } else if (tooltip) {

--- a/task_log.md
+++ b/task_log.md
@@ -37,6 +37,8 @@
     * [x] Attach menus to the player's left hand. — Completed
     * [x] Ensure menu verbiage and layout are faithful to the original. — Completed
     * [x] Refined Ascension Conduit menu with header/footer dividers and button colors matching the 2D game.
+    * [x] Synced Ascension Conduit title glow and 16:9 talent grid with the 2D version.
+    * [x] Documented 2D layout rationale inside Ascension Conduit modal comments.
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.
     * [x] Reworked stage list to use original stage configuration and match button colors.

--- a/tests/ascensionNexus.test.js
+++ b/tests/ascensionNexus.test.js
@@ -79,7 +79,7 @@ test('nexus talents use green border color', async () => {
   showModal('ascension');
   const ascensionModal = getModalObjects().find(m => m.name === 'modal_ascension');
   assert.ok(ascensionModal);
-  const grid = ascensionModal.children.find(c => c.position && c.position.y === -0.1);
+  const grid = ascensionModal.children.find(c => c.name === 'ascension_grid');
   const nexusButton = grid.children.find(c => c.userData && c.userData.talentId === 'core-nexus');
   assert.ok(nexusButton, 'core nexus button should exist');
   const border = nexusButton.children[1];


### PR DESCRIPTION
## Summary
- Match Ascension Conduit modal title color and glow to the original 2D menu
- Scale and center the talent grid to a 16:9 layout and adjust tooltip offsets
- Update tests and task log for the refined menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689111a47cf8833199ddf67efd3363d5