### PR TITLE
Sync ascension conduit HUD and line layers

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -912,7 +912,14 @@ function createAscensionModal() {
                             colorHex = new THREE.Color(getConstellationColorOfTalent(pr)).getHex();
                         }
                     }
-                    const mat = new THREE.LineBasicMaterial({ color: new THREE.Color(colorHex), transparent: true, opacity, linewidth: width });
+                    const mat = new THREE.LineBasicMaterial({
+                        color: new THREE.Color(colorHex),
+                        transparent: true,
+                        opacity,
+                        linewidth: width,
+                        depthTest: false,
+                        depthWrite: false
+                    });
                     const geom = new THREE.BufferGeometry().setFromPoints([start, end]);
                     lines.add(new THREE.Line(geom, mat));
                 });

--- a/modules/ascension.js
+++ b/modules/ascension.js
@@ -1,6 +1,7 @@
 import { state, savePlayerState } from './state.js';
 import { TALENT_GRID_CONFIG } from './talents.js';
 import { AudioManager } from './audio.js';
+import { updateHud } from './UIManager.js';
 
 // Create a flat map of all talents for easy lookup
 const allTalents = {};
@@ -46,6 +47,7 @@ export function purchaseTalent(talentId) {
         
         applyAllTalentEffects();
         savePlayerState();
+        updateHud();
     } else {
         AudioManager.playSfx('talentError');
         console.warn("Cannot purchase talent: Not enough AP or prerequisites not met.");
@@ -61,6 +63,7 @@ export function applyAllTalentEffects() {
     state.player.maxHealth = 100;
     state.player.speed = 1.0;
     state.player.talent_modifiers.damage_multiplier = 1.0;
+    state.player.talent_modifiers.damage_taken_multiplier = 1.0;
     state.player.talent_modifiers.pickup_radius_bonus = 0;
     state.player.talent_modifiers.essence_gain_modifier = 1.0;
     state.player.talent_modifiers.power_spawn_rate_modifier = 1.0;

--- a/task_log.md
+++ b/task_log.md
@@ -56,6 +56,7 @@
     * [x] Reworked render ordering so button faces, borders, and labels always draw above their modal backgrounds.
     * [x] Made controller hand menu buttons show their labels and frames only when hovered to reduce clutter.
     * [x] Added tooltip footer divider and 1.15 hover scale so Ascension talents mirror 2D visuals precisely.
+    * [x] Synced talent purchases with HUD updates and drew connector lines without depth testing so the Ascension grid layers exactly like the 2D menu.
 * [x] Raised modal positions so menus appear higher with their bottoms at waist height.
 * [x] Restore backgrounds and fix scaling issues. — Completed
 * [x] Recreate stage select layout and styling to mirror the 2D game's menu.

--- a/tests/ascensionNexus.test.js
+++ b/tests/ascensionNexus.test.js
@@ -68,7 +68,8 @@ async function setup() {
       },
       getBgTexture: () => null,
       showUnlockNotification: () => {},
-      showBossBanner: () => {}
+      showBossBanner: () => {},
+      updateHud: () => {}
     }
   });
 


### PR DESCRIPTION
## Summary
- trigger VR HUD refresh when purchasing ascension talents
- reset damage modifiers and draw talent connectors without depth testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689261d203b08331aee1863d7f805658