### PR TITLE
Fix VR menu button overflow

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -384,7 +384,9 @@ function createConfirmModal() {
 }
 
 function createStageSelectModal() {
-    const modal = createModalContainer(1.4, 1.2, 'SELECT STAGE');
+    const width = 1.4;
+    const height = 1.2;
+    const modal = createModalContainer(width, height, 'SELECT STAGE');
     modal.name = 'modal_levelSelect';
     const listContainer = new THREE.Group();
     listContainer.position.y = -0.1;
@@ -400,21 +402,27 @@ function createStageSelectModal() {
         0xff8800,
         0.25
     );
-    loreCodexBtn.position.set(0.5, 0.5, 0.02);
+    // Tuck the button 5cm from the top-right edge to keep it inside the panel
+    // bounds and mirror the 2D menu's margin.
+    loreCodexBtn.position.set(width / 2 - 0.05 - 0.2, height / 2 - 0.05 - 0.04, 0.02);
     modal.add(loreCodexBtn);
 
     const arenaBtn = createButton("WEAVER'S ORRERY", () => { hideModal(); showModal('orrery'); }, 0.6, 0.1, 0x9b59b6);
-    arenaBtn.position.set(-0.45, -0.5, 0.01);
+    // Center the bottom buttons with equal 5cm side margins so they no longer
+    // bleed past the container.
+    const bottomY = -height / 2 + 0.1;
+    arenaBtn.position.set(-width / 2 + 0.05 + 0.3, bottomY, 0.01);
     const frontierBtn = createButton('JUMP TO FRONTIER', () => {
         const stage = state.player.highestStageBeaten > 0 ? state.player.highestStageBeaten + 1 : 1;
         state.currentStage = stage;
         resetGame(bossData);
         hideModal();
     }, 0.6, 0.1, 0x00ffff, 0x00ffff, 0x1e1e2f);
-    frontierBtn.position.set(0.45, -0.5, 0.01);
+    frontierBtn.position.set(width / 2 - 0.05 - 0.3, bottomY, 0.01);
 
     const closeBtn = createButton('Close', () => hideModal(), 0.5, 0.1, 0xf000ff);
-    closeBtn.position.set(0, -0.65, 0.01);
+    // Raise the close button so its bottom edge aligns with the modal's border.
+    closeBtn.position.set(0, -height / 2 + 0.05, 0.01);
 
     modal.add(arenaBtn, frontierBtn, closeBtn);
 
@@ -1018,7 +1026,9 @@ function createLoreModal() {
 }
 
 function createBossInfoModal() {
-    const modal = createModalContainer(1.2, 1.0, 'BOSS INFO');
+    const width = 1.2;
+    const height = 1.0;
+    const modal = createModalContainer(width, height, 'BOSS INFO');
     modal.name = 'modal_bossInfo';
 
     // Left-align wrapped lore text and bump the font size for readability.
@@ -1028,7 +1038,9 @@ function createBossInfoModal() {
     modal.add(content);
 
     const closeBtn = createButton('✖', () => hideModal(), 0.12, 0.12, 0xf000ff);
-    closeBtn.position.set(0.55, 0.45, 0.02);
+    // Keep the close button inset from the top-right corner so it doesn't
+    // bleed beyond the modal's bounds.
+    closeBtn.position.set(width / 2 - 0.05 - 0.06, height / 2 - 0.05 - 0.06, 0.02);
     modal.add(closeBtn);
 
     modal.userData.contentSprite = content;

--- a/task_log.md
+++ b/task_log.md
@@ -92,6 +92,7 @@
 * [x] Styled game over menu buttons and background to match the 2D color scheme.
 * [x] Refined confirm modal with magenta border and button colors matching the 2D game's custom confirm dialog.
 * [x] Prevented sever timeline warning text from overflowing its menu.
+* [x] Repositioned Stage Select and Boss Info buttons so none bleed beyond their menu boundaries.
 * [x] Hardened general utilities: randomInRange handles reversed bounds, safeAddEventListener reports status, drawLightning clamps width, lineCircleCollision rejects zero/negative radii, and wrapText ignores non-positive lengths.
 * [x] Prevented avatar drift toward UI by locking movement target during menu interaction, including when pointing at non-interactive panels.
 * [x] Added safeguards for edge cases: spherical direction now returns zero for degenerate inputs, UV sanitization wraps v values, movement steps are clamped to avoid overshoot, player damage ignores invalid values, and ring drawing normalizes radii and alpha.


### PR DESCRIPTION
## Summary
- nudge Stage Select buttons inside their panel and lift close control
- inset Boss Info close button from top-right corner
- log menu layout fix in task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892200a34608331b62fd161f335d822