### PR TITLE
Fix ascension grid layering

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -108,10 +108,12 @@ function createButton(
     group.add(bg);
 
     const border = new THREE.Mesh(borderGeom, holoMaterial(color, 0.5));
-    border.position.z = -0.001;
-    // The border sits behind the button face but still needs to render above
-    // the modal background so its edges remain visible.
-    border.renderOrder = 0.5;
+    // Keep the border coplanar with the button face so it doesn't appear to
+    // drift relative to the background when the player moves their head.
+    border.position.z = 0.001;
+    // Draw the border just above the button background but below the label so
+    // its frame is always visible without fighting the face for depth.
+    border.renderOrder = 1.1;
     group.add(border);
 
     const txtColor = textColor !== undefined ? textColor : color;
@@ -178,9 +180,12 @@ function createModalContainer(width, height, title, options = {}) {
     }
 
     if (borderOpacity > 0) {
-        const border = new THREE.Mesh(new THREE.PlaneGeometry(width + 0.02, height + 0.02), holoMaterial(borderColor, borderOpacity));
-        border.position.z = -0.001;
-        border.renderOrder = -1;
+        const borderGeom = new THREE.PlaneGeometry(width + 0.02, height + 0.02);
+        const border = new THREE.Mesh(borderGeom, holoMaterial(borderColor, borderOpacity));
+        // Place the border slightly in front of the background so its edge is
+        // always visible and coplanar with the panel.
+        border.position.z = 0.001;
+        border.renderOrder = 1;
         group.add(border);
     }
 
@@ -697,6 +702,7 @@ function createAscensionModal() {
     modal.add(grid);
 
     const lines = new THREE.Group();
+    lines.renderOrder = 0.5;
     grid.add(lines);
 
     function createApDisplay() {
@@ -705,7 +711,8 @@ function createAscensionModal() {
         const bgHeight = 0.15;
         const bg = new THREE.Mesh(new THREE.PlaneGeometry(1, bgHeight), holoMaterial(0x000000, 0.3));
         const border = new THREE.Mesh(new THREE.PlaneGeometry(1.02, bgHeight + 0.02), holoMaterial(0x00ffff, 0.4));
-        border.position.z = -0.001;
+        border.position.z = 0.001;
+        border.renderOrder = 1;
 
         // Use the same cyan/white pairing as the 2D header and tone the label
         // opacity down to 70% to mirror its semi-transparent styling.
@@ -754,12 +761,16 @@ function createAscensionModal() {
 
     // Divider lines to mirror the 2D modal's header and footer borders.
     const headerDivider = new THREE.Mesh(new THREE.PlaneGeometry(1.55, 0.01), holoMaterial(0x00ffff, 0.4));
-    headerDivider.position.set(0, 0.45, 0.02);
+    // Keep dividers nearly coplanar with the modal so they don't appear to
+    // float above or sink behind the panel.
+    headerDivider.position.set(0, 0.45, 0.001);
+    headerDivider.renderOrder = 1;
     headerDivider.name = 'ascension_header_divider';
     modal.add(headerDivider);
 
     const footerDivider = new THREE.Mesh(new THREE.PlaneGeometry(1.55, 0.01), holoMaterial(0x00ffff, 0.4));
-    footerDivider.position.set(0, -0.45, 0.02);
+    footerDivider.position.set(0, -0.45, 0.001);
+    footerDivider.renderOrder = 1;
     footerDivider.name = 'ascension_footer_divider';
     modal.add(footerDivider);
 

--- a/modules/ascension.js
+++ b/modules/ascension.js
@@ -59,64 +59,78 @@ export function purchaseTalent(talentId) {
  * This should be called after loading a save or purchasing a talent.
  */
 export function applyAllTalentEffects() {
-    // Reset all modifiers to their base values before recalculating
-    state.player.maxHealth = 100;
-    state.player.speed = 1.0;
-    state.player.talent_modifiers.damage_multiplier = 1.0;
-    state.player.talent_modifiers.damage_taken_multiplier = 1.0;
-    state.player.talent_modifiers.pickup_radius_bonus = 0;
-    state.player.talent_modifiers.essence_gain_modifier = 1.0;
-    state.player.talent_modifiers.power_spawn_rate_modifier = 1.0;
+    // Reset all modifiers to their base values just like the original 2D game
+    // before applying the bonuses from purchased talents.
+    let baseMaxHealth = 100;
+    let baseSpeed = 1.0;
+    let baseDamageMultiplier = 1.0;
+    let baseDamageTakenMultiplier = 1.0;
+    let basePickupRadius = 0;
+    let baseEssenceGain = 1.0;
+    let basePowerSpawnRate = 1.0;
+    let basePullResistance = 0;
 
     state.player.purchasedTalents.forEach((rank, id) => {
-        const talent = allTalents[id];
-        if (!talent) return;
-        
-        // This is a simplified application based on your talents.js file.
-        // It directly modifies the state properties.
         switch (id) {
-            case 'exo-weave-plating':
-                const healthValues = [15, 20, 25];
-                for (let i = 0; i < rank; i++) state.player.maxHealth += healthValues[i];
+            case 'exo-weave-plating': {
+                const values = [15, 20, 25];
+                for (let i = 0; i < rank; i++) baseMaxHealth += values[i];
                 break;
-            case 'solar-wind':
-                state.player.speed += rank * 0.06;
+            }
+            case 'solar-wind': {
+                const values = [0.06, 0.06];
+                for (let i = 0; i < rank; i++) baseSpeed += values[i];
                 break;
-            case 'high-frequency-emitters':
-                const damageValues = [0.05, 0.07];
-                for (let i = 0; i < rank; i++) state.player.talent_modifiers.damage_multiplier += damageValues[i];
+            }
+            case 'high-frequency-emitters': {
+                const values = [0.05, 0.07];
+                for (let i = 0; i < rank; i++) baseDamageMultiplier += values[i];
                 break;
+            }
             case 'resonance-magnet':
-                // NOTE: This pixel value should be converted to world units where it's used
-                state.player.talent_modifiers.pickup_radius_bonus += rank * 75;
+                basePickupRadius += rank * 75;
                 break;
-            case 'essence-conduit':
-                 const essenceValues = [0.10, 0.15];
-                for (let i = 0; i < rank; i++) state.player.talent_modifiers.essence_gain_modifier += essenceValues[i];
+            case 'essence-conduit': {
+                const values = [0.10, 0.15];
+                for (let i = 0; i < rank; i++) baseEssenceGain += values[i];
                 break;
-            case 'resonant-frequencies':
-                state.player.talent_modifiers.power_spawn_rate_modifier += rank * 0.10;
+            }
+            case 'resonant-frequencies': {
+                const values = [0.10, 0.10];
+                for (let i = 0; i < rank; i++) basePowerSpawnRate += values[i];
                 break;
+            }
+            // Endless talents
             case 'core-reinforcement':
-                state.player.maxHealth += rank * 5;
+                baseMaxHealth += rank * 5;
                 break;
             case 'momentum-drive':
-                state.player.speed += rank * 0.01;
+                baseSpeed += rank * 0.01;
                 break;
             case 'weapon-calibration':
-                state.player.talent_modifiers.damage_multiplier += rank * 0.01;
+                baseDamageMultiplier += rank * 0.01;
                 break;
         }
     });
 
-    // Reset dynamic talent states
+    // Apply all calculated values to the state
+    state.player.maxHealth = baseMaxHealth;
+    state.player.speed = baseSpeed;
+    state.player.talent_modifiers.damage_multiplier = baseDamageMultiplier;
+    state.player.talent_modifiers.damage_taken_multiplier = baseDamageTakenMultiplier;
+    state.player.talent_modifiers.pickup_radius_bonus = basePickupRadius;
+    state.player.talent_modifiers.essence_gain_modifier = baseEssenceGain;
+    state.player.talent_modifiers.power_spawn_rate_modifier = basePowerSpawnRate;
+    state.player.talent_modifiers.pull_resistance_modifier = basePullResistance;
+
+    // Reset dynamic talent states to match 2D behaviour
     state.player.talent_states.phaseMomentum.active = false;
     if (state.player.purchasedTalents.has('phase-momentum')) {
         state.player.talent_states.phaseMomentum.lastDamageTime = Date.now();
     }
     state.player.talent_states.reactivePlating.lastTrigger = 0;
 
-    // After applying all maxHealth modifiers, ensure current health isn't higher.
+    // After applying maxHealth modifiers ensure current health isn't higher
     state.player.health = Math.min(state.player.health, state.player.maxHealth);
 }
 /**

--- a/task_log.md
+++ b/task_log.md
@@ -117,4 +117,5 @@
 * [x] Restored hit sound on fatal player damage.
 * [x] Awarded essence on enemy and boss deaths, clearing stages and resuming enemy and power-up spawns.
 * [x] Fixed ascension menu so talents render correctly even when `purchasedTalents` loads from a legacy array save, ensuring the Core Nexus is always visible.
+* [x] Aligned Ascension modal borders and talent nodes with their backgrounds so frames no longer flicker or drift in VR.
 * [x] Corrected boss health bar logic so colored fills track each boss's `health` value instead of a nonexistent `hp` field.


### PR DESCRIPTION
## Summary
- Keep talent node borders and modal frames coplanar with their panels so they no longer flicker or drift in VR
- Re-implement talent stat calculations to mirror original 2D game's ascension logic
- Document UI layering fix in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68935d0581408331b4a0d5080f01d7ef