### PR TITLE
Fix missile targeting from controller position

### DIFF
--- a/modules/powers.js
+++ b/modules/powers.js
@@ -79,14 +79,12 @@ export const powers = {
           aimDir.copy(state.cursorDir);
       }
 
-      // Fire the projectile along the controller's aim direction from the
-      // controller's position.  Previously the target was computed relative to
-      // the world origin which caused missiles to shoot through the sphere's
-      // centre.  Offsetting from the start position keeps the projectile moving
-      // away from the player as intended.
-      // Target a point on the far side of the sphere relative to the player so
-      // that missiles travel away from the avatar instead of toward the centre.
-      const targetPos = origin.position.clone().add(aimDir.clone().multiplyScalar(ARENA_RADIUS * 2));
+      // Fire the projectile along the controller's aim direction from its
+      // actual start position. Computing the target from the player's origin
+      // caused missiles to steer through the sphere's centre whenever the
+      // controller was offset from the avatar. Targeting from `startPos`
+      // keeps the projectile travelling straight away from the controller.
+      const targetPos = startPos.clone().add(aimDir.clone().multiplyScalar(ARENA_RADIUS * 2));
       const velocity = targetPos.clone().sub(startPos).normalize().multiplyScalar(VR_PROJECTILE_SPEED_SCALE);
 
       state.effects.push({

--- a/task_log.md
+++ b/task_log.md
@@ -11,6 +11,7 @@
     * Cleared stale references so repeated initialisation cannot spawn duplicate avatars or lasers.
 * [ ] **Power-up Functionality:**
     * [x] Fix the missile power-up. — Completed
+        * Resolved controller offset so missiles spawn from the controller tip and target the correct direction.
     * [x] Ensure all other power-ups are functional.
         * [x] Chain lightning power adapted with 3D beam effect.
         * [x] Heal and black hole powers render 3D effects.


### PR DESCRIPTION
## Summary
- prevent missiles from drifting through the sphere by computing their target from the controller's start position
- expand missile unit test to verify controller offset and adjust simulation steps
- document missile fix in task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68926b64015483319e71b64ec2aad539