### PR TITLE
Fix boss UI and talent visibility

### DIFF
--- a/tests/isBossEnemy.test.js
+++ b/tests/isBossEnemy.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isBossEnemy } from '../modules/UIManager.js';
+import { bossData } from '../modules/bosses.js';
+
+test('isBossEnemy matches by kind', () => {
+  const enemy = { kind: bossData[0].id };
+  assert.equal(isBossEnemy(enemy), true);
+});
+
+test('isBossEnemy matches by id', () => {
+  const enemy = { id: bossData[1].id };
+  assert.equal(isBossEnemy(enemy), true);
+});
+
+test('isBossEnemy rejects normal enemy', () => {
+  const enemy = { id: 'not_a_boss' };
+  assert.equal(isBossEnemy(enemy), false);
+});

--- a/tests/isTalentVisible.test.js
+++ b/tests/isTalentVisible.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isTalentVisible } from '../modules/ascension.js';
+import { TALENT_GRID_CONFIG } from '../modules/talents.js';
+import { state } from '../modules/state.js';
+
+test('isTalentVisible handles array unlockedPowers', () => {
+  const original = state.player.unlockedPowers;
+  state.player.unlockedPowers = ['heal', 'missile'];
+  const talent = TALENT_GRID_CONFIG.core['core-nexus'];
+  assert.equal(isTalentVisible(talent), true);
+  state.player.unlockedPowers = original;
+});


### PR DESCRIPTION
## Summary
- Detect bosses by ID for hand-mounted health bar rendering
- Harden talent visibility checks to handle array-based power unlocks
- Restyle and reposition level progress bar beneath AP display
- Add unit tests for boss recognition and talent visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892b5bda25083319207b7720c5f8a3b