### PR TITLE
Ignore HUD in controller raycasts

### DIFF
--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -331,6 +331,11 @@ export function initUI() {
 
     createHudElements();
 
+    // The HUD is purely informational and should never block controller
+    // rays. Disable raycasting on the entire HUD tree so the cursor can
+    // pass through without affecting player movement.
+    hudMesh.traverse(obj => { obj.raycast = () => {}; });
+
     bossContainer = new THREE.Group();
     bossContainer.name = 'bossContainer';
     bossContainer.position.set(0, 0.1, -0.05);

--- a/task_log.md
+++ b/task_log.md
@@ -119,3 +119,4 @@
 * [x] Fixed ascension menu so talents render correctly even when `purchasedTalents` loads from a legacy array save, ensuring the Core Nexus is always visible.
 * [x] Aligned Ascension modal borders and talent nodes with their backgrounds so frames no longer flicker or drift in VR.
 * [x] Corrected boss health bar logic so colored fills track each boss's `health` value instead of a nonexistent `hp` field.
+* [x] Disabled HUD raycasts so the cursor passes through without affecting player movement.

--- a/tests/hudRaycastIgnore.test.js
+++ b/tests/hudRaycastIgnore.test.js
@@ -1,0 +1,57 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+async function setup() {
+  const controller = new THREE.Object3D();
+  const camera = new THREE.Object3D();
+  const makeCanvas = () => {
+    const ctx = {
+      font: '',
+      shadowColor: '',
+      shadowBlur: 0,
+      fillStyle: '',
+      textBaseline: '',
+      textAlign: '',
+      measureText: () => ({ width: 0 }),
+      fillText: () => {},
+      clearRect: () => {},
+    };
+    return { getContext: () => ctx, width: 0, height: 0 };
+  };
+  global.document = {
+    createElement: () => makeCanvas(),
+    getElementById: () => null,
+    body: { appendChild: () => {} }
+  };
+  global.window = { devicePixelRatio: 1 };
+
+  await mock.module('../modules/scene.js', {
+    namedExports: {
+      getCamera: () => camera,
+      getPrimaryController: () => controller,
+      getRenderer: () => ({ domElement: { style: {} } }),
+      getScene: () => new THREE.Scene(),
+      getArena: () => ({})
+    }
+  });
+
+  const ui = await import(`../modules/UIManager.js?test=${Math.random()}`);
+  return { controller, camera, ...ui };
+}
+
+test('HUD elements ignore controller raycasts', async () => {
+  mock.reset();
+  const { initUI, getUIRoot } = await setup();
+  initUI();
+  const uiRoot = getUIRoot();
+  const hud = uiRoot.children.find(c => c.name === 'hudContainer');
+  hud.position.set(0, 0, -1);
+  hud.updateMatrixWorld(true);
+  const raycaster = new THREE.Raycaster(new THREE.Vector3(0, 0, 0), new THREE.Vector3(0, 0, -1));
+  const hits = raycaster.intersectObjects([hud], true);
+  assert.equal(hits.length, 0);
+  delete global.document;
+  delete global.window;
+  mock.reset();
+});


### PR DESCRIPTION
## Summary
- prevent HUD from intercepting controller rays
- document fix
- add regression test verifying HUD ignores raycasts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68937cd8a6c48331af3cfcf7bbf0f891