### PR TITLE
Remove bg texture from buttons

### DIFF
--- a/modules/ControllerMenu.js
+++ b/modules/ControllerMenu.js
@@ -3,7 +3,7 @@ import { getSecondaryController } from './scene.js';
 import { showModal } from './ModalManager.js';
 import { AudioManager } from './audio.js';
 import { state } from './state.js';
-import { holoMaterial, createTextSprite, updateTextSprite, getBgTexture } from './UIManager.js';
+import { holoMaterial, createTextSprite, updateTextSprite } from './UIManager.js';
 
 let menuGroup;
 let coreButton, soundBtn;
@@ -24,16 +24,12 @@ function createButton(label, icon, onSelect) {
   const textWidth = textSprite.scale.x;
   const totalWidth = padding * 3 + iconWidth + textWidth;
 
-  // Apply the game's hex texture so buttons resemble their 2D counterparts.
+  // Button backgrounds mirror the flat panels from the 2D game without
+  // applying the global wallpaper texture.
   const bg = new THREE.Mesh(new THREE.PlaneGeometry(totalWidth, 0.08), holoMaterial(0x111122, 0.8));
   // Ensure controller menu buttons render above any panel backing by
   // giving their faces a higher render order.
   bg.renderOrder = 1;
-  const tex = getBgTexture();
-  if (tex) {
-    bg.material.map = tex;
-    bg.material.needsUpdate = true;
-  }
   const border = new THREE.Mesh(new THREE.PlaneGeometry(totalWidth + 0.01, 0.09), holoMaterial(0x00ffff, 0.5));
   border.position.z = -0.001;
   // Border renders behind the button face yet above any modal background.

--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -106,22 +106,6 @@ function createButton(
     bg.renderOrder = 1;
     group.add(bg);
 
-    const tex = getBgTexture();
-    if (tex) {
-        const pattern = new THREE.Mesh(bgGeom.clone(), new THREE.MeshBasicMaterial({
-            map: tex,
-            transparent: true,
-            opacity: 0.15,
-            depthTest: false,
-            depthWrite: false
-        }));
-        pattern.position.z = 0.001;
-        // Draw the texture overlay above the solid background but below text
-        // sprites so it doesn't occlude labels.
-        pattern.renderOrder = 1.5;
-        group.add(pattern);
-    }
-
     const border = new THREE.Mesh(borderGeom, holoMaterial(color, 0.5));
     border.position.z = -0.001;
     // The border sits behind the button face but still needs to render above
@@ -134,7 +118,7 @@ function createButton(
     const text = createTextSprite(label.substring(0, 20), 32, colorObj.getStyle());
     text.material.color.set(colorObj);
     // Text needs the highest render order so it always appears above the
-    // button face and overlay pattern.
+    // button face.
     text.renderOrder = 2;
     text.position.z = 0.002;
     group.add(text);

--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -221,11 +221,6 @@ function createBossBar(boss) {
 function createCommandBar(width = 0.9, height = 0.25) {
     const group = new THREE.Group();
     const bg = new THREE.Mesh(new THREE.PlaneGeometry(width, height), holoMaterial(0x111122, 0.9));
-    const tex = getBgTexture();
-    if (tex) {
-        bg.material.map = tex;
-        bg.material.needsUpdate = true;
-    }
     const border = new THREE.Mesh(new THREE.PlaneGeometry(width + 0.02, height + 0.02), holoMaterial(0x00ffff, 0.5));
     border.position.z = -0.001;
     group.add(bg, border);

--- a/task_log.md
+++ b/task_log.md
@@ -98,4 +98,5 @@
 * [x] Prevented avatar drift toward UI by locking movement target during menu interaction, including when pointing at non-interactive panels.
 * [x] Added safeguards for edge cases: spherical direction now returns zero for degenerate inputs, UV sanitization wraps v values, movement steps are clamped to avoid overshoot, player damage ignores invalid values, and ring drawing normalizes radii and alpha.
 * [x] Reapplied `bg.png` pattern overlay on modal and button backgrounds for faithful 2D-style menus.
+* [x] Removed `bg.png` texture from buttons and HUD elements so it only serves as modal wallpaper, matching the original 2D game.
 * [x] Fixed additional gameplay bugs: projectile updates now validate callbacks, shield timers clear on break, player health clamps non-negative, circle drawing guards against invalid contexts, and particle spawner verifies inputs.


### PR DESCRIPTION
## Summary
- Strip global wallpaper texture from HUD command bar to restore flat look
- Drop bg.png overlay on modal and controller menu buttons for cleaner 2D parity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68922f18441883319e349fde086173dc