### PR TITLE
Normalize stage select bars and realign game over menu

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -430,23 +430,21 @@ function createStageSelectModal() {
                 hideModal();
             };
 
+            const rowWidth = width - 0.1;
             // Row background and border to mimic original stage-select item
-            const row = createButton('', startStage, 0.9, 0.12, 0x00ffff, 0x00ffff, 0x00ffff, 0.1);
+            const row = createButton('', startStage, rowWidth, 0.12, 0x00ffff, 0x00ffff, 0x00ffff, 0.1);
             const bg = row.children[0];
             const border = row.children[1];
             border.material.opacity = 0.4; // match rgba border from 2D menu
             if (row.children[2]) row.children[2].visible = false; // hide default label
 
             const stageText = createTextSprite(`STAGE ${i}`, 32, '#00ffff', 'left');
-            // Align text with the row's left edge by offsetting it by half the
-            // sprite's width. Using a fixed position caused labels to spill
-            // outside the bar.
-            const leftEdge = -0.43;
+            const leftEdge = -rowWidth / 2 + 0.02;
             stageText.position.set(leftEdge + stageText.scale.x / 2, 0.02, 0.01);
             const bossText = createTextSprite(stageLabel, 24, '#eaf2ff', 'left');
             bossText.material.opacity = 0.8;
             bossText.position.set(leftEdge + bossText.scale.x / 2, -0.04, 0.01);
-            enableTextScroll(bossText, 0.6);
+            enableTextScroll(bossText, rowWidth - 0.4);
 
             const handleHover = hovered => {
                 bg.material.opacity = hovered ? 0.2 : 0.1;
@@ -482,14 +480,19 @@ function createStageSelectModal() {
             };
             const mechBtn = createInfoButton('❔', 0xf1c40f, 'Mechanics', () => showBossInfo(bossIds, 'mechanics'));
             const loreBtn = createInfoButton('ℹ️', 0x9b59b6, 'Lore', () => showBossInfo(bossIds, 'lore'));
-            mechBtn.position.set(0.23, 0, 0.01);
-            loreBtn.position.set(0.37, 0, 0.01);
+            const rightEdge = rowWidth / 2;
+            const btnRadius = 0.06;
+            const gap = 0.04;
+            const loreX = rightEdge - (btnRadius + 0.02);
+            const mechX = loreX - (btnRadius * 2 + gap);
+            mechBtn.position.set(mechX, 0, 0.01);
+            loreBtn.position.set(loreX, 0, 0.01);
             row.add(mechBtn, loreBtn);
 
             row.position.y = 0.4 - (i - 1) * 0.15;
             listContainer.add(row);
         }
-        addScrollBar(modal, listContainer, { itemHeight: 0.15, viewHeight: 0.8, topOffset: 0.4, x: 0.55, startAt: 'bottom' });
+        addScrollBar(modal, listContainer, { itemHeight: 0.15, viewHeight: 0.8, topOffset: 0.4, x: width / 2 - 0.05, startAt: 'bottom' });
     };
 
     return modal;
@@ -1050,10 +1053,11 @@ function createGameOverModal() {
     modal.name = 'modal_gameOver';
 
     const btnWidth = 0.3;
-    const gap = 0.06;
-    // Inset the button row slightly so long labels like "Restart Stage" stay
-    // within the modal bounds.
-    const startX = -0.7 + btnWidth / 2 + 0.02;
+    const gap = 0.04;
+    const totalWidth = btnWidth * 4 + gap * 3;
+    // Center the button row and keep a small margin so no button spills past
+    // the container edge.
+    const startX = -totalWidth / 2 + btnWidth / 2;
     const y = -0.2;
 
     const restartBtn = createButton('Restart Stage', () => {

--- a/task_log.md
+++ b/task_log.md
@@ -94,6 +94,8 @@
 * [x] Prevented sever timeline warning text from overflowing its menu.
 * [x] Repositioned Stage Select and Boss Info buttons so none bleed beyond their menu boundaries.
 * [x] Realigned stage labels and boss names with their bars and kept Game Over's restart label within bounds.
+* [x] Standardized Stage Select row widths and anchored info buttons to match the 2D menu.
+* [x] Centered Game Over buttons so Stage Select stays within the modal frame.
 * [x] Hardened general utilities: randomInRange handles reversed bounds, safeAddEventListener reports status, drawLightning clamps width, lineCircleCollision rejects zero/negative radii, and wrapText ignores non-positive lengths.
 * [x] Prevented avatar drift toward UI by locking movement target during menu interaction, including when pointing at non-interactive panels.
 * [x] Added safeguards for edge cases: spherical direction now returns zero for degenerate inputs, UV sanitization wraps v values, movement steps are clamped to avoid overshoot, player damage ignores invalid values, and ring drawing normalizes radii and alpha.


### PR DESCRIPTION
## Summary
- anchor stage select rows to modal width for consistent bar lengths
- center game over menu buttons so "Stage Select" stays within bounds
- document UI alignment work in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923470354c8331b04c10088352182a