### PR TITLE
Align Ascension Conduit header with original layout

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -140,6 +140,7 @@ function createModalContainer(width, height, title, options = {}) {
         backgroundOpacity = 0.95,
         borderColor = 0x00ffff,
         borderOpacity = 0.5,
+        titleAlign = 'center'
     } = options;
 
     const bg = new THREE.Mesh(new THREE.PlaneGeometry(width, height), holoMaterial(backgroundColor, backgroundOpacity));
@@ -154,8 +155,15 @@ function createModalContainer(width, height, title, options = {}) {
     }
 
     if (title) {
-        const titleSprite = createTextSprite(title, 48, titleColor, 'center', titleShadowColor, titleShadowBlur);
-        titleSprite.position.set(0, height / 2 - 0.1, 0.01);
+        const titleSprite = createTextSprite(title, 48, titleColor, titleAlign, titleShadowColor, titleShadowBlur);
+        const margin = 0.1;
+        let x = 0;
+        if (titleAlign === 'left') {
+            x = -width / 2 + margin + titleSprite.scale.x / 2;
+        } else if (titleAlign === 'right') {
+            x = width / 2 - margin - titleSprite.scale.x / 2;
+        }
+        titleSprite.position.set(x, height / 2 - 0.1, 0.01);
         titleSprite.userData.isTitle = true; // Mark this as the title sprite
         group.add(titleSprite);
     }
@@ -592,11 +600,14 @@ export function getModalByName(id) {
 }
 
 function createAscensionModal() {
-    // Match the 2D game's cyan title and glow.
-    const modal = createModalContainer(1.6, 1.4, 'ASCENSION CONDUIT', {
+    const width = 1.6;
+    const height = 1.4;
+    // Match the 2D game's cyan title, glow, and left-aligned header.
+    const modal = createModalContainer(width, height, 'ASCENSION CONDUIT', {
         titleColor: '#00ffff',
         titleShadowColor: '#00ffff',
-        titleShadowBlur: 10
+        titleShadowBlur: 10,
+        titleAlign: 'left'
     });
     modal.name = 'modal_ascension';
 
@@ -631,13 +642,14 @@ function createAscensionModal() {
         }
 
         group.add(bg, border, label, value);
-        group.userData = { value, updateLayout };
+        group.userData = { value, updateLayout, bgWidth };
         updateLayout();
         return group;
     }
 
     const apDisplay = createApDisplay();
-    apDisplay.position.set(0.55, 0.55, 0.01);
+    const headerY = height / 2 - 0.1;
+    apDisplay.position.set(width / 2 - apDisplay.userData.bgWidth / 2 - 0.1, headerY, 0.01);
     modal.add(apDisplay);
 
     // Divider lines to mirror the 2D modal's header and footer borders.

--- a/task_log.md
+++ b/task_log.md
@@ -39,6 +39,7 @@
     * [x] Refined Ascension Conduit menu with header/footer dividers and button colors matching the 2D game.
     * [x] Synced Ascension Conduit title glow and 16:9 talent grid with the 2D version.
     * [x] Aligned Ascension Point header with side-by-side label and value to match the 2D layout.
+    * [x] Left-aligned Ascension Conduit title and right-aligned AP display to mirror the original menu.
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.
     * [x] Reworked stage list to use original stage configuration and match button colors.


### PR DESCRIPTION
## Summary
- Add `titleAlign` option to modal container helper for flexible title placement
- Left-align Ascension Conduit title and right-align AP header to mirror the 2D menu
- Log header alignment update in task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689117acb87c8331b02fb5200a659cfe