### PR TITLE
fix: keep VR menu buttons above panels

### DIFF
--- a/modules/ControllerMenu.js
+++ b/modules/ControllerMenu.js
@@ -17,6 +17,7 @@ function createButton(label, icon, onSelect) {
   // exactly, mirroring the flexible width of the 2D game's buttons.
   const iconSprite = createTextSprite(icon, 32);
   const textSprite = createTextSprite(label, 24);
+  iconSprite.renderOrder = textSprite.renderOrder = 2;
 
   const padding = 0.02;
   const iconWidth = iconSprite.scale.x;
@@ -25,7 +26,9 @@ function createButton(label, icon, onSelect) {
 
   // Apply the game's hex texture so buttons resemble their 2D counterparts.
   const bg = new THREE.Mesh(new THREE.PlaneGeometry(totalWidth, 0.08), holoMaterial(0x111122, 0.8));
-  bg.renderOrder = 0;
+  // Ensure controller menu buttons render above any panel backing by
+  // giving their faces a higher render order.
+  bg.renderOrder = 1;
   const tex = getBgTexture();
   if (tex) {
     bg.material.map = tex;
@@ -33,7 +36,8 @@ function createButton(label, icon, onSelect) {
   }
   const border = new THREE.Mesh(new THREE.PlaneGeometry(totalWidth + 0.01, 0.09), holoMaterial(0x00ffff, 0.5));
   border.position.z = -0.001;
-  border.renderOrder = -1;
+  // Border renders behind the button face yet above any modal background.
+  border.renderOrder = 0.5;
   group.add(bg, border);
 
   // Position icon and text with even padding from the left edge.

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -100,7 +100,10 @@ function createButton(
     }
 
     const bg = new THREE.Mesh(bgGeom, holoMaterial(bgColor, bgOpacity));
-    bg.renderOrder = 0;
+    // Button backgrounds need to draw after the modal panel so they aren't
+    // hidden when depth testing is disabled. Raising the renderOrder keeps
+    // them consistently on top of the container background.
+    bg.renderOrder = 1;
     group.add(bg);
 
     const tex = getBgTexture();
@@ -113,19 +116,26 @@ function createButton(
             depthWrite: false
         }));
         pattern.position.z = 0.001;
-        pattern.renderOrder = 0.5;
+        // Draw the texture overlay above the solid background but below text
+        // sprites so it doesn't occlude labels.
+        pattern.renderOrder = 1.5;
         group.add(pattern);
     }
 
     const border = new THREE.Mesh(borderGeom, holoMaterial(color, 0.5));
     border.position.z = -0.001;
-    border.renderOrder = -1;
+    // The border sits behind the button face but still needs to render above
+    // the modal background so its edges remain visible.
+    border.renderOrder = 0.5;
     group.add(border);
 
     const txtColor = textColor !== undefined ? textColor : color;
     const colorObj = new THREE.Color(txtColor);
     const text = createTextSprite(label.substring(0, 20), 32, colorObj.getStyle());
     text.material.color.set(colorObj);
+    // Text needs the highest render order so it always appears above the
+    // button face and overlay pattern.
+    text.renderOrder = 2;
     text.position.z = 0.002;
     group.add(text);
 

--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -97,7 +97,10 @@ export function createTextSprite(
         side: THREE.DoubleSide
     });
     const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), material);
-    mesh.renderOrder = 1;
+    // Text should always render above menu backgrounds and button frames.
+    // Giving sprites a higher renderOrder keeps them visible even when other
+    // UI elements share the same Z position or disable depth testing.
+    mesh.renderOrder = 2;
     // Apply the global pixel-to-world scale so changing SPRITE_SCALE adjusts
     // all text sprites uniformly.
     mesh.scale.set(canvas.width * SPRITE_SCALE, canvas.height * SPRITE_SCALE, 1);

--- a/task_log.md
+++ b/task_log.md
@@ -53,6 +53,7 @@
     * [x] Bolded Ascension Point total and aligned footer buttons with modal padding to match the 2D layout.
     * [x] Split talent tooltips into left-aligned rank and right-aligned cost fields, using 'Mastery' and 'MAXED' phrasing like the 2D menu.
     * [x] Resolved layering bug where menu buttons could render behind panels.
+    * [x] Reworked render ordering so button faces, borders, and labels always draw above their modal backgrounds.
 * [x] Raised modal positions so menus appear higher with their bottoms at waist height.
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.


### PR DESCRIPTION
## Summary
- ensure text sprites render above all menu surfaces
- raise button backgrounds and borders above modal panels
- align controller menu button render order with modal buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689217bce2288331ae051a7402e067fa