### PR TITLE
feat: mirror 2D ascension menu

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -741,14 +741,26 @@ function createAscensionModal() {
                     } else if (canPurchase) {
                         borderColor = 0x00ff00;
                     }
+                    const onSelect = () => {
+                        if (!isMax && canPurchase) {
+                            purchaseTalent(t.id);
+                        } else if (!isMax && prereqsMet) {
+                            AudioManager.playSfx('talentError');
+                        } else {
+                            AudioManager.playSfx('uiClickSound');
+                        }
+                        modal.userData.refresh();
+                    };
                     const btn = createButton(
                         t.icon,
-                        () => { purchaseTalent(t.id); modal.userData.refresh(); },
+                        onSelect,
                         0.12,
                         0.12,
                         borderColor,
                         0x111122,
-                        0xffffff
+                        0xffffff,
+                        0.8,
+                        'circle'
                     );
                     btn.userData.talentId = t.id;
                     btn.position.copy(positions[t.id]);

--- a/task_log.md
+++ b/task_log.md
@@ -42,6 +42,7 @@
     * [x] Left-aligned Ascension Conduit title and right-aligned AP display to mirror the original menu.
     * [x] Restored AP header styling and hover sound cues to match the 2D Ascension interface.
     * [x] Realigned talent nodes and connector lines so constellations mirror the 2D arrangement exactly.
+    * [x] Switched talent nodes to circular buttons and mirrored 2D click responses.
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.
     * [x] Reworked stage list to use original stage configuration and match button colors.


### PR DESCRIPTION
## Summary
- Use circular buttons for ascension talents and mirror 2D menu click behaviour
- Log updated to reflect ascension conduit parity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68911e02fb548331ab275c003f724ea5