### PR TITLE
Fix menu facing and hide HUD during modals

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -6,7 +6,7 @@ import { AudioManager } from './audio.js';
 import { bossData } from './bosses.js';
 import { TALENT_GRID_CONFIG } from './talents.js';
 import { purchaseTalent, isTalentVisible, getConstellationColorOfTalent } from './ascension.js';
-import { holoMaterial, createTextSprite, updateTextSprite, getBgTexture } from './UIManager.js';
+import { holoMaterial, createTextSprite, updateTextSprite, getBgTexture, hideHud, showHud } from './UIManager.js';
 import { gameHelpers } from './gameHelpers.js';
 import { disposeGroupChildren, wrapText } from './helpers.js';
 import { STAGE_CONFIG } from './config.js';
@@ -591,14 +591,17 @@ export function showModal(id) {
     const modalHeight = (modal?.userData?.height || 0) * modalGroup.scale.y;
     const waistOffset = 0.6; // approximate distance from head to waist in meters
     modalGroup.position.y = camera.position.y - waistOffset + modalHeight / 2;
-    const yawOnly = new THREE.Euler(0, camera.rotation.y, 0, 'YXZ');
-    modalGroup.quaternion.setFromEuler(yawOnly);
+    const lookTarget = camera.position.clone();
+    lookTarget.y = modalGroup.position.y;
+    modalGroup.lookAt(lookTarget);
+    modalGroup.rotation.y += Math.PI;
 
     state.activeModalId = id;
     // Pause the game before heavy UI creation to avoid race conditions
     state.isPaused = true;
     resetInputFlags();
     state.uiInteractionCooldownUntil = Date.now() + 250;
+    hideHud();
     modal.visible = true;
     AudioManager.playSfx('uiModalOpen');
 
@@ -625,8 +628,10 @@ export function updateActiveModalTransform() {
     const modalHeight = (modal?.userData?.height || 0) * modalGroup.scale.y;
     const waistOffset = 0.6;
     modalGroup.position.y = camera.position.y - waistOffset + modalHeight / 2;
-    const yawOnly = new THREE.Euler(0, camera.rotation.y, 0, 'YXZ');
-    modalGroup.quaternion.setFromEuler(yawOnly);
+    const lookTarget = camera.position.clone();
+    lookTarget.y = modalGroup.position.y;
+    modalGroup.lookAt(lookTarget);
+    modalGroup.rotation.y += Math.PI;
 }
 
 export function hideModal() {
@@ -640,6 +645,7 @@ export function hideModal() {
         resetInputFlags();
         AudioManager.playSfx('uiModalClose');
         state.isPaused = false; // Unpause unless another condition requires it
+        showHud();
     }
 }
 

--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -327,6 +327,7 @@ export function initUI() {
 }
 
 export function showHud() { if (uiGroup) uiGroup.visible = true; }
+export function hideHud() { if (uiGroup) uiGroup.visible = false; }
 export function getUIRoot() { return uiGroup; }
 
 export function updateHud() {

--- a/tests/ascensionNexus.test.js
+++ b/tests/ascensionNexus.test.js
@@ -69,7 +69,9 @@ async function setup() {
       getBgTexture: () => null,
       showUnlockNotification: () => {},
       showBossBanner: () => {},
-      updateHud: () => {}
+      updateHud: () => {},
+      showHud: () => {},
+      hideHud: () => {}
     }
   });
 


### PR DESCRIPTION
## Summary
- Ensure menus always face the player smoothly by billboarding toward the camera
- Hide HUD while any modal is displayed and restore it when closed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68928fdb034883318511131384f961f0