### PR TITLE
Prevent avatar drift when pointing at menus

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -178,13 +178,12 @@ export function updatePlayerController() {
     const uiHits = raycaster.intersectObjects(allUI, true);
     const uiHit = uiHits[0];
 
-    if (uiHit && uiHit.object.userData.onSelect) {
-        // When interacting with UI elements, hold position instead of
-        // drifting toward the UI panel. Previously `targetPoint` was set to
-        // `uiHit.point`, which lies off the spherical arena and caused the
-        // avatar to slide toward menus when the pointer hovered over them.
-        // By locking the target to the current avatar position we keep the
-        // player stationary while still allowing UI interaction.
+    if (uiHit) {
+        // When the pointer intersects any UI element, lock the movement target
+        // to the current avatar position so the player does not drift toward
+        // menus or panels. Previously this safeguard only applied to
+        // interactive elements, allowing passive surfaces to trigger unwanted
+        // movement toward the arena behind them.
         if (avatar) targetPoint.copy(avatar.position);
         laser.scale.z = uiHit.distance;
         crosshair.visible = false;
@@ -193,11 +192,14 @@ export function updatePlayerController() {
             if (hoveredUi && hoveredUi.userData.onHover) hoveredUi.userData.onHover(false);
             hoveredUi = uiHit.object;
             if (hoveredUi.userData.onHover) hoveredUi.userData.onHover(true);
-            gameHelpers.play('uiHoverSound');
+            if (hoveredUi.userData.onHover || hoveredUi.userData.onSelect) {
+                gameHelpers.play('uiHoverSound');
+            }
         }
-        if (triggerJustPressed) {
+
+        if (triggerJustPressed && uiHit.object.userData.onSelect) {
             if (Date.now() > state.uiInteractionCooldownUntil) {
-                hoveredUi.userData.onSelect();
+                uiHit.object.userData.onSelect();
                 gameHelpers.play('uiClickSound');
             }
         }

--- a/task_log.md
+++ b/task_log.md
@@ -88,4 +88,4 @@
 * [x] Refined confirm modal with magenta border and button colors matching the 2D game's custom confirm dialog.
 * [x] Prevented sever timeline warning text from overflowing its menu.
 * [x] Hardened general utilities: randomInRange handles reversed bounds, safeAddEventListener reports status, drawLightning clamps width, lineCircleCollision rejects zero/negative radii, and wrapText ignores non-positive lengths.
-* [x] Prevented avatar drift toward UI by locking movement target during menu interaction.
+* [x] Prevented avatar drift toward UI by locking movement target during menu interaction, including when pointing at non-interactive panels.


### PR DESCRIPTION
## Summary
- Stop movement toward arena when pointer hits any UI surface
- Log UI-drift fix in task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68914b7eae0c8331855c62ecaa6d52bb