### PR TITLE
Align ascension conduit grid with 2D layout

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -695,15 +695,22 @@ function createAscensionModal() {
         grid.add(tooltip);
         const positions = {};
         const allTalents = {};
+        // The 2D game used a 16:9 talent grid nested inside the modal with
+        // small horizontal padding.  Mirror that exact layout so constellations
+        // line up with their original coordinates.
+        const gridWidth = 1.55; // matches header/footer divider width
+        const gridHeight = gridWidth * 9 / 16;
+        const halfW = gridWidth / 2;
+        const halfH = gridHeight / 2;
+
         Object.values(TALENT_GRID_CONFIG).forEach(con => {
             Object.keys(con).forEach(key => {
                 if (key === 'color') return;
                 const t = con[key];
                 allTalents[key] = t;
-                // Scale the grid to the 16:9 aspect ratio of the 2D game.
                 positions[t.id] = new THREE.Vector3(
-                    (t.position.x / 50 - 1) * 0.8,
-                    (1 - t.position.y / 50) * 0.45,
+                    (t.position.x / 100) * gridWidth - halfW,
+                    halfH - (t.position.y / 100) * gridHeight,
                     0.01
                 );
             });
@@ -760,10 +767,12 @@ function createAscensionModal() {
                             );
                             const basePos = positions[t.id];
                             let offsetX = 0.3;
-                            if (basePos.x > 0.4) offsetX = -0.3;
-                            else if (basePos.x < -0.4) offsetX = 0.3;
+                            const xBoundary = halfW - 0.4;
+                            if (basePos.x > xBoundary) offsetX = -0.3;
+                            else if (basePos.x < -xBoundary) offsetX = 0.3;
                             let offsetY = 0.12;
-                            if (basePos.y > 0.25) offsetY = -0.12;
+                            const yBoundary = halfH - 0.2;
+                            if (basePos.y > yBoundary) offsetY = -0.12;
                             tooltip.position.copy(basePos).add(new THREE.Vector3(offsetX, offsetY, 0));
                             tooltip.visible = true;
                         } else if (tooltip) {

--- a/task_log.md
+++ b/task_log.md
@@ -41,6 +41,7 @@
     * [x] Aligned Ascension Point header with side-by-side label and value to match the 2D layout.
     * [x] Left-aligned Ascension Conduit title and right-aligned AP display to mirror the original menu.
     * [x] Restored AP header styling and hover sound cues to match the 2D Ascension interface.
+    * [x] Realigned talent nodes and connector lines so constellations mirror the 2D arrangement exactly.
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.
     * [x] Reworked stage list to use original stage configuration and match button colors.


### PR DESCRIPTION
## Summary
- Match 2D talent constellation layout by scaling the VR ascension grid to the original modal's 16:9 dimensions
- Adjust tooltip positioning logic to respect new grid bounds
- Log the constellation alignment work in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68911c9ca1d083318739cbc6c7f96e58