### PR TITLE
Show controller menu labels on hover

### DIFF
--- a/modules/ControllerMenu.js
+++ b/modules/ControllerMenu.js
@@ -40,10 +40,18 @@ function createButton(label, icon, onSelect) {
   border.renderOrder = 0.5;
   group.add(bg, border);
 
-  // Position icon and text with even padding from the left edge.
+  // Position icon and text with even padding from the left edge for the
+  // expanded state.  We'll collapse to just the icon by default and restore
+  // these positions on hover.
   const startX = -totalWidth / 2 + padding;
-  iconSprite.position.set(startX + iconWidth / 2, 0, 0.01);
-  textSprite.position.set(iconSprite.position.x + iconWidth / 2 + padding + textWidth / 2, 0, 0.01);
+  const expandedIconX = startX + iconWidth / 2;
+  const expandedTextX = expandedIconX + iconWidth / 2 + padding + textWidth / 2;
+
+  // Start with the icon centered and hide the label/background so only the
+  // emoji is visible until hovered.
+  iconSprite.position.set(0, 0, 0.01);
+  textSprite.position.set(expandedTextX, 0, 0.01);
+  bg.visible = border.visible = textSprite.visible = false;
   group.add(iconSprite, textSprite);
 
   const setHover = hovered => {
@@ -51,12 +59,22 @@ function createButton(label, icon, onSelect) {
     bg.material.emissiveIntensity = intensity;
     border.material.emissiveIntensity = intensity;
     group.scale.setScalar(hovered ? 1.05 : 1);
+    bg.visible = border.visible = textSprite.visible = hovered;
+    if (hovered) {
+      iconSprite.position.x = expandedIconX;
+      textSprite.position.x = expandedTextX;
+    } else {
+      iconSprite.position.x = 0;
+    }
   };
 
   [bg, border, iconSprite, textSprite].forEach(obj => {
     obj.userData.onSelect = onSelect;
     obj.userData.onHover = setHover;
   });
+
+  // Ensure we start collapsed.
+  setHover(false);
 
   return group;
 }

--- a/task_log.md
+++ b/task_log.md
@@ -54,6 +54,7 @@
     * [x] Split talent tooltips into left-aligned rank and right-aligned cost fields, using 'Mastery' and 'MAXED' phrasing like the 2D menu.
     * [x] Resolved layering bug where menu buttons could render behind panels.
     * [x] Reworked render ordering so button faces, borders, and labels always draw above their modal backgrounds.
+    * [x] Made controller hand menu buttons show their labels and frames only when hovered to reduce clutter.
 * [x] Raised modal positions so menus appear higher with their bottoms at waist height.
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.


### PR DESCRIPTION
## Summary
- collapse controller hand menu buttons to emoji icons
- reveal button background and label only while hovering
- log menu tooltip refinement in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68921a77006c833184b7ca65e75b3dac