### PR TITLE
Enhance boss models with lore-driven designs

### DIFF
--- a/task_log.md
+++ b/task_log.md
@@ -35,6 +35,7 @@
     * [x] Create a swirling cube animation for the "glitch" enemy. — Completed
     * [ ] Ensure all animations are interpolated for VR. — In Progress (projectiles, effects, and enemy AI use delta timing)
     * [x] Upgraded boss models with lore-driven shapes for progressive visual flair (Splitter, Reflector, Vampire, Gravity, Epoch Ender).
+    * [x] Expanded upgrades to additional bosses so designs scale with difficulty (Syphon, Centurion, Sentinel Pair, Annihilator, Architect, Quantum Shadow, Puppeteer).
 * [x] **Sizing:** Increase the size of the player, bosses, and enemies by 30%. — Completed
 
 ## UI


### PR DESCRIPTION
## Summary
- Elaborated boss models so syphon, centurion, sentinel pair, annihilator, architect, quantum shadow, and puppeteer each feature geometry inspired by their lore
- Logged the additional model upgrades in the task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893a8462794833189f09ef1508a86e8