### PR TITLE
fix: ensure menu elements render above panels

### DIFF
--- a/modules/ControllerMenu.js
+++ b/modules/ControllerMenu.js
@@ -25,6 +25,7 @@ function createButton(label, icon, onSelect) {
 
   // Apply the game's hex texture so buttons resemble their 2D counterparts.
   const bg = new THREE.Mesh(new THREE.PlaneGeometry(totalWidth, 0.08), holoMaterial(0x111122, 0.8));
+  bg.renderOrder = 0;
   const tex = getBgTexture();
   if (tex) {
     bg.material.map = tex;
@@ -32,6 +33,7 @@ function createButton(label, icon, onSelect) {
   }
   const border = new THREE.Mesh(new THREE.PlaneGeometry(totalWidth + 0.01, 0.09), holoMaterial(0x00ffff, 0.5));
   border.position.z = -0.001;
+  border.renderOrder = -1;
   group.add(bg, border);
 
   // Position icon and text with even padding from the left edge.

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -100,11 +100,13 @@ function createButton(
     }
 
     const bg = new THREE.Mesh(bgGeom, holoMaterial(bgColor, bgOpacity));
+    bg.renderOrder = 0;
     const tex = getBgTexture();
     if (tex) { bg.material.map = tex; bg.material.needsUpdate = true; }
 
     const border = new THREE.Mesh(borderGeom, holoMaterial(color, 0.5));
     border.position.z = -0.001;
+    border.renderOrder = -1;
 
     const txtColor = textColor !== undefined ? textColor : color;
     const colorObj = new THREE.Color(txtColor);
@@ -145,6 +147,7 @@ function createModalContainer(width, height, title, options = {}) {
     } = options;
 
     const bg = new THREE.Mesh(new THREE.PlaneGeometry(width, height), holoMaterial(backgroundColor, backgroundOpacity));
+    bg.renderOrder = 0;
     const tex = getBgTexture();
     if (tex) { bg.material.map = tex; bg.material.needsUpdate = true; }
     group.add(bg);
@@ -152,6 +155,7 @@ function createModalContainer(width, height, title, options = {}) {
     if (borderOpacity > 0) {
         const border = new THREE.Mesh(new THREE.PlaneGeometry(width + 0.02, height + 0.02), holoMaterial(borderColor, borderOpacity));
         border.position.z = -0.001;
+        border.renderOrder = -1;
         group.add(border);
     }
 

--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -35,7 +35,8 @@ export function holoMaterial(color = 0x1e1e2f, opacity = 0.85) {
     transparent: true,
     opacity,
     side: THREE.DoubleSide,
-    depthTest: false
+    depthTest: false,
+    depthWrite: false
   });
 }
 
@@ -79,9 +80,11 @@ export function createTextSprite(
         map: texture,
         transparent: true,
         depthTest: false,
+        depthWrite: false,
         side: THREE.DoubleSide
     });
     const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), material);
+    mesh.renderOrder = 1;
     const scale = 0.001;
     mesh.scale.set(canvas.width * scale, canvas.height * scale, 1);
     mesh.userData = { text, canvas, ctx, font, color, size, align, shadowColor, shadowBlur, fontWeight };

--- a/task_log.md
+++ b/task_log.md
@@ -47,6 +47,7 @@
     * [x] Switched talent nodes to circular buttons and mirrored 2D click responses.
     * [x] Updated controller menu Ascension button to use original 'Ascension Conduit' wording with auto-sized background.
     * [x] Bolded Ascension Point total and aligned footer buttons with modal padding to match the 2D layout.
+    * [x] Resolved layering bug where menu buttons could render behind panels.
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.
     * [x] Reworked stage list to use original stage configuration and match button colors.


### PR DESCRIPTION
## Summary
- force UI text and icons to render above menu panels by disabling depth writes and assigning explicit render order
- apply render order to controller menu and modal buttons
- log menu layering fix

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689134d3df9c83318fc59ff6e24d2657