### PR TITLE
Clear stale player meshes to prevent duplicate avatars

### DIFF
--- a/modules/PlayerController.js
+++ b/modules/PlayerController.js
@@ -104,10 +104,15 @@ export async function initPlayerController() {
     if (!scene || !arena) return;
 
     // Clean up any existing controller meshes so repeated calls do not
-    // spawn duplicate avatars or laser pointers.
+    // spawn duplicate avatars or laser pointers.  Explicitly null out
+    // references so stale objects are eligible for garbage collection and
+    // cannot accidentally be re-added to the scene elsewhere.
     if (avatar && avatar.parent) avatar.parent.remove(avatar);
     if (crosshair && crosshair.parent) crosshair.parent.remove(crosshair);
     if (laser && primaryController) primaryController.remove(laser);
+    avatar = null;
+    crosshair = null;
+    laser = null;
 
     const radius = arena.geometry.parameters.radius;
 

--- a/task_log.md
+++ b/task_log.md
@@ -8,6 +8,7 @@
 * [x] **Player Movement & Avatar Duplication:** Ensured reliable controller input and single avatar instance. — Completed
     * Added controller fallbacks to prevent missing input on platforms reporting a single controller.
     * Cleaned up existing avatar meshes when reinitializing the player controller.
+    * Cleared stale references so repeated initialisation cannot spawn duplicate avatars or lasers.
 * [ ] **Power-up Functionality:**
     * [x] Fix the missile power-up. — Completed
     * [x] Ensure all other power-ups are functional.

--- a/tests/playerControllerInit.test.js
+++ b/tests/playerControllerInit.test.js
@@ -1,0 +1,61 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+// Verify that initPlayerController only keeps a single avatar instance even
+// when called multiple times.
+test('initPlayerController resets previous avatar meshes', async () => {
+  mock.reset();
+
+  const scene = new THREE.Scene();
+  const arena = { geometry: { parameters: { radius: 5 } } };
+  const controller = {
+    addEventListener: mock.fn(),
+    removeEventListener: mock.fn(),
+    add: mock.fn(),
+    remove: mock.fn()
+  };
+
+  await mock.module('../modules/scene.js', {
+    namedExports: {
+      getScene: () => scene,
+      getArena: () => arena,
+      getPrimaryController: () => controller,
+      getCamera: () => ({})
+    }
+  });
+  await mock.module('../modules/UIManager.js', { namedExports: { attachBossUI: mock.fn() } });
+  await mock.module('../modules/PowerManager.js', { namedExports: { useOffensivePower: mock.fn(), useDefensivePower: mock.fn() } });
+  await mock.module('../modules/CoreManager.js', { namedExports: { useCoreActive: mock.fn() } });
+  await mock.module('../modules/ModalManager.js', { namedExports: { getModalObjects: () => [] } });
+  await mock.module('../modules/ControllerMenu.js', { namedExports: { getControllerMenuObjects: () => [] } });
+  await mock.module('../modules/gameHelpers.js', { namedExports: { gameHelpers: {} } });
+  await mock.module('../modules/config.js', { namedExports: { MODEL_SCALE: 1 } });
+  await mock.module('../modules/movement3d.js', { namedExports: { moveTowards: () => {} } });
+  await mock.module('../modules/AssetManager.js', {
+    namedExports: {
+      AssetManager: class {
+        async loadTexture() { return new THREE.Texture(); }
+      }
+    }
+  });
+  const state = {
+    player: { position: new THREE.Vector3(), speed: 1, talent_states: { phaseMomentum: { active: false } }, stunnedUntil: 0 },
+    isPaused: false,
+    cursorDir: new THREE.Vector3()
+  };
+  await mock.module('../modules/state.js', { namedExports: { state } });
+
+  const { initPlayerController, getAvatar } = await import('../modules/PlayerController.js');
+
+  await initPlayerController();
+  const firstAvatar = getAvatar();
+  assert.equal(scene.children.filter(o => o.name === 'playerAvatar').length, 1);
+
+  await initPlayerController();
+  const secondAvatar = getAvatar();
+  assert.equal(scene.children.filter(o => o.name === 'playerAvatar').length, 1);
+  assert.notEqual(firstAvatar, secondAvatar);
+
+  mock.reset();
+});


### PR DESCRIPTION
## Summary
- prevent duplicate player avatars by removing and nulling any previous avatar, crosshair, or laser before reinitializing the player controller
- add regression test ensuring initPlayerController leaves only a single avatar when invoked repeatedly
- document the cleanup in task_log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68916625e934833184d3256af2adb806