### PR TITLE
Remove stone sound on player death

### DIFF
--- a/modules/vrGameLoop.js
+++ b/modules/vrGameLoop.js
@@ -124,7 +124,6 @@ export function vrGameLoop(timestamp) {
     if (state.player.health <= 0) {
         if (!CoreManager.onFatalDamage(null, gameHelpers)) {
             state.gameOver = true;
-            AudioManager.playSfx('stoneCrackingSound');
         }
     }
 }

--- a/task_log.md
+++ b/task_log.md
@@ -112,6 +112,7 @@
 * [x] Fixed missile explosions so nearby bosses and enemies take damage even if they lack an explicit `alive` flag.
 * [x] Added enemy separation logic to keep foes from occupying the same spot.
 * [x] Replaced death audio with the original 2D "stone cracking" sound effect.
+* [x] Removed stone death sound so only the standard hit audio plays on fatal damage, matching 2D behavior.
 * [x] Ensured missile explosions trigger even when fired through the floor.
 * [x] Restored hit sound on fatal player damage.
 * [x] Awarded essence on enemy and boss deaths, clearing stages and resuming enemy and power-up spawns.


### PR DESCRIPTION
## Summary
- remove stone cracking sound effect from player death logic so only the standard hit sound plays when health reaches zero
- document removal of stone death sound in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892bcfe884083319edb86046ff57c0a