### PR TITLE
Harden utility helpers

### DIFF
--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -141,7 +141,8 @@ export function clamp(value, min, max) {
  * @returns {number} The player's updated health.
  */
 export function applyPlayerHeal(amount) {
-  const newHealth = clamp(state.player.health + amount, 0, state.player.maxHealth);
+  const amt = Number.isFinite(amount) ? amount : 0;
+  const newHealth = clamp(state.player.health + amt, 0, state.player.maxHealth);
   state.player.health = newHealth;
   return newHealth;
 }

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -26,13 +26,16 @@ export function drawCircle(ctx, x, y, r, c) {
 }
 
 export function drawCrystal(ctx, x, y, size, color) {
+  if (!ctx || typeof ctx.beginPath !== 'function') return;
+  const s = Number.isFinite(size) ? size : 0;
+  if (s <= 0) return;
   const sides = 6;
   ctx.fillStyle = color;
   ctx.beginPath();
-  ctx.moveTo(x + size * Math.cos(0), y + size * Math.sin(0));
+  ctx.moveTo(x + s * Math.cos(0), y + s * Math.sin(0));
   for (let i = 1; i <= sides; i++) {
     const angle = i * 2 * Math.PI / sides;
-    const modSize = (i % 2 === 0) ? size : size * 0.6;
+    const modSize = (i % 2 === 0) ? s : s * 0.6;
     ctx.lineTo(x + modSize * Math.cos(angle), y + modSize * Math.sin(angle));
   }
   ctx.closePath();
@@ -52,6 +55,9 @@ export function drawCrystal(ctx, x, y, size, color) {
  * @param {string} color - Fill style for the player representation.
  */
 export function drawPlayer(ctx, player, color) {
+  if (!ctx || !player || !player.position || !player.position.isVector3) return;
+  const radius = Number.isFinite(player.r) ? player.r : 0;
+  if (radius <= 0) return;
   const { x, y } = toCanvasPos(
     player.position,
     ctx.canvas.width,
@@ -59,7 +65,7 @@ export function drawPlayer(ctx, player, color) {
   );
   ctx.fillStyle = color;
   ctx.beginPath();
-  ctx.arc(x, y, player.r, 0, 2 * Math.PI);
+  ctx.arc(x, y, radius, 0, 2 * Math.PI);
   ctx.fill();
 }
 
@@ -68,8 +74,11 @@ export function drawPlayer(ctx, player, color) {
  * object.  Used for the player's Annihilator core effect.
  */
 export function drawShadowCone(ctx, sourceX, sourceY, shadowCaster, color) {
+  if (!ctx || !shadowCaster) return;
+  const r = Number.isFinite(shadowCaster.r) ? shadowCaster.r : 0;
+  if (r <= 0) return;
   const distToCaster = Math.hypot(shadowCaster.x - sourceX, shadowCaster.y - sourceY);
-  const safeRadius = shadowCaster.r * 1.5;
+  const safeRadius = r * 1.5;
   if (distToCaster <= safeRadius) return; // Source is inside the caster's safe zone
   const angleToCaster = Math.atan2(shadowCaster.y - sourceY, shadowCaster.x - sourceX);
   const angleToTangent = Math.asin(safeRadius / distToCaster);
@@ -136,11 +145,13 @@ export function spawnParticles(particles, x, y, c, n, spd, life, r = 3) {
 }
 
 export function updateParticles(ctx, particles) {
+  if (!ctx || !Array.isArray(particles)) return;
   for (let i = particles.length - 1; i >= 0; i--) {
     const p = particles[i];
     p.position.add(p.velocity);
     p.life--;
-    ctx.globalAlpha = p.life / p.maxLife;
+    const alpha = p.maxLife > 0 ? p.life / p.maxLife : 0;
+    ctx.globalAlpha = Math.max(0, Math.min(1, alpha));
     ctx.fillStyle = p.color;
     ctx.beginPath();
     if (p.r > 0) {
@@ -154,8 +165,10 @@ export function updateParticles(ctx, particles) {
 }
 
 export function triggerScreenShake(duration, magnitude) {
-  screenShakeEnd = Date.now() + duration;
-  screenShakeMagnitude = magnitude;
+  const dur = Number.isFinite(duration) ? Math.max(0, duration) : 0;
+  const mag = Number.isFinite(magnitude) ? Math.max(0, magnitude) : 0;
+  screenShakeEnd = Date.now() + dur;
+  screenShakeMagnitude = mag;
 }
 
 export function applyScreenShake(ctx) {

--- a/task_log.md
+++ b/task_log.md
@@ -110,6 +110,7 @@
 * [x] Reapplied `bg.png` pattern overlay on modal and button backgrounds for faithful 2D-style menus.
 * [x] Removed `bg.png` texture from buttons and HUD elements so it only serves as modal wallpaper, matching the original 2D game.
 * [x] Fixed additional gameplay bugs: projectile updates now validate callbacks, shield timers clear on break, player health clamps non-negative, circle drawing guards against invalid contexts, and particle spawner verifies inputs.
+* [x] Hardened drawing helpers against bad inputs: crystal and player rendering now validate contexts, shadow cones require valid radii, particle updates avoid divide-by-zero alpha, and screen shake clamps magnitude and duration.
 * [x] Corrected modal orientation so menus face the player instead of showing their backs.
 * [x] Fixed missile explosions so nearby bosses and enemies take damage even if they lack an explicit `alive` flag.
 * [x] Added enemy separation logic to keep foes from occupying the same spot.


### PR DESCRIPTION
## Summary
- prevent NaN healing by validating `applyPlayerHeal` input
- add defensive checks for crystal, player, and shadow cone drawing
- stabilize particle alpha and screen shake duration handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68939e1beffc833191a118535bdb9291