### PR TITLE
fix: halt avatar movement when pointing at UI

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -179,7 +179,13 @@ export function updatePlayerController() {
     const uiHit = uiHits[0];
 
     if (uiHit && uiHit.object.userData.onSelect) {
-        targetPoint.copy(uiHit.point);
+        // When interacting with UI elements, hold position instead of
+        // drifting toward the UI panel. Previously `targetPoint` was set to
+        // `uiHit.point`, which lies off the spherical arena and caused the
+        // avatar to slide toward menus when the pointer hovered over them.
+        // By locking the target to the current avatar position we keep the
+        // player stationary while still allowing UI interaction.
+        if (avatar) targetPoint.copy(avatar.position);
         laser.scale.z = uiHit.distance;
         crosshair.visible = false;
 

--- a/task_log.md
+++ b/task_log.md
@@ -88,3 +88,4 @@
 * [x] Refined confirm modal with magenta border and button colors matching the 2D game's custom confirm dialog.
 * [x] Prevented sever timeline warning text from overflowing its menu.
 * [x] Hardened general utilities: randomInRange handles reversed bounds, safeAddEventListener reports status, drawLightning clamps width, lineCircleCollision rejects zero/negative radii, and wrapText ignores non-positive lengths.
+* [x] Prevented avatar drift toward UI by locking movement target during menu interaction.


### PR DESCRIPTION
## Summary
- keep player avatar stationary while interacting with UI elements
- log fix in task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689147254f488331bfda440c3c8fb1d8