### PR TITLE
Fix boss health bar display

### DIFF
--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -431,7 +431,7 @@ export function updateHud() {
                 bossBars.set(boss.instanceId, bar);
                 bossContainer.add(bar);
             }
-            const cur = boss.id === 'fractal_horror' ? (state.fractalHorrorSharedHp ?? 0) : boss.hp;
+            const cur = boss.id === 'fractal_horror' ? (state.fractalHorrorSharedHp ?? 0) : boss.health;
             const pct = Math.max(0, cur / boss.maxHP);
             bar.userData.fill.scale.x = pct;
             const color = getBossColor(boss);

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -335,7 +335,7 @@ export function updateUI() {
             }
 
             const bar = wrapper.querySelector('.boss-hp-bar');
-            const currentHp = boss.id === 'fractal_horror' ? (state.fractalHorrorSharedHp ?? 0) : boss.hp;
+            const currentHp = boss.id === 'fractal_horror' ? (state.fractalHorrorSharedHp ?? 0) : boss.health;
             bar.style.backgroundColor = boss.color;
             bar.style.width = `${Math.max(0, currentHp / boss.maxHP) * 100}%`;
         });
@@ -343,7 +343,7 @@ export function updateUI() {
 
     const mainBoss = bossesToDisplay[0];
     if(mainBoss && vrBossFill){
-        const cur = mainBoss.id === 'fractal_horror' ? (state.fractalHorrorSharedHp ?? 0) : mainBoss.hp;
+        const cur = mainBoss.id === 'fractal_horror' ? (state.fractalHorrorSharedHp ?? 0) : mainBoss.health;
         const pct = Math.max(0, cur / mainBoss.maxHP);
         vrBossFill.object3D.scale.x = pct;
         vrBossFill.setAttribute('material', `color:${mainBoss.color}; emissive:${mainBoss.color}; emissiveIntensity:0.6`);

--- a/task_log.md
+++ b/task_log.md
@@ -116,3 +116,4 @@
 * [x] Restored hit sound on fatal player damage.
 * [x] Awarded essence on enemy and boss deaths, clearing stages and resuming enemy and power-up spawns.
 * [x] Fixed ascension menu so talents render correctly even when `purchasedTalents` loads from a legacy array save, ensuring the Core Nexus is always visible.
+* [x] Corrected boss health bar logic so colored fills track each boss's `health` value instead of a nonexistent `hp` field.


### PR DESCRIPTION
## Summary
- Display boss health bars correctly by reading `health` instead of non-existent `hp`
- Apply fix to both VR and DOM UI implementations
- Log health bar fix in task tracker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892bb923f908331b5a4ee381cb7ff3d