### PR TITLE
Fix lore codex text alignment

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -958,9 +958,12 @@ function createLoreModal() {
         lines.push({ text: '', color: '#eaf2ff' });
     });
 
+    const leftMargin = -modal.userData.width / 2 + 0.05;
     lines.forEach(line => {
         const sprite = createTextSprite(line.text || ' ', 32, line.color, 'left');
-        sprite.position.x = -0.55;
+        // Offset by half the sprite width so the text's left edge lines up with
+        // the modal's inner margin instead of rendering outside the container.
+        sprite.position.x = leftMargin + sprite.scale.x / 2;
         list.add(sprite);
     });
 

--- a/task_log.md
+++ b/task_log.md
@@ -57,6 +57,7 @@
     * [x] Synced row highlight with info button hover and matched button placement/opacity to the 2D version.
     * [x] Matched border translucency and hover effects for rows and info buttons to mirror 2D visuals.
     * [x] Restored Lore Codex story modal and button styling to match the original game's presentation.
+    * [x] Corrected Lore Codex text alignment so entries render within the menu bounds.
     * [x] Added in-VR tooltips for Mechanics and Lore buttons and pulled stage labels from `STAGE_CONFIG` for fidelity.
 * [x] **HUD:**
     * [x] Fix the bug preventing power-up emojis from displaying in the inventory.


### PR DESCRIPTION
## Summary
- Offset Lore Codex text sprites so entries render inside the modal bounds
- Document UI fix in task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891380a23e88331b11711e6a18e70c4