### PR TITLE
feat: add ascension modal glow

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -612,6 +612,16 @@ function createAscensionModal() {
     });
     modal.name = 'modal_ascension';
 
+    // Add a subtle cyan glow behind the container to mirror the 2D game's
+    // box-shadow effect around the Ascension Conduit modal.
+    const glow = new THREE.Mesh(
+        new THREE.PlaneGeometry(width + 0.2, height + 0.2),
+        holoMaterial(0x00ffff, 0.15)
+    );
+    glow.position.z = -0.005;
+    glow.renderOrder = -1;
+    modal.add(glow);
+
     // Center the talent grid and keep a referenceable name for tests.
     const grid = new THREE.Group();
     grid.name = 'ascension_grid';

--- a/task_log.md
+++ b/task_log.md
@@ -38,6 +38,7 @@
     * [x] Ensure menu verbiage and layout are faithful to the original. — Completed
     * [x] Refined Ascension Conduit menu with header/footer dividers and button colors matching the 2D game.
     * [x] Synced Ascension Conduit title glow and 16:9 talent grid with the 2D version.
+    * [x] Added cyan glow around Ascension Conduit modal to mirror the 2D box-shadow.
     * [x] Aligned Ascension Point header with side-by-side label and value to match the 2D layout.
     * [x] Left-aligned Ascension Conduit title and right-aligned AP display to mirror the original menu.
     * [x] Restored AP header styling and hover sound cues to match the 2D Ascension interface.


### PR DESCRIPTION
## Summary
- mirror the 2D game's box-shadow by adding a subtle cyan glow behind the Ascension Conduit modal
- document ascension menu glow work in task log

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68911f4b1cfc8331917187facf65aa0d