### PR TITLE
feat: enrich boss models with lore-based shapes

### DIFF
--- a/modules/BaseAgent.js
+++ b/modules/BaseAgent.js
@@ -4,30 +4,39 @@ import * as THREE from '../vendor/three.module.js';
 import * as CoreManager from './CoreManager.js';
 import { state } from './state.js';
 import { gameHelpers as globalGameHelpers } from './gameHelpers.js';
+import { createBossModel } from './bossModelFactory.js';
 
 export class BaseAgent extends THREE.Group {
   constructor(options = {}) {
     super();
-    const { health = 1, model = null, color = null, radius = 0.65 } = options;
+    const { health = 1, model = null, color = null, radius = 0.65, kind = null } = options;
     // Store the agent's base collision radius so the game loop can scale it
     // uniformly. Having a defined radius ensures accurate hit detection for
     // both default sphere agents and those using custom models.
     this.r = radius;
+    this.kind = kind;
     this.maxHealth = health;
+    this.maxHP = health;
     this.health = health;
     this.alive = true;
     if (model) {
       this.add(model);
       this.model = model;
-    } else if (color !== null) {
-      const material = new THREE.MeshStandardMaterial({
-        color,
-        emissive: color,
-        emissiveIntensity: 0.5,
-      });
-      const geometry = new THREE.SphereGeometry(radius, 32, 16);
-      this.model = new THREE.Mesh(geometry, material);
-      this.add(this.model);
+    } else {
+      const autoModel = createBossModel(kind, color, radius);
+      if (autoModel) {
+        this.add(autoModel);
+        this.model = autoModel;
+      } else if (color !== null) {
+        const material = new THREE.MeshStandardMaterial({
+          color,
+          emissive: color,
+          emissiveIntensity: 0.5,
+        });
+        const geometry = new THREE.SphereGeometry(radius, 32, 16);
+        this.model = new THREE.Mesh(geometry, material);
+        this.add(this.model);
+      }
     }
   }
 

--- a/modules/agents/AnnihilatorAI.js
+++ b/modules/agents/AnnihilatorAI.js
@@ -9,14 +9,10 @@ const ARENA_RADIUS = 50;
 
 export class AnnihilatorAI extends BaseAgent {
   constructor() {
-    super({ color: 0xd63031 });
-
     const bossData = { id: "annihilator", name: "The Annihilator", maxHP: 480 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0xd63031, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.isChargingBeam = false;
     this.lastBeamTime = 0;
 

--- a/modules/agents/ArchitectAI.js
+++ b/modules/agents/ArchitectAI.js
@@ -7,14 +7,10 @@ const ARENA_RADIUS = 50;
 
 export class ArchitectAI extends BaseAgent {
   constructor() {
-    super({ color: 0x7f8c8d });
-
     const bossData = { id: "architect", name: "The Architect", maxHP: 280 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0x7f8c8d, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.lastBuildTime = 0;
   }
 

--- a/modules/agents/CenturionAI.js
+++ b/modules/agents/CenturionAI.js
@@ -7,14 +7,10 @@ const ARENA_RADIUS = 50;
 
 export class CenturionAI extends BaseAgent {
   constructor() {
-    super({ color: 0xd35400 });
-
     const bossData = { id: "centurion", name: "The Centurion", maxHP: 480 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0xd35400, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.lastWallTime = 0;
   }
 

--- a/modules/agents/EMPOverloadAI.js
+++ b/modules/agents/EMPOverloadAI.js
@@ -5,14 +5,10 @@ import { gameHelpers } from '../gameHelpers.js';
 
 export class EMPOverloadAI extends BaseAgent {
   constructor() {
-    super({ color: 0x3498db });
-
     const bossData = { id: "emp", name: "EMP Overload", maxHP: 260 };
-    this.kind = bossData.id;
-    this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
+    super({ health: bossData.maxHP, color: 0x3498db, kind: bossData.id });
 
+    this.name = bossData.name;
     this.lastEMPTime = 0;
     this.isCharging = false;
   }

--- a/modules/agents/EpochEnderAI.js
+++ b/modules/agents/EpochEnderAI.js
@@ -5,14 +5,10 @@ import { gameHelpers } from '../gameHelpers.js';
 
 export class EpochEnderAI extends BaseAgent {
   constructor() {
-    super({ color: 0xbdc3c7 });
-
     const bossData = { id: "epoch_ender", name: "The Epoch-Ender", maxHP: 550 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0xbdc3c7, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.damageInWindow = 0;
     this.lastStateSnapshot = { position: this.position.clone(), health: this.health };
     this.lastSnapshotTime = 0;

--- a/modules/agents/FractalHorrorAI.js
+++ b/modules/agents/FractalHorrorAI.js
@@ -6,20 +6,14 @@ import { gameHelpers } from '../gameHelpers.js';
 export class FractalHorrorAI extends BaseAgent {
   constructor(generation = 1) {
     const size = 1.2 / generation;
-    super({ color: 0xbe2edd });
-    
-    if (generation === 1) {
-        const bossData = { id: "fractal_horror", name: "The Fractal Horror", maxHP: 10000 };
-        this.kind = bossData.id;
-    this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-        state.fractalHorrorSharedHp = this.maxHP;
-    } else {
-        this.maxHP = 10000 / generation;
-        this.health = this.maxHP;
-    }
+    const bossData = { id: "fractal_horror", name: "The Fractal Horror", maxHP: 10000 };
+    super({ health: bossData.maxHP / generation, color: 0xbe2edd, kind: bossData.id, radius: size });
 
+    if (generation === 1) {
+        this.name = bossData.name;
+        state.fractalHorrorSharedHp = this.maxHP;
+    }
+    
     this.generation = generation;
   }
 

--- a/modules/agents/GravityAI.js
+++ b/modules/agents/GravityAI.js
@@ -6,14 +6,10 @@ const ARENA_RADIUS = 50;
 
 export class GravityAI extends BaseAgent {
   constructor() {
-    super({ color: 0x9b59b6 });
-
     const bossData = { id: "gravity", name: "Gravity Tyrant", maxHP: 168 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0x9b59b6, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.wells = [];
     this.wellObjects = new THREE.Group();
     this.add(this.wellObjects);
@@ -21,7 +17,7 @@ export class GravityAI extends BaseAgent {
     for (let i = 0; i < 8; i++) {
         const well = { angle: i * (Math.PI / 4), dist: 8, radius: 2 }; // World units
         this.wells.push(well);
-        
+
         const wellGeo = new THREE.TorusGeometry(well.radius, 0.2, 8, 24);
         const wellMat = new THREE.MeshBasicMaterial({ color: 0x9b59b6, transparent: true, opacity: 0.4 });
         const wellMesh = new THREE.Mesh(wellGeo, wellMat);

--- a/modules/agents/JuggernautAI.js
+++ b/modules/agents/JuggernautAI.js
@@ -8,14 +8,10 @@ const ARENA_RADIUS = 50;
 
 export class JuggernautAI extends BaseAgent {
   constructor() {
-    super({ color: 0x636e72 });
-
     const bossData = { id: "juggernaut", name: "The Juggernaut", maxHP: 360 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0x636e72, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.isCharging = false;
     this.chargeEndTime = 0;
     this.lastChargeTime = 0;

--- a/modules/agents/LoopingEyeAI.js
+++ b/modules/agents/LoopingEyeAI.js
@@ -7,14 +7,10 @@ const ARENA_RADIUS = 50;
 
 export class LoopingEyeAI extends BaseAgent {
   constructor() {
-    super({ color: 0xecf0f1 });
-
     const bossData = { id: "looper", name: "Looping Eye", maxHP: 320 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0xecf0f1, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.lastTeleportTime = Date.now();
     this.isChargingTeleport = false;
   }

--- a/modules/agents/MiasmaAI.js
+++ b/modules/agents/MiasmaAI.js
@@ -7,14 +7,10 @@ const ARENA_RADIUS = 50;
 
 export class MiasmaAI extends BaseAgent {
   constructor() {
-    super({ color: 0x6ab04c });
-
     const bossData = { id: "miasma", name: "The Miasma", maxHP: 400 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0x6ab04c, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.isGasActive = false;
     this.lastGasAttack = 0;
     this.isChargingSlam = false;

--- a/modules/agents/PantheonAI.js
+++ b/modules/agents/PantheonAI.js
@@ -10,14 +10,10 @@ import { AnnihilatorAI } from './AnnihilatorAI.js';
 
 export class PantheonAI extends BaseAgent {
   constructor() {
-    super({ color: 0xecf0f1 });
-
     const bossData = { id: "pantheon", name: "The Pantheon", maxHP: 3000 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0xecf0f1, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.nextActionTime = Date.now() + 3000;
     this.activeAspects = new Map(); // Use a Map to store aspect AI instances
 

--- a/modules/agents/PuppeteerAI.js
+++ b/modules/agents/PuppeteerAI.js
@@ -5,14 +5,10 @@ import { gameHelpers } from '../gameHelpers.js';
 
 export class PuppeteerAI extends BaseAgent {
   constructor() {
-    super({ color: 0xa29bfe });
-    
     const bossData = { id: "puppeteer", name: "The Puppeteer", maxHP: 320 };
-    this.kind = bossData.id;
-    this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
+    super({ health: bossData.maxHP, color: 0xa29bfe, kind: bossData.id });
 
+    this.name = bossData.name;
     this.lastConvertTime = 0;
   }
 

--- a/modules/agents/QuantumShadowAI.js
+++ b/modules/agents/QuantumShadowAI.js
@@ -7,14 +7,10 @@ const ARENA_RADIUS = 50;
 
 export class QuantumShadowAI extends BaseAgent {
   constructor() {
-    super({ color: 0x81ecec });
-
     const bossData = { id: "quantum_shadow", name: "Quantum Shadow", maxHP: 360 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0x81ecec, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.phase = 'seeking'; // 'seeking' or 'superposition'
     this.lastPhaseChangeTime = Date.now();
     this.invulnerable = false;

--- a/modules/agents/SentinelPairAI.js
+++ b/modules/agents/SentinelPairAI.js
@@ -9,14 +9,10 @@ const ARENA_RADIUS = 50;
 
 export class SentinelPairAI extends BaseAgent {
   constructor(partner = null) {
-    super({ color: 0xf1c40f });
-    
     const bossData = { id: "sentinel_pair", name: "Sentinel Pair", maxHP: 400 };
-    this.kind = bossData.id;
-    this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
+    super({ health: bossData.maxHP, color: 0xf1c40f, kind: bossData.id });
 
+    this.name = bossData.name;
     this.partner = partner;
     if (this.partner) {
         this.partner.partner = this; // Link back

--- a/modules/agents/ShaperOfFateAI.js
+++ b/modules/agents/ShaperOfFateAI.js
@@ -7,14 +7,10 @@ const ARENA_RADIUS = 50;
 
 export class ShaperOfFateAI extends BaseAgent {
   constructor() {
-    super({ color: 0xf1c40f });
-
     const bossData = { id: "shaper_of_fate", name: "The Shaper of Fate", maxHP: 600 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0xf1c40f, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.phase = 'idle'; // idle -> prophecy -> fulfillment
     this.phaseTimer = Date.now() + 3000;
   }

--- a/modules/agents/SingularityAI.js
+++ b/modules/agents/SingularityAI.js
@@ -7,14 +7,10 @@ const ARENA_RADIUS = 50;
 
 export class SingularityAI extends BaseAgent {
   constructor() {
-    super({ color: 0x000000 });
-
     const bossData = { id: "singularity", name: "The Singularity", maxHP: 600 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0x000000, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.phase = 1;
     this.lastActionTime = 0;
   }

--- a/modules/agents/SyphonAI.js
+++ b/modules/agents/SyphonAI.js
@@ -5,14 +5,10 @@ import { gameHelpers } from '../gameHelpers.js';
 
 export class SyphonAI extends BaseAgent {
   constructor() {
-    super({ color: 0x9b59b6 });
-
     const bossData = { id: "syphon", name: "The Syphon", maxHP: 450 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0x9b59b6, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.isCharging = false;
     this.lastSyphonTime = 0;
   }

--- a/modules/agents/TimeEaterAI.js
+++ b/modules/agents/TimeEaterAI.js
@@ -7,14 +7,10 @@ const ARENA_RADIUS = 50;
 
 export class TimeEaterAI extends BaseAgent {
   constructor() {
-    super({ color: 0xdfe6e9 });
-
     const bossData = { id: "time_eater", name: "Time Eater", maxHP: 440 };
-    this.kind = bossData.id;
+    super({ health: bossData.maxHP, color: 0xdfe6e9, kind: bossData.id });
+
     this.name = bossData.name;
-    this.maxHP = bossData.maxHP;
-    this.health = this.maxHP;
-    
     this.lastAbilityTime = 0;
   }
 

--- a/modules/bossModelFactory.js
+++ b/modules/bossModelFactory.js
@@ -1,0 +1,98 @@
+import * as THREE from '../vendor/three.module.js';
+
+export function createBossModel(kind, color = 0xffffff, radius = 0.65) {
+  const material = new THREE.MeshStandardMaterial({
+    color,
+    emissive: color,
+    emissiveIntensity: 0.5,
+  });
+  let mesh;
+  switch (kind) {
+    case 'syphon':
+      mesh = new THREE.Mesh(new THREE.TorusGeometry(radius * 1.2, radius / 3, 16, 32), material);
+      break;
+    case 'centurion':
+      mesh = new THREE.Mesh(new THREE.CylinderGeometry(radius * 0.8, radius * 0.8, radius * 2, 16), material);
+      break;
+    case 'gravity': {
+      const group = new THREE.Group();
+      const sphere = new THREE.Mesh(new THREE.SphereGeometry(radius, 32, 16), material);
+      const ring = new THREE.Mesh(new THREE.TorusGeometry(radius * 1.4, radius / 6, 8, 32), material.clone());
+      ring.rotation.x = Math.PI / 2;
+      group.add(sphere);
+      group.add(ring);
+      mesh = group;
+      break;
+    }
+    case 'emp':
+      mesh = new THREE.Mesh(new THREE.OctahedronGeometry(radius), material);
+      break;
+    case 'fractal_horror':
+      mesh = new THREE.Mesh(new THREE.IcosahedronGeometry(radius, 2), material);
+      break;
+    case 'pantheon':
+      mesh = new THREE.Mesh(new THREE.TorusKnotGeometry(radius, radius / 4, 64, 8), material);
+      break;
+    case 'sentinel_pair':
+      mesh = new THREE.Mesh(new THREE.BoxGeometry(radius * 1.2, radius * 1.2, radius * 1.2), material);
+      break;
+    case 'annihilator':
+      mesh = new THREE.Mesh(new THREE.ConeGeometry(radius, radius * 2, 16), material);
+      break;
+    case 'architect':
+      mesh = new THREE.Mesh(new THREE.BoxGeometry(radius * 1.5, radius * 1.5, radius * 1.5), material);
+      break;
+    case 'quantum_shadow':
+      material.transparent = true;
+      material.opacity = 0.7;
+      mesh = new THREE.Mesh(new THREE.TetrahedronGeometry(radius), material);
+      break;
+    case 'puppeteer':
+      mesh = new THREE.Mesh(new THREE.OctahedronGeometry(radius), material);
+      break;
+    case 'singularity': {
+      const group = new THREE.Group();
+      material.metalness = 1;
+      material.roughness = 0.1;
+      const core = new THREE.Mesh(new THREE.SphereGeometry(radius, 32, 16), material);
+      const halo = new THREE.Mesh(new THREE.TorusGeometry(radius * 1.2, radius / 6, 8, 32), material.clone());
+      halo.rotation.x = Math.PI / 2;
+      group.add(core);
+      group.add(halo);
+      mesh = group;
+      break;
+    }
+    case 'juggernaut':
+      mesh = new THREE.Mesh(new THREE.DodecahedronGeometry(radius * 1.3), material);
+      break;
+    case 'shaper_of_fate':
+      mesh = new THREE.Mesh(new THREE.TorusKnotGeometry(radius, radius / 5, 32, 8), material);
+      break;
+    case 'time_eater':
+      mesh = new THREE.Mesh(new THREE.RingGeometry(radius * 0.5, radius, 32), material);
+      mesh.rotation.x = Math.PI / 2;
+      break;
+    case 'miasma':
+      material.transparent = true;
+      material.opacity = 0.6;
+      mesh = new THREE.Mesh(new THREE.SphereGeometry(radius, 16, 16), material);
+      break;
+    case 'epoch_ender':
+      mesh = new THREE.Mesh(new THREE.DodecahedronGeometry(radius), material);
+      break;
+    case 'looper': {
+      const group = new THREE.Group();
+      const eye = new THREE.Mesh(new THREE.SphereGeometry(radius, 32, 16), material);
+      const pupilMat = new THREE.MeshStandardMaterial({ color: 0x000000 });
+      const pupil = new THREE.Mesh(new THREE.SphereGeometry(radius * 0.3, 16, 16), pupilMat);
+      pupil.position.z = radius * 0.7;
+      group.add(eye);
+      group.add(pupil);
+      mesh = group;
+      break;
+    }
+    default:
+      mesh = new THREE.Mesh(new THREE.SphereGeometry(radius, 32, 16), material);
+  }
+  return mesh;
+}

--- a/task_log.md
+++ b/task_log.md
@@ -27,7 +27,7 @@
 ## 3D Assets and Animations
 
 * [ ] **3D Models and Animations:**
-    * [ ] Create 3D spherical models for all bosses and enemies. — In Progress (most enemies now use base spheres)
+    * [x] Create 3D spherical models for all bosses and enemies. — Completed
     * [ ] Implement animations for all bosses, enemies, and power-ups. — In Progress
         * [x] Enabled delta-based enemy AI updates to support animations.
         * [x] Added expanding sphere visual for the `shockwave` power-up.


### PR DESCRIPTION
## Summary
- add bossModelFactory to build lore-appropriate geometries for each boss
- hook BaseAgent into the model factory and pass boss IDs to constructors
- mark 3D boss model task complete in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893a2ec259483319fd475c9f854aa47