### PR TITLE
Align Ascension tooltips with 2D layout

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -84,7 +84,8 @@ function createButton(
     bgColor = 0x111122,
     textColor,
     bgOpacity = 0.8,
-    shape = 'rect'
+    shape = 'rect',
+    hoverScale = 1.05
 ) {
     const group = new THREE.Group();
     group.name = `button_${label.replace(/\s+/g, '_')}`;
@@ -128,7 +129,7 @@ function createButton(
         const intensity = hovered ? 1.5 : 1;
         bg.material.emissiveIntensity = intensity;
         border.material.emissiveIntensity = intensity;
-        group.scale.setScalar(hovered ? 1.05 : 1);
+        group.scale.setScalar(hovered ? hoverScale : 1);
         if (hovered) AudioManager.playSfx('uiHoverSound');
     };
 
@@ -754,12 +755,16 @@ function createAscensionModal() {
         name.position.set(-0.18, 0.06, 0.01);
         const desc = createTextSprite('', 24, '#ffffff', 'left');
         desc.position.set(-0.32, -0.02, 0.01);
+        // Divider line and footer text mimic the 2D tooltip layout.
+        const divider = new THREE.Mesh(new THREE.PlaneGeometry(0.66, 0.005), holoMaterial(0x00ffff, 0.4));
+        divider.position.set(0, -0.06, 0.01);
+        divider.name = 'tooltip_footer_divider';
         // Separate rank and cost text like the 2D menu's flex layout.
         const rank = createTextSprite('', 24, '#cccccc', 'left');
         rank.position.set(-0.32, -0.11, 0.01);
         const cost = createTextSprite('', 24, '#cccccc', 'right');
         cost.position.set(0.32, -0.11, 0.01);
-        group.add(bg, border, icon, name, desc, rank, cost);
+        group.add(bg, border, icon, name, desc, divider, rank, cost);
         group.userData = { icon, name, desc, rank, cost };
         return group;
     }
@@ -837,11 +842,14 @@ function createAscensionModal() {
                         0x111122,
                         0xffffff,
                         0.8,
-                        'circle'
+                        'circle',
+                        1.15
                     );
                     btn.userData.talentId = t.id;
                     btn.position.copy(positions[t.id]);
+                    const baseHover = btn.children[0].userData.onHover;
                     btn.userData.onHover = hovered => {
+                        if (baseHover) baseHover(hovered);
                         if (hovered) {
                             AudioManager.playSfx('uiHoverSound');
                             const purchasedNow = state.player.purchasedTalents.get(t.id) || 0;

--- a/task_log.md
+++ b/task_log.md
@@ -55,6 +55,7 @@
     * [x] Resolved layering bug where menu buttons could render behind panels.
     * [x] Reworked render ordering so button faces, borders, and labels always draw above their modal backgrounds.
     * [x] Made controller hand menu buttons show their labels and frames only when hovered to reduce clutter.
+    * [x] Added tooltip footer divider and 1.15 hover scale so Ascension talents mirror 2D visuals precisely.
 * [x] Raised modal positions so menus appear higher with their bottoms at waist height.
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.

--- a/tests/ascensionNexus.test.js
+++ b/tests/ascensionNexus.test.js
@@ -132,5 +132,21 @@ test('ascension tooltip shows Mastery and cost for unpurchased talent', async ()
   assert.ok(tooltip, 'tooltip should exist');
   assert.equal(tooltip.userData.rank.userData.text, 'Mastery');
   assert.equal(tooltip.userData.cost.userData.text, 'Cost: 1 AP');
+  const divider = tooltip.children.find(c => c.name === 'tooltip_footer_divider');
+  assert.ok(divider, 'tooltip footer divider should exist');
+  assert.equal(divider.material.color.getHex(), 0x00ffff);
+});
+
+test('talent button uses 1.15 hover scale', async () => {
+  const { initModals, showModal, getModalObjects } = await setup();
+  initModals();
+  showModal('ascension');
+  const ascensionModal = getModalObjects().find(m => m.name === 'modal_ascension');
+  assert.ok(ascensionModal);
+  const grid = ascensionModal.children.find(c => c.name === 'ascension_grid');
+  const coreBtn = grid.children.find(c => c.userData && c.userData.talentId === 'core-nexus');
+  assert.ok(coreBtn, 'core nexus button should exist');
+  coreBtn.userData.onHover(true);
+  assert.equal(coreBtn.scale.x, 1.15);
 });
 


### PR DESCRIPTION
## Summary
- allow buttons to specify hover scale and apply the original 1.15 hover size to Ascension talent nodes
- add a cyan divider inside talent tooltips for a 2D-accurate footer layout
- test Ascension tooltip divider and hover scaling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68925fcac078833189256262f0315750