### PR TITLE
Fix overflow for sever timeline warning text

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -890,7 +890,7 @@ function createAscensionModal() {
     const clearBtn = createButton('ERASE TIMELINE', () => {
         showConfirm(
             '|| SEVER TIMELINE? ||',
-            'All Ascension progress and unlocked powers will be lost to the void. This action cannot be undone.',
+            'All Ascension progress and unlocked powers will be lost to the void.\nThis action cannot be undone.',
             () => {
                 localStorage.removeItem('eternalMomentumSave');
                 window.location.reload();

--- a/task_log.md
+++ b/task_log.md
@@ -82,3 +82,4 @@
 * [x] Matched game over title color and glow to the 2D game's design.
 * [x] Styled game over menu buttons and background to match the 2D color scheme.
 * [x] Refined confirm modal with magenta border and button colors matching the 2D game's custom confirm dialog.
+* [x] Prevented sever timeline warning text from overflowing its menu.


### PR DESCRIPTION
## Summary
- Wrap warning copy in sever timeline confirm dialog onto two lines to keep text within modal
- Record fix in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68913c663c308331a832136f9ff90d1a