### PR TITLE
Refine Ascension Conduit menu

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -118,6 +118,7 @@ function createButton(
         bg.material.emissiveIntensity = intensity;
         border.material.emissiveIntensity = intensity;
         group.scale.setScalar(hovered ? 1.05 : 1);
+        if (hovered) AudioManager.playSfx('uiHoverSound');
     };
 
     [bg, border, text].forEach(obj => {
@@ -628,8 +629,11 @@ function createAscensionModal() {
         const border = new THREE.Mesh(new THREE.PlaneGeometry(bgWidth + 0.02, bgHeight + 0.02), holoMaterial(0x00ffff, 0.4));
         border.position.z = -0.001;
 
-        // The label text uses a dimmer white to simulate 70% opacity.
-        const label = createTextSprite('ASCENSION POINTS', 24, '#cccccc', 'left');
+        // Use the same cyan/white pairing as the 2D header and tone the label
+        // opacity down to 70% to mirror its semi-transparent styling.
+        const label = createTextSprite('ASCENSION POINTS', 24, '#eaf2ff', 'left');
+        label.material.opacity = 0.7;
+        label.material.transparent = true;
         const value = createTextSprite(`${state.player.ascensionPoints}`, 32, '#00ffff', 'left');
 
         const padding = 0.02;
@@ -743,6 +747,7 @@ function createAscensionModal() {
                     btn.position.copy(positions[t.id]);
                     btn.userData.onHover = hovered => {
                         if (hovered) {
+                            AudioManager.playSfx('uiHoverSound');
                             let displayCost;
                             if (isMax) displayCost = 'MAXED';
                             else displayCost = `${cost} AP`;

--- a/task_log.md
+++ b/task_log.md
@@ -40,6 +40,7 @@
     * [x] Synced Ascension Conduit title glow and 16:9 talent grid with the 2D version.
     * [x] Aligned Ascension Point header with side-by-side label and value to match the 2D layout.
     * [x] Left-aligned Ascension Conduit title and right-aligned AP display to mirror the original menu.
+    * [x] Restored AP header styling and hover sound cues to match the 2D Ascension interface.
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.
     * [x] Reworked stage list to use original stage configuration and match button colors.


### PR DESCRIPTION
## Summary
- Add hover sound feedback to modal buttons and talent nodes for authentic 2D feel
- Restore Ascension Point header styling with cyan/white text and 70% label opacity
- Update task log to record Ascension Conduit polish

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68911986d5608331bdff55167b8c187f