### PR TITLE
Handle missing power set in ascension grid

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -912,7 +912,8 @@ function createAscensionModal() {
                 if (key === 'color') return;
                 const t = con[key];
                 const end = positions[t.id];
-                const powerUnlocked = !t.powerPrerequisite || state.player.unlockedPowers.has(t.powerPrerequisite);
+                const powerUnlocked = !t.powerPrerequisite ||
+                    (state.player.unlockedPowers && state.player.unlockedPowers.has(t.powerPrerequisite));
                 t.prerequisites.forEach(pr => {
                     const start = positions[pr];
                     if (!start) return;

--- a/modules/ascension.js
+++ b/modules/ascension.js
@@ -140,9 +140,9 @@ export function getConstellationColorOfTalent(talentId) {
  */
 export function isTalentVisible(talent) {
     if (!talent) return false;
-
+    const unlockedPowers = state.player.unlockedPowers || new Set();
     const powerUnlocked = !talent.powerPrerequisite ||
-        state.player.unlockedPowers.has(talent.powerPrerequisite);
+        unlockedPowers.has(talent.powerPrerequisite);
     if (!powerUnlocked) {
         return false;
     }


### PR DESCRIPTION
## Summary
- Guard talent visibility against undefined `unlockedPowers`
- Skip connector rendering unless required power is unlocked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689266bdb0d4833191e42add527e5e1f