### PR TITLE
Fix misaligned stage menu and game over restart label

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -454,10 +454,14 @@ function createStageSelectModal() {
             if (row.children[2]) row.children[2].visible = false; // hide default label
 
             const stageText = createTextSprite(`STAGE ${i}`, 32, '#00ffff', 'left');
-            stageText.position.set(-0.43, 0.02, 0.01);
+            // Align text with the row's left edge by offsetting it by half the
+            // sprite's width. Using a fixed position caused labels to spill
+            // outside the bar.
+            const leftEdge = -0.43;
+            stageText.position.set(leftEdge + stageText.scale.x / 2, 0.02, 0.01);
             const bossText = createTextSprite(stageLabel, 24, '#eaf2ff', 'left');
             bossText.material.opacity = 0.8;
-            bossText.position.set(-0.43, -0.04, 0.01);
+            bossText.position.set(leftEdge + bossText.scale.x / 2, -0.04, 0.01);
             enableTextScroll(bossText, 0.6);
 
             const handleHover = hovered => {
@@ -1063,7 +1067,9 @@ function createGameOverModal() {
 
     const btnWidth = 0.3;
     const gap = 0.06;
-    const startX = -0.7 + btnWidth / 2;
+    // Inset the button row slightly so long labels like "Restart Stage" stay
+    // within the modal bounds.
+    const startX = -0.7 + btnWidth / 2 + 0.02;
     const y = -0.2;
 
     const restartBtn = createButton('Restart Stage', () => {
@@ -1074,6 +1080,9 @@ function createGameOverModal() {
         hideModal();
     }, btnWidth, 0.1, 0x00ffff, 0x00ffff, 0xffffff, 0.2);
     restartBtn.position.set(startX, y, 0.01);
+    // Shrink the label slightly so it doesn't spill past the button frame.
+    const restartText = restartBtn.children.find(c => c.userData?.text !== undefined);
+    if (restartText) restartText.scale.multiplyScalar(0.9);
     modal.add(restartBtn);
 
     const ascBtn = createButton('Ascension Conduit', () => {

--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -24,13 +24,16 @@ const SPRITE_SCALE = 0.001; // world units per canvas pixel
 const PIXELS_PER_UNIT = 1 / SPRITE_SCALE; // helper for world->pixel math
 
 let bgTexture = null;
+// Cache the shared menu background texture and configure it to behave like the
+// 2D game's single image. We clamp the edges and force a 1x1 repeat so `bg.png`
+// doesn't tile; otherwise seams show up on modal panels and button overlays.
 export function getBgTexture() {
   if (!bgTexture) {
     const manager = new AssetManager();
     bgTexture = manager.getTexture('assets/bg.png');
     if (bgTexture) {
-      // Mirror the 2D game's single-image background by disabling texture
-      // tiling; repeating caused visible seams inside modal sections.
+      // Disable wrapping in both directions and keep a single copy of the
+      // texture so it matches the non-repeating 2D background.
       bgTexture.wrapS = THREE.ClampToEdgeWrapping;
       bgTexture.wrapT = THREE.ClampToEdgeWrapping;
       bgTexture.repeat.set(1, 1);

--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -29,9 +29,11 @@ export function getBgTexture() {
     const manager = new AssetManager();
     bgTexture = manager.getTexture('assets/bg.png');
     if (bgTexture) {
-      bgTexture.wrapS = THREE.RepeatWrapping;
-      bgTexture.wrapT = THREE.RepeatWrapping;
-      bgTexture.repeat.set(4, 4);
+      // Mirror the 2D game's single-image background by disabling texture
+      // tiling; repeating caused visible seams inside modal sections.
+      bgTexture.wrapS = THREE.ClampToEdgeWrapping;
+      bgTexture.wrapT = THREE.ClampToEdgeWrapping;
+      bgTexture.repeat.set(1, 1);
     }
   }
   return bgTexture;

--- a/task_log.md
+++ b/task_log.md
@@ -93,6 +93,7 @@
 * [x] Refined confirm modal with magenta border and button colors matching the 2D game's custom confirm dialog.
 * [x] Prevented sever timeline warning text from overflowing its menu.
 * [x] Repositioned Stage Select and Boss Info buttons so none bleed beyond their menu boundaries.
+* [x] Realigned stage labels and boss names with their bars and kept Game Over's restart label within bounds.
 * [x] Hardened general utilities: randomInRange handles reversed bounds, safeAddEventListener reports status, drawLightning clamps width, lineCircleCollision rejects zero/negative radii, and wrapText ignores non-positive lengths.
 * [x] Prevented avatar drift toward UI by locking movement target during menu interaction, including when pointing at non-interactive panels.
 * [x] Added safeguards for edge cases: spherical direction now returns zero for degenerate inputs, UV sanitization wraps v values, movement steps are clamped to avoid overshoot, player damage ignores invalid values, and ring drawing normalizes radii and alpha.


### PR DESCRIPTION
## Summary
- Prevent bg pattern tiling to match 2D menu styling
- Align stage labels and boss names with their selection bars
- Keep Game Over's Restart Stage label inside its button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689227f6209c83318bf7ed1c760e23ef