### PR TITLE
Fix projectile floor collision, death audio and progression

### DIFF
--- a/modules/BaseAgent.js
+++ b/modules/BaseAgent.js
@@ -2,6 +2,8 @@
 // Import a local copy of three.js instead of relying on a global THREE
 import * as THREE from '../vendor/three.module.js';
 import * as CoreManager from './CoreManager.js';
+import { state } from './state.js';
+import { gameHelpers as globalGameHelpers } from './gameHelpers.js';
 
 export class BaseAgent extends THREE.Group {
   constructor(options = {}) {
@@ -47,9 +49,14 @@ export class BaseAgent extends THREE.Group {
   }
 
   die(gameHelpers = null) {
-    if (!gameHelpers) gameHelpers = {};
+    if (!gameHelpers) gameHelpers = globalGameHelpers;
     this.alive = false;
+    if (gameHelpers && typeof gameHelpers.addEssence === 'function') {
+      gameHelpers.addEssence(this.boss ? 300 : 20);
+    }
     CoreManager.onEnemyDeath(this, gameHelpers);
+    const idx = state.enemies.indexOf(this);
+    if (idx !== -1) state.enemies.splice(idx, 1);
     if (this.parent) this.parent.remove(this);
   }
 }

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -102,6 +102,10 @@ export function applyPlayerDamage(amount, source = null, gameHelpers = {}) {
     return 0;
   }
 
+  if (gameHelpers && typeof gameHelpers.play === 'function') {
+    gameHelpers.play('hitSound');
+  }
+
   const newHealth = state.player.health - damage;
   if (newHealth <= 0) {
     if (!CoreManager.onFatalDamage(source, gameHelpers)) {

--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -179,9 +179,10 @@ export function updateEffects3d(radius = 50, deltaMs = 16){
         break;
       }
       case 'fireball':{
-        ef.position.add(ef.velocity.clone().multiplyScalar(deltaFactor));
-        const reached = ef.position.distanceTo(ef.target) < 0.5;
-        if(reached){
+        const step = ef.velocity.clone().multiplyScalar(deltaFactor);
+        const toTarget = ef.target.clone().sub(ef.position);
+        if (toTarget.length() <= step.length()) {
+          ef.position.copy(ef.target);
           state.effects.splice(i,1);
           state.effects.push({
             type:'shockwave',
@@ -197,6 +198,7 @@ export function updateEffects3d(radius = 50, deltaMs = 16){
           });
           break;
         }
+        ef.position.add(step);
         break;
       }
       case 'ricochet_projectile':{

--- a/modules/vrGameLoop.js
+++ b/modules/vrGameLoop.js
@@ -22,8 +22,6 @@ function updatePhaseMomentum() {
     }
 }
 
-let lastSpawnTime = 0;
-let lastPowerUpTime = 0;
 let lastFrameTime = null;
 
 function handleLevelProgression() {
@@ -41,20 +39,17 @@ function handleLevelProgression() {
 }
 
 function handleEnemyAndPowerSpawning() {
-    const now = Date.now();
     if (!state.bossActive) return;
-
-    if (now - lastSpawnTime > 4000) {
+    const enemyChance = 0.007 + state.player.level * 0.001;
+    if (Math.random() < enemyChance) {
         if (state.enemies.filter(e => !e.boss).length < 15) {
             spawnEnemy(false);
         }
-        lastSpawnTime = now;
     }
-
-    const spawnInterval = 6000 / state.player.talent_modifiers.power_spawn_rate_modifier;
-    if (now - lastPowerUpTime > spawnInterval) {
+    const baseSpawnChance = 0.02 + state.player.level * 0.0002;
+    const finalSpawnChance = baseSpawnChance * state.player.talent_modifiers.power_spawn_rate_modifier;
+    if (Math.random() < finalSpawnChance) {
         spawnPickup();
-        lastPowerUpTime = now;
     }
 }
 

--- a/task_log.md
+++ b/task_log.md
@@ -112,3 +112,6 @@
 * [x] Fixed missile explosions so nearby bosses and enemies take damage even if they lack an explicit `alive` flag.
 * [x] Added enemy separation logic to keep foes from occupying the same spot.
 * [x] Replaced death audio with the original 2D "stone cracking" sound effect.
+* [x] Ensured missile explosions trigger even when fired through the floor.
+* [x] Restored hit sound on fatal player damage.
+* [x] Awarded essence on enemy and boss deaths, clearing stages and resuming enemy and power-up spawns.

--- a/tests/experienceOnKill.test.js
+++ b/tests/experienceOnKill.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { BaseAgent } from '../modules/BaseAgent.js';
+import { state } from '../modules/state.js';
+import { initGameHelpers } from '../modules/gameHelpers.js';
+
+initGameHelpers({ addEssence: amt => { state.player.essence += amt; } });
+
+test('enemy death grants essence and removes from state', () => {
+  state.player.essence = 0;
+  state.enemies.length = 0;
+  const enemy = new BaseAgent();
+  state.enemies.push(enemy);
+  enemy.die();
+  assert.equal(state.player.essence, 20);
+  assert.ok(!state.enemies.includes(enemy));
+});
+
+test('boss death grants more essence', () => {
+  state.player.essence = 0;
+  state.enemies.length = 0;
+  const boss = new BaseAgent();
+  boss.boss = true;
+  state.enemies.push(boss);
+  boss.die();
+  assert.equal(state.player.essence, 300);
+  assert.ok(!state.enemies.includes(boss));
+});

--- a/tests/missileFireball.test.js
+++ b/tests/missileFireball.test.js
@@ -107,3 +107,26 @@ test('missile damages enemies without explicit alive flag', () => {
 
   assert.ok(enemy.takeDamage.mock.calls.length > 0, 'enemy damaged despite missing alive flag');
 });
+
+test('missile fireball explodes when firing downward through floor', () => {
+  initGameHelpers({ play: () => {}, pulseControllers: () => {}, addStatusEffect: () => {} });
+  state.effects.length = 0;
+  state.enemies.length = 0;
+  state.offensiveInventory = ['missile', null, null];
+
+  state.player.position.set(0, 0, 50);
+  state.cursorDir.set(0, -1, 0);
+
+  useOffensivePower();
+  const fireball = state.effects.find(e => e.type === 'fireball');
+  assert.ok(fireball, 'fireball spawned');
+
+  for (let i = 0; i < 1000 && state.effects.includes(fireball); i++) {
+    updateEffects3d(16);
+    updateProjectiles3d(50, 1000, 1000, 16);
+  }
+
+  assert.ok(!state.effects.includes(fireball), 'fireball resolved');
+  const explosion = state.effects.find(e => e.type === 'shockwave');
+  assert.ok(explosion, 'explosion triggered');
+});

--- a/tests/playerDeathSound.test.js
+++ b/tests/playerDeathSound.test.js
@@ -1,0 +1,15 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { applyPlayerDamage } from '../modules/helpers.js';
+import { state } from '../modules/state.js';
+
+test('player death triggers hitSound', () => {
+  state.player.health = 5;
+  state.player.shield = false;
+  state.gameOver = false;
+  const helpers = { play: mock.fn() };
+  applyPlayerDamage(10, null, helpers);
+  assert.equal(helpers.play.mock.calls[0].arguments[0], 'hitSound');
+  assert.ok(state.gameOver, 'game over triggered');
+});


### PR DESCRIPTION
## Summary
- Ensure missile fireballs detonate even when overshooting through the floor
- Play the classic hit sound whenever fatal damage is applied to the player
- Grant experience and advance stages when enemies or bosses die; resume enemy and power-up spawns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892b002c9e483318b3109aa055942fb