### PR TITLE
Ensure game over menu faces the player

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -612,6 +612,23 @@ export function showModal(id) {
     }
 }
 
+export function updateActiveModalTransform() {
+    if (!modalGroup || !state.activeModalId) return;
+    const camera = getCamera();
+    if (!camera) return;
+    const modal = modals[state.activeModalId];
+    const forward = new THREE.Vector3(0, 0, -1)
+        .applyQuaternion(camera.quaternion)
+        .setY(0)
+        .normalize();
+    modalGroup.position.copy(camera.position).addScaledVector(forward, 2);
+    const modalHeight = (modal?.userData?.height || 0) * modalGroup.scale.y;
+    const waistOffset = 0.6;
+    modalGroup.position.y = camera.position.y - waistOffset + modalHeight / 2;
+    const yawOnly = new THREE.Euler(0, camera.rotation.y, 0, 'YXZ');
+    modalGroup.quaternion.setFromEuler(yawOnly);
+}
+
 export function hideModal() {
     if (state.activeModalId && modals[state.activeModalId]) {
         const modal = modals[state.activeModalId];

--- a/task_log.md
+++ b/task_log.md
@@ -101,6 +101,7 @@
 * [x] Realigned stage labels and boss names with their bars and kept Game Over's restart label within bounds.
 * [x] Standardized Stage Select row widths and anchored info buttons to match the 2D menu.
 * [x] Centered Game Over buttons so Stage Select stays within the modal frame.
+* [x] Ensured Game Over menu reorients toward the player so it's always readable after death.
 * [x] Hardened general utilities: randomInRange handles reversed bounds, safeAddEventListener reports status, drawLightning clamps width, lineCircleCollision rejects zero/negative radii, and wrapText ignores non-positive lengths.
 * [x] Prevented avatar drift toward UI by locking movement target during menu interaction, including when pointing at non-interactive panels.
 * [x] Added safeguards for edge cases: spherical direction now returns zero for degenerate inputs, UV sanitization wraps v values, movement steps are clamped to avoid overshoot, player damage ignores invalid values, and ring drawing normalizes radii and alpha.

--- a/tests/vrMain.test.js
+++ b/tests/vrMain.test.js
@@ -35,9 +35,9 @@ async function setupLaunch() {
     namedExports: { initUI: mock.fn(), updateHud: mock.fn(), showHud }
   });
 
-  await mock.module('../modules/ModalManager.js', {
-    namedExports: { initModals: mock.fn(), showModal: mock.fn() }
-  });
+    await mock.module('../modules/ModalManager.js', {
+      namedExports: { initModals: mock.fn(), showModal: mock.fn(), updateActiveModalTransform: mock.fn() }
+    });
 
   await mock.module('../modules/vrGameLoop.js', {
     namedExports: { vrGameLoop: mock.fn() }

--- a/vrMain.js
+++ b/vrMain.js
@@ -3,7 +3,7 @@ import { XRButton } from './vendor/addons/webxr/XRButton.js';
 import { initScene, getScene, getRenderer, getCamera } from './modules/scene.js';
 import { initPlayerController, updatePlayerController } from './modules/PlayerController.js';
 import { initUI, updateHud, showHud } from './modules/UIManager.js';
-import { initModals, showModal } from './modules/ModalManager.js';
+import { initModals, showModal, updateActiveModalTransform } from './modules/ModalManager.js';
 import { vrGameLoop } from './modules/vrGameLoop.js';
 import { Telemetry } from './modules/telemetry.js';
 import { state, resetGame } from './modules/state.js';
@@ -24,6 +24,8 @@ function render(timestamp, frame) {
     if (state.gameOver && !state.isPaused) {
         showModal('gameOver');
     }
+
+    updateActiveModalTransform();
 
     updateHud();
     renderer.render(getScene(), getCamera());


### PR DESCRIPTION
## Summary
- reorient active modal each frame so game over menu tracks the player's view
- update render loop to reposition modals every frame
- log UI improvement in task log and adjust test mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68928bdd480c8331b669b65ebaf305ed