### PR TITLE
Fix VR modals facing away from player

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -594,7 +594,6 @@ export function showModal(id) {
     const lookTarget = camera.position.clone();
     lookTarget.y = modalGroup.position.y;
     modalGroup.lookAt(lookTarget);
-    modalGroup.rotation.y += Math.PI;
 
     state.activeModalId = id;
     // Pause the game before heavy UI creation to avoid race conditions
@@ -631,7 +630,6 @@ export function updateActiveModalTransform() {
     const lookTarget = camera.position.clone();
     lookTarget.y = modalGroup.position.y;
     modalGroup.lookAt(lookTarget);
-    modalGroup.rotation.y += Math.PI;
 }
 
 export function hideModal() {

--- a/task_log.md
+++ b/task_log.md
@@ -108,3 +108,4 @@
 * [x] Reapplied `bg.png` pattern overlay on modal and button backgrounds for faithful 2D-style menus.
 * [x] Removed `bg.png` texture from buttons and HUD elements so it only serves as modal wallpaper, matching the original 2D game.
 * [x] Fixed additional gameplay bugs: projectile updates now validate callbacks, shield timers clear on break, player health clamps non-negative, circle drawing guards against invalid contexts, and particle spawner verifies inputs.
+* [x] Corrected modal orientation so menus face the player instead of showing their backs.


### PR DESCRIPTION
## Summary
- Remove redundant 180° rotation so VR menus face the camera properly
- Note orientation fix in the project task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68929778d44c83318c011a0f0fc1cfb2