### PR TITLE
fix: harden gameplay helpers

### DIFF
--- a/modules/ProjectileManager.js
+++ b/modules/ProjectileManager.js
@@ -32,10 +32,12 @@ export function spawnProjectile(props = {}) {
 }
 
 export function updateProjectiles(stepFn, collisionFn) {
+  const doStep = typeof stepFn === 'function' ? stepFn : null;
+  const doCollide = typeof collisionFn === 'function' ? collisionFn : null;
   for (let i = active.length - 1; i >= 0; i--) {
     const p = active[i];
-    if (stepFn) stepFn(p);
-    if (collisionFn && collisionFn(p)) {
+    if (doStep) doStep(p);
+    if (doCollide && doCollide(p)) {
       p.alive = false;
     }
     if (!p.alive) {

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -97,6 +97,7 @@ export function applyPlayerDamage(amount, source = null, gameHelpers = {}) {
 
   if (state.player.shield) {
     state.player.shield = false;
+    state.player.shield_end_time = 0;
     CoreManager.onShieldBreak();
     return 0;
   }
@@ -110,6 +111,7 @@ export function applyPlayerDamage(amount, source = null, gameHelpers = {}) {
   } else {
     state.player.health = newHealth;
   }
+  if (state.player.health < 0) state.player.health = 0;
 
   return damage;
 }
@@ -151,6 +153,7 @@ export function wrapText(text, maxLen = 60) {
   if (!Number.isFinite(maxLen) || maxLen <= 0) {
     return String(text).trim();
   }
+  maxLen = Math.max(1, Math.floor(maxLen));
   const lines = String(text).split('\n');
   return lines.map(line => {
     const words = line.split(' ');

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -16,10 +16,12 @@ let screenShakeEnd = 0;
 let screenShakeMagnitude = 0;
 
 export function drawCircle(ctx, x, y, r, c) {
-  if (r <= 0) return; // Safeguard to prevent negative radius errors
+  if (!ctx || typeof ctx.beginPath !== 'function') return;
+  const radius = Number.isFinite(r) ? r : 0;
+  if (radius <= 0) return; // Safeguard to prevent negative radius errors
   ctx.fillStyle = c;
   ctx.beginPath();
-  ctx.arc(x, y, r, 0, 2 * Math.PI);
+  ctx.arc(x, y, radius, 0, 2 * Math.PI);
   ctx.fill();
 }
 
@@ -109,12 +111,14 @@ export function isPointInShadow(shadowCaster, point, sourceX, sourceY) {
 }
 
 export function spawnParticles(particles, x, y, c, n, spd, life, r = 3) {
+  if (!Array.isArray(particles) || !Number.isFinite(n) || n <= 0) return;
   const u = ((x / 2048) - 0.5 + 1) % 1;
   const v = y / 1024;
   const center = uvToSpherePos(u, v, 1);
   const basisA = new THREE.Vector3(center.z, 0, -center.x).normalize();
   const basisB = new THREE.Vector3().crossVectors(center, basisA).normalize();
-  const speed = (spd / 2048) * 2 * Math.PI;
+  const speed = Number.isFinite(spd) ? (spd / 2048) * 2 * Math.PI : 0;
+  const lifeTicks = Number.isFinite(life) ? life : 0;
   for (let i = 0; i < n; i++) {
     const a = Math.random() * 2 * Math.PI;
     const dir = basisA.clone().multiplyScalar(Math.cos(a))
@@ -125,8 +129,8 @@ export function spawnParticles(particles, x, y, c, n, spd, life, r = 3) {
       velocity: dir,
       r,
       color: c,
-      life,
-      maxLife: life,
+      life: lifeTicks,
+      maxLife: lifeTicks,
     });
   }
 }

--- a/task_log.md
+++ b/task_log.md
@@ -94,3 +94,4 @@
 * [x] Prevented avatar drift toward UI by locking movement target during menu interaction, including when pointing at non-interactive panels.
 * [x] Added safeguards for edge cases: spherical direction now returns zero for degenerate inputs, UV sanitization wraps v values, movement steps are clamped to avoid overshoot, player damage ignores invalid values, and ring drawing normalizes radii and alpha.
 * [x] Reapplied `bg.png` pattern overlay on modal and button backgrounds for faithful 2D-style menus.
+* [x] Fixed additional gameplay bugs: projectile updates now validate callbacks, shield timers clear on break, player health clamps non-negative, circle drawing guards against invalid contexts, and particle spawner verifies inputs.


### PR DESCRIPTION
## Summary
- guard drawCircle and particle spawning against invalid inputs
- ensure projectile update callbacks are verified before use
- reset shield timers and clamp health in player damage routine

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68921240f8988331b82171445d3d0849