### PR TITLE
Align VR stage menu with original game

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -421,8 +421,6 @@ function createStageSelectModal() {
                 const b = bossData.find(x => x.id === id);
                 return b ? b.name : 'Unknown';
             }).join(' & ');
-            const stageInfo = STAGE_CONFIG.find(s => s.stage === i);
-            const stageLabel = stageInfo?.displayName || bossNames;
 
             const startStage = () => {
                 state.currentStage = i;
@@ -441,7 +439,7 @@ function createStageSelectModal() {
             const stageText = createTextSprite(`STAGE ${i}`, 32, '#00ffff', 'left');
             const leftEdge = -rowWidth / 2 + 0.02;
             stageText.position.set(leftEdge + stageText.scale.x / 2, 0.02, 0.01);
-            const bossText = createTextSprite(stageLabel, 24, '#eaf2ff', 'left');
+            const bossText = createTextSprite(bossNames, 24, '#eaf2ff', 'left');
             bossText.material.opacity = 0.8;
             bossText.position.set(leftEdge + bossText.scale.x / 2, -0.04, 0.01);
             enableTextScroll(bossText, rowWidth - 0.4);

--- a/task_log.md
+++ b/task_log.md
@@ -65,7 +65,7 @@
     * [x] Matched border translucency and hover effects for rows and info buttons to mirror 2D visuals.
     * [x] Restored Lore Codex story modal and button styling to match the original game's presentation.
     * [x] Corrected Lore Codex text alignment so entries render within the menu bounds.
-    * [x] Added in-VR tooltips for Mechanics and Lore buttons and pulled stage labels from `STAGE_CONFIG` for fidelity.
+    * [x] Added in-VR tooltips for Mechanics and Lore buttons and restored boss-name listing to match the 2D stage menu.
 * [x] **HUD:**
     * [x] Fix the bug preventing power-up emojis from displaying in the inventory.
     * [x] Reworked inventory HUD rendering to scale emoji sprites consistently and refresh even when hidden.


### PR DESCRIPTION
## Summary
- Show boss names in VR stage select menu to mirror the original 2D layout
- Update task log to note restored boss-name listing for stage menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68925ddebd80833183385662c262abb9