### PR TITLE
Add progressive boss ability animations

### DIFF
--- a/modules/BaseAgent.js
+++ b/modules/BaseAgent.js
@@ -5,6 +5,7 @@ import * as CoreManager from './CoreManager.js';
 import { state } from './state.js';
 import { gameHelpers as globalGameHelpers } from './gameHelpers.js';
 import { createBossModel } from './bossModelFactory.js';
+import { spawnBossAbilityEffect } from './bossAbilityEffects.js';
 
 export class BaseAgent extends THREE.Group {
   constructor(options = {}) {
@@ -67,5 +68,9 @@ export class BaseAgent extends THREE.Group {
     const idx = state.enemies.indexOf(this);
     if (idx !== -1) state.enemies.splice(idx, 1);
     if (this.parent) this.parent.remove(this);
+  }
+
+  triggerAbilityAnimation(stage = 1, duration = 1000) {
+    spawnBossAbilityEffect(this, stage, duration);
   }
 }

--- a/modules/agents/AethelUmbraAI.js
+++ b/modules/agents/AethelUmbraAI.js
@@ -12,7 +12,7 @@ export class AethelUmbraAI extends BaseAgent {
         emissiveIntensity: 0.5
     });
     super({ model: new THREE.Mesh(geometry, material) });
-    
+
     this.role = role;
     this.partner = partner;
     this.enraged = false;
@@ -20,6 +20,7 @@ export class AethelUmbraAI extends BaseAgent {
     this.maxHP = isAethel ? 280 * 0.75 : 280 * 1.5;
     this.health = this.maxHP;
     this.speed = isAethel ? 1.5 : 0.8;
+    this.kind = role.toLowerCase();
   }
   
   update(delta) {
@@ -46,5 +47,6 @@ export class AethelUmbraAI extends BaseAgent {
     const healthBonus = this.maxHP * 0.5;
     this.maxHP += healthBonus;
     this.health += healthBonus;
+    this.triggerAbilityAnimation(3, 1500);
   }
 }

--- a/modules/agents/ReflectorAI.js
+++ b/modules/agents/ReflectorAI.js
@@ -35,6 +35,8 @@ export class ReflectorAI extends BaseAgent {
         this.cycles++;
         if (this.cycles % 3 === 0) {
           this.reflecting = true;
+          const stage = Math.min(3, Math.floor(this.cycles / 3));
+          this.triggerAbilityAnimation(stage, 1000);
           setTimeout(() => { this.reflecting = false; }, 2000);
         }
       }

--- a/modules/agents/SplitterAI.js
+++ b/modules/agents/SplitterAI.js
@@ -22,6 +22,7 @@ export class SplitterAI extends BaseAgent {
     if (!this.alive) return;
     super.die(); // This sets this.alive = false
     gameHelpers.play('splitterOnDeath');
+    this.triggerAbilityAnimation(2, 1200);
 
     const spawnInOrbit = (count, orbitRadius) => {
         const centerVec = this.position.clone().normalize();

--- a/modules/bossAbilityEffects.js
+++ b/modules/bossAbilityEffects.js
@@ -1,0 +1,89 @@
+import * as THREE from '../vendor/three.module.js';
+import { state } from './state.js';
+import { getScene } from './scene.js';
+
+function addRing(group, radius, material) {
+  const ring = new THREE.Mesh(new THREE.TorusGeometry(radius, radius / 8, 8, 32), material.clone());
+  ring.rotation.x = Math.PI / 2;
+  group.add(ring);
+}
+
+export function createAbilityEffect(kind = 'generic', stage = 1, color = 0xffffff, radius = 1) {
+  const group = new THREE.Group();
+  const baseMat = new THREE.MeshStandardMaterial({
+    color,
+    emissive: color,
+    emissiveIntensity: 0.8,
+    transparent: true,
+    opacity: 0.7,
+  });
+
+  switch (kind) {
+    case 'splitter': {
+      addRing(group, radius * 1.0, baseMat);
+      if (stage > 1) {
+        addRing(group, radius * 1.4, baseMat);
+        const shardGeom = new THREE.TetrahedronGeometry(radius * 0.25);
+        for (let i = 0; i < stage * 4; i++) {
+          const shard = new THREE.Mesh(shardGeom, baseMat.clone());
+          const angle = (i / (stage * 4)) * Math.PI * 2;
+          shard.position.set(Math.cos(angle) * radius * 1.4, 0, Math.sin(angle) * radius * 1.4);
+          group.add(shard);
+        }
+      }
+      if (stage > 2) {
+        addRing(group, radius * 1.8, baseMat);
+      }
+      break;
+    }
+    case 'reflector': {
+      const shield = new THREE.Mesh(new THREE.SphereGeometry(radius * (1 + 0.2 * stage), 32, 16), baseMat.clone());
+      shield.material.opacity = 0.3;
+      group.add(shield);
+      for (let i = 1; i < stage; i++) {
+        addRing(group, radius * (1 + i * 0.3), baseMat);
+      }
+      break;
+    }
+    case 'aethel':
+    case 'umbra': {
+      const geo = kind === 'aethel'
+        ? new THREE.DodecahedronGeometry(radius * 0.5)
+        : new THREE.IcosahedronGeometry(radius * 0.6);
+      const core = new THREE.Mesh(geo, baseMat.clone());
+      group.add(core);
+      for (let i = 1; i <= stage; i++) {
+        addRing(group, radius * (0.8 + i * 0.4), baseMat);
+      }
+      break;
+    }
+    default: {
+      for (let i = 1; i <= stage; i++) {
+        addRing(group, radius * (0.8 + i * 0.3), baseMat);
+      }
+    }
+  }
+
+  group.userData.kind = kind;
+  group.userData.stage = stage;
+  return group;
+}
+
+export function spawnBossAbilityEffect(owner, stage = 1, duration = 1000) {
+  if (!owner) return;
+  const color = owner.model && owner.model.material && owner.model.material.color
+    ? owner.model.material.color.getHex()
+    : 0xffffff;
+  const radius = owner.r || 1;
+  const mesh = createAbilityEffect(owner.kind || 'generic', stage, color, radius);
+  mesh.position.copy(owner.position);
+  getScene().add(mesh);
+  state.effects.push({
+    type: 'boss_ability',
+    owner,
+    mesh,
+    stage,
+    startTime: Date.now(),
+    duration,
+  });
+}

--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -3,7 +3,7 @@
 import * as THREE from '../vendor/three.module.js';
 import { state } from './state.js';
 import { uvToSpherePos, spherePosToUv } from './utils.js';
-import { getRenderer } from './scene.js';
+import { getRenderer, getScene } from './scene.js';
 import { VR_PROJECTILE_SPEED_SCALE } from './config.js';
 import { usePower } from './powers.js';
 import { gameHelpers } from './gameHelpers.js';
@@ -199,6 +199,24 @@ export function updateEffects3d(radius = 50, deltaMs = 16){
           break;
         }
         ef.position.add(step);
+        break;
+      }
+      case 'boss_ability':{
+        if(ef.owner && ef.owner.alive){
+          ef.mesh.position.copy(ef.owner.position);
+        }
+        if(ef.mesh){
+          ef.mesh.rotation.y += 0.01 * deltaFactor * (ef.stage || 1);
+        }
+        if(now - ef.startTime > ef.duration){
+          if(ef.mesh){
+            const scene = getScene && getScene();
+            if(scene) scene.remove(ef.mesh);
+            if(ef.mesh.geometry) ef.mesh.geometry.dispose();
+            if(ef.mesh.material) ef.mesh.material.dispose();
+          }
+          state.effects.splice(i,1);
+        }
         break;
       }
       case 'ricochet_projectile':{

--- a/task_log.md
+++ b/task_log.md
@@ -37,6 +37,7 @@
     * [x] Upgraded boss models with lore-driven shapes for progressive visual flair (Splitter, Reflector, Vampire, Gravity, Epoch Ender).
     * [x] Expanded upgrades to additional bosses so designs scale with difficulty (Syphon, Centurion, Sentinel Pair, Annihilator, Architect, Quantum Shadow, Puppeteer).
     * [x] Added extra rings, shards, and orbiting details so later bosses look increasingly epic and aligned with their lore.
+    * [x] Introduced progressive ability animations with lore-based shapes for Aethel & Umbra, Splitter, and Reflector bosses.
 * [x] **Sizing:** Increase the size of the player, bosses, and enemies by 30%. — Completed
 
 ## UI


### PR DESCRIPTION
## Summary
- Add `bossAbilityEffects` to generate lore-shaped ability visuals that scale by stage
- Wire new `triggerAbilityAnimation` into BaseAgent and boss AIs (Aethel & Umbra, Splitter, Reflector)
- Update projectile/effects loop to animate and clean up boss ability effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893b1d534448331bf32930eea8423c2