### PR TITLE
feat: restore menu background texture

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -101,18 +101,33 @@ function createButton(
 
     const bg = new THREE.Mesh(bgGeom, holoMaterial(bgColor, bgOpacity));
     bg.renderOrder = 0;
+    group.add(bg);
+
     const tex = getBgTexture();
-    if (tex) { bg.material.map = tex; bg.material.needsUpdate = true; }
+    if (tex) {
+        const pattern = new THREE.Mesh(bgGeom.clone(), new THREE.MeshBasicMaterial({
+            map: tex,
+            transparent: true,
+            opacity: 0.15,
+            depthTest: false,
+            depthWrite: false
+        }));
+        pattern.position.z = 0.001;
+        pattern.renderOrder = 0.5;
+        group.add(pattern);
+    }
 
     const border = new THREE.Mesh(borderGeom, holoMaterial(color, 0.5));
     border.position.z = -0.001;
     border.renderOrder = -1;
+    group.add(border);
 
     const txtColor = textColor !== undefined ? textColor : color;
     const colorObj = new THREE.Color(txtColor);
     const text = createTextSprite(label.substring(0, 20), 32, colorObj.getStyle());
     text.material.color.set(colorObj);
     text.position.z = 0.002;
+    group.add(text);
 
     // Interactive behaviour
     const setHover = hovered => {
@@ -128,7 +143,6 @@ function createButton(
         obj.userData.onHover = setHover;
     });
 
-    group.add(bg, border, text);
     return group;
 }
 
@@ -152,9 +166,21 @@ function createModalContainer(width, height, title, options = {}) {
 
     const bg = new THREE.Mesh(new THREE.PlaneGeometry(width, height), holoMaterial(backgroundColor, backgroundOpacity));
     bg.renderOrder = 0;
-    const tex = getBgTexture();
-    if (tex) { bg.material.map = tex; bg.material.needsUpdate = true; }
     group.add(bg);
+
+    const tex = getBgTexture();
+    if (tex) {
+        const pattern = new THREE.Mesh(new THREE.PlaneGeometry(width, height), new THREE.MeshBasicMaterial({
+            map: tex,
+            transparent: true,
+            opacity: 0.15,
+            depthTest: false,
+            depthWrite: false
+        }));
+        pattern.position.z = 0.001;
+        pattern.renderOrder = 0.5;
+        group.add(pattern);
+    }
 
     if (borderOpacity > 0) {
         const border = new THREE.Mesh(new THREE.PlaneGeometry(width + 0.02, height + 0.02), holoMaterial(borderColor, borderOpacity));

--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -28,6 +28,11 @@ export function getBgTexture() {
   if (!bgTexture) {
     const manager = new AssetManager();
     bgTexture = manager.getTexture('assets/bg.png');
+    if (bgTexture) {
+      bgTexture.wrapS = THREE.RepeatWrapping;
+      bgTexture.wrapT = THREE.RepeatWrapping;
+      bgTexture.repeat.set(4, 4);
+    }
   }
   return bgTexture;
 }

--- a/task_log.md
+++ b/task_log.md
@@ -93,3 +93,4 @@
 * [x] Hardened general utilities: randomInRange handles reversed bounds, safeAddEventListener reports status, drawLightning clamps width, lineCircleCollision rejects zero/negative radii, and wrapText ignores non-positive lengths.
 * [x] Prevented avatar drift toward UI by locking movement target during menu interaction, including when pointing at non-interactive panels.
 * [x] Added safeguards for edge cases: spherical direction now returns zero for degenerate inputs, UV sanitization wraps v values, movement steps are clamped to avoid overshoot, player damage ignores invalid values, and ring drawing normalizes radii and alpha.
+* [x] Reapplied `bg.png` pattern overlay on modal and button backgrounds for faithful 2D-style menus.


### PR DESCRIPTION
## Summary
- tile `bg.png` texture and repeat-wrap for reuse
- overlay subtle bg pattern on VR buttons and modals
- log menu background restoration in task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68920e5868308331bb979062c1b248c3