### PR TITLE
Align stage menu labels with original 2D game

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -393,8 +393,6 @@ function createStageSelectModal() {
                 const b = bossData.find(x => x.id === id);
                 return b ? b.name : 'Unknown';
             }).join(' & ');
-            const stageInfo = STAGE_CONFIG.find(s => s.stage === i);
-            const stageLabel = stageInfo?.displayName || bossNames;
 
             const startStage = () => {
                 state.currentStage = i;
@@ -411,7 +409,7 @@ function createStageSelectModal() {
 
             const stageText = createTextSprite(`STAGE ${i}`, 32, '#00ffff', 'left');
             stageText.position.set(-0.43, 0.02, 0.01);
-            const bossText = createTextSprite(stageLabel, 24, '#eaf2ff', 'left');
+            const bossText = createTextSprite(bossNames, 24, '#eaf2ff', 'left');
             bossText.material.opacity = 0.8;
             bossText.position.set(-0.43, -0.04, 0.01);
             enableTextScroll(bossText, 0.6);

--- a/task_log.md
+++ b/task_log.md
@@ -58,7 +58,7 @@
     * [x] Matched border translucency and hover effects for rows and info buttons to mirror 2D visuals.
     * [x] Restored Lore Codex story modal and button styling to match the original game's presentation.
     * [x] Corrected Lore Codex text alignment so entries render within the menu bounds.
-    * [x] Added in-VR tooltips for Mechanics and Lore buttons and pulled stage labels from `STAGE_CONFIG` for fidelity.
+    * [x] Added in-VR tooltips for Mechanics and Lore buttons and ensured stage rows display boss names exactly like the 2D game.
 * [x] **HUD:**
     * [x] Fix the bug preventing power-up emojis from displaying in the inventory.
 


### PR DESCRIPTION
## Summary
- Render boss names in stage select rows to mirror the original game's menu
- Update task log to note stage menu parity with the 2D version

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68913d90d88c8331a6c751bc9b3c5a7c