### PR TITLE
Fix ascension talent visibility with legacy saves

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -842,23 +842,31 @@ function createAscensionModal() {
             });
         });
 
+        const purchasedTalents =
+            state.player.purchasedTalents && typeof state.player.purchasedTalents.get === 'function'
+                ? state.player.purchasedTalents
+                : new Map(state.player.purchasedTalents || []);
+        if (purchasedTalents !== state.player.purchasedTalents) {
+            state.player.purchasedTalents = purchasedTalents;
+        }
+
         Object.values(TALENT_GRID_CONFIG).forEach(con => {
             Object.keys(con).forEach(key => {
                 if (key === 'color') return;
                 const t = con[key];
-                const purchased = state.player.purchasedTalents.get(t.id) || 0;
+                const purchased = purchasedTalents.get(t.id) || 0;
                 const isMax = !t.isInfinite && purchased >= t.maxRanks;
                 const cost = t.isInfinite ? t.costPerRank[0] : t.costPerRank[purchased];
                 const prereqsMet = t.prerequisites.every(p => {
                     const prereqTalent = allTalents[p];
                     if (!prereqTalent) return false;
                     const needed = prereqTalent.maxRanks;
-                    const current = state.player.purchasedTalents.get(p) || 0;
+                    const current = purchasedTalents.get(p) || 0;
                     return current >= needed;
                 });
                 const canPurchase = prereqsMet && state.player.ascensionPoints >= cost;
 
-                if (state.player.purchasedTalents.has(t.id) || isTalentVisible(t)) {
+                if (purchasedTalents.has(t.id) || isTalentVisible(t)) {
                     let borderColor = 0xaaaaaa;
                     if (t.isNexus || t.isInfinite) {
                         borderColor = 0x00ff00;
@@ -896,7 +904,7 @@ function createAscensionModal() {
                         if (baseHover) baseHover(hovered);
                         if (hovered) {
                             AudioManager.playSfx('uiHoverSound');
-                            const purchasedNow = state.player.purchasedTalents.get(t.id) || 0;
+                            const purchasedNow = purchasedTalents.get(t.id) || 0;
                             const isMaxNow = !t.isInfinite && purchasedNow >= t.maxRanks;
                             const costNow = t.isInfinite ? t.costPerRank[0] : t.costPerRank[purchasedNow];
                             const costText = isMaxNow ? 'MAXED' : `Cost: ${costNow} AP`;
@@ -939,7 +947,7 @@ function createAscensionModal() {
                     const start = positions[pr];
                     if (!start) return;
                     if (!powerUnlocked) return;
-                    if (!state.player.purchasedTalents.has(pr) && pr !== 'core-nexus') return;
+                    if (!purchasedTalents.has(pr) && pr !== 'core-nexus') return;
                     const prereq = allTalents[pr];
                     const nexusConnection = (t.isNexus || (prereq && prereq.isNexus));
                     let colorHex = 0xaaaaaa;
@@ -949,7 +957,7 @@ function createAscensionModal() {
                         width = 0.015;
                     }
                     const needed = prereq ? prereq.maxRanks : 1;
-                    const current = state.player.purchasedTalents.get(pr) || 0;
+                    const current = purchasedTalents.get(pr) || 0;
                     let opacity = 0.3;
                     if (current >= needed) {
                         opacity = 1.0;

--- a/task_log.md
+++ b/task_log.md
@@ -115,3 +115,4 @@
 * [x] Ensured missile explosions trigger even when fired through the floor.
 * [x] Restored hit sound on fatal player damage.
 * [x] Awarded essence on enemy and boss deaths, clearing stages and resuming enemy and power-up spawns.
+* [x] Fixed ascension menu so talents render correctly even when `purchasedTalents` loads from a legacy array save, ensuring the Core Nexus is always visible.

--- a/tests/ascensionLegacyTalents.test.js
+++ b/tests/ascensionLegacyTalents.test.js
@@ -1,0 +1,91 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+async function setup(purchasedTalents) {
+  mock.reset();
+  global.requestAnimationFrame = (fn) => fn();
+  const scene = { children: [], add(obj) { this.children.push(obj); } };
+  await mock.module('../modules/scene.js', {
+    namedExports: {
+      getScene: () => scene,
+      getCamera: () => ({
+        position: new THREE.Vector3(),
+        rotation: new THREE.Euler(),
+        quaternion: new THREE.Quaternion()
+      }),
+      getRenderer: () => ({}),
+      getPrimaryController: () => ({})
+    }
+  });
+
+  const state = {
+    activeModalId: null,
+    isPaused: false,
+    uiInteractionCooldownUntil: 0,
+    player: {
+      ascensionPoints: 0,
+      purchasedTalents,
+      unlockedPowers: new Set()
+    }
+  };
+
+  await mock.module('../modules/state.js', {
+    namedExports: { state, savePlayerState: mock.fn(), resetGame: mock.fn() }
+  });
+
+  await mock.module('../modules/PlayerController.js', {
+    namedExports: { refreshPrimaryController: mock.fn(), resetInputFlags: mock.fn() }
+  });
+
+  await mock.module('../modules/audio.js', {
+    namedExports: { AudioManager: { playSfx: mock.fn() } }
+  });
+
+  await mock.module('../modules/gameHelpers.js', {
+    namedExports: { gameHelpers: {}, initGameHelpers: () => {} }
+  });
+
+  await mock.module('../modules/UIManager.js', {
+    namedExports: {
+      holoMaterial: (color = 0x1e1e2f, opacity = 0.85) => ({
+        color: new THREE.Color(color),
+        emissive: new THREE.Color(color),
+        emissiveIntensity: 1,
+        transparent: true,
+        opacity,
+        dispose: () => {}
+      }),
+      createTextSprite: (text = '') => {
+        const obj = new THREE.Object3D();
+        obj.material = { color: new THREE.Color(0xffffff), opacity: 1, dispose: () => {} };
+        obj.userData = { text };
+        return obj;
+      },
+      updateTextSprite: (obj, newText) => {
+        obj.userData.text = newText;
+      },
+      getBgTexture: () => null,
+      showUnlockNotification: () => {},
+      showBossBanner: () => {},
+      updateHud: () => {},
+      showHud: () => {},
+      hideHud: () => {}
+    }
+  });
+
+  const { initModals, showModal, getModalObjects } = await import('../modules/ModalManager.js');
+  return { scene, initModals, showModal, getModalObjects };
+}
+
+// Ensure the talent grid renders even if purchasedTalents comes from a legacy array save.
+test('ascension modal shows core nexus with array purchasedTalents', async () => {
+  const { initModals, showModal, getModalObjects } = await setup([]);
+  initModals();
+  showModal('ascension');
+  const ascensionModal = getModalObjects().find(m => m.name === 'modal_ascension');
+  assert.ok(ascensionModal);
+  const grid = ascensionModal.children.find(c => c.name === 'ascension_grid');
+  const nexusButton = grid.children.find(c => c.userData && c.userData.talentId === 'core-nexus');
+  assert.ok(nexusButton, 'core nexus button should exist');
+});


### PR DESCRIPTION
## Summary
- handle legacy array `purchasedTalents` when rendering the Ascension grid so talents like Core Nexus always appear
- add regression test ensuring Core Nexus shows with array-based talent data
- log the fix in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892b9b7b8848331a2ebcbc6f437ded1