### PR TITLE
Refine utility helpers and cover edge cases

### DIFF
--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -146,6 +146,9 @@ export function applyPlayerHeal(amount) {
  * @returns {string} Wrapped text.
  */
 export function wrapText(text, maxLen = 60) {
+  if (!Number.isFinite(maxLen) || maxLen <= 0) {
+    return String(text).trim();
+  }
   const lines = String(text).split('\n');
   return lines.map(line => {
     const words = line.split(' ');

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -165,7 +165,8 @@ export function applyScreenShake(ctx) {
 export function drawLightning(ctx, x1, y1, x2, y2, color, width = 2) {
   ctx.save();
   ctx.strokeStyle = color;
-  ctx.lineWidth = Math.random() * width + 1;
+  const w = Number.isFinite(width) ? Math.max(0, width) : 0;
+  ctx.lineWidth = Math.random() * w + 1;
   ctx.globalAlpha = Math.random() * 0.5 + 0.5;
   ctx.beginPath();
   ctx.moveTo(x1, y1);
@@ -188,19 +189,27 @@ export function drawLightning(ctx, x1, y1, x2, y2, color, width = 2) {
 }
 
 export function randomInRange(min, max) {
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return NaN;
+  if (min > max) [min, max] = [max, min];
+  if (min === max) return min;
   return Math.random() * (max - min) + min;
 }
 
 export function lineCircleCollision(x1, y1, x2, y2, cx, cy, r) {
+  if (r <= 0) return false;
+  r = Math.max(0, r);
   const len = Math.hypot(x2 - x1, y2 - y1);
   if (len === 0) return Math.hypot(cx - x1, cy - y1) <= r; // Handle case where line is a point
   const dot = (((cx - x1) * (x2 - x1)) + ((cy - y1) * (y2 - y1))) / Math.pow(len, 2);
   const closestX = x1 + dot * (x2 - x1);
   const closestY = y1 + dot * (y2 - y1);
   const onSegment = () => {
-    const d1 = Math.hypot(closestX - x1, closestY - y1);
-    const d2 = Math.hypot(closestX - x2, closestY - y2);
-    return d1 + d2 >= len - 0.1 && d1 + d2 <= len + 0.1;
+    return (
+      closestX >= Math.min(x1, x2) - 1e-6 &&
+      closestX <= Math.max(x1, x2) + 1e-6 &&
+      closestY >= Math.min(y1, y2) - 1e-6 &&
+      closestY <= Math.max(y1, y2) + 1e-6
+    );
   };
   if (!onSegment()) {
     const dist1 = Math.hypot(cx - x1, cy - y1);
@@ -336,9 +345,10 @@ export function pixelsToArc(pixels, width = 2048){
  * @param {Object} [options]
  */
 export function safeAddEventListener(el, type, handler, options){
-  if(!el || typeof el.addEventListener !== 'function') return;
-  if(typeof handler !== 'function') return;
-  el.addEventListener(type, handler, options || false);
+  if(!el || typeof el.addEventListener !== 'function') return false;
+  if(typeof handler !== 'function') return false;
+  el.addEventListener(type, handler, options ?? false);
+  return true;
 }
 
 /**

--- a/task_log.md
+++ b/task_log.md
@@ -87,3 +87,4 @@
 * [x] Styled game over menu buttons and background to match the 2D color scheme.
 * [x] Refined confirm modal with magenta border and button colors matching the 2D game's custom confirm dialog.
 * [x] Prevented sever timeline warning text from overflowing its menu.
+* [x] Hardened general utilities: randomInRange handles reversed bounds, safeAddEventListener reports status, drawLightning clamps width, lineCircleCollision rejects zero/negative radii, and wrapText ignores non-positive lengths.

--- a/tests/helpersEdgeCases.test.js
+++ b/tests/helpersEdgeCases.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
 
-const { getCanvasPos, setPositionFromCanvas, playerHasCore } = await import('../modules/helpers.js');
+const { getCanvasPos, setPositionFromCanvas, playerHasCore, wrapText } = await import('../modules/helpers.js');
 const { spherePosToUv } = await import('../modules/utils.js');
 const { state } = await import('../modules/state.js');
 
@@ -26,4 +26,8 @@ test('playerHasCore returns false for falsy ids', () => {
   state.player.equippedAberrationCore = null;
   state.player.activePantheonBuffs = [];
   assert.equal(playerHasCore(null), false);
+});
+
+test('wrapText returns input when maxLen is non-positive', () => {
+  assert.equal(wrapText('hello world', 0), 'hello world');
 });

--- a/tests/utilsEdgeCases.test.js
+++ b/tests/utilsEdgeCases.test.js
@@ -1,0 +1,38 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { randomInRange, safeAddEventListener, drawLightning, lineCircleCollision } = await import('../modules/utils.js');
+
+test('randomInRange handles reversed and invalid ranges', () => {
+  const originalRandom = Math.random;
+  Math.random = () => 0.5;
+  const val = randomInRange(5, 1);
+  Math.random = originalRandom;
+  assert.ok(val >= 1 && val <= 5);
+  assert.ok(Number.isNaN(randomInRange('a', 5)));
+});
+
+test('safeAddEventListener guards inputs and reports status', () => {
+  const handler = () => {};
+  const el = { addEventListener: mock.fn() };
+  assert.equal(safeAddEventListener(el, 'click', handler), true);
+  assert.equal(el.addEventListener.mock.calls.length, 1);
+  assert.equal(safeAddEventListener(null, 'click', handler), false);
+});
+
+test('drawLightning clamps width to non-negative values', () => {
+  const ctx = {
+    save(){}, restore(){}, beginPath(){}, moveTo(){}, lineTo(){}, stroke(){},
+    lineWidth: 0, strokeStyle: '', globalAlpha: 1
+  };
+  const originalRandom = Math.random;
+  Math.random = () => 0.5;
+  drawLightning(ctx, 0, 0, 10, 0, '#fff', -3);
+  Math.random = originalRandom;
+  assert.equal(ctx.lineWidth, 1);
+});
+
+test('lineCircleCollision respects radius and segment bounds', () => {
+  assert.equal(lineCircleCollision(0,0,10,0,5,0,-3), false);
+  assert.equal(lineCircleCollision(0,0,10,0,5,0,3), true);
+});


### PR DESCRIPTION
## Summary
- clamp lightning stroke width and sanitize line-circle collision math
- handle reversed ranges and invalid input in randomInRange
- expose success flag from safeAddEventListener
- guard wrapText against non-positive line lengths
- add unit tests for utility edge cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689145af37a48331a231ee6da8c0ef28