### PR TITLE
Scale boss ability effects by encounter order

### DIFF
--- a/modules/BaseAgent.js
+++ b/modules/BaseAgent.js
@@ -70,7 +70,8 @@ export class BaseAgent extends THREE.Group {
     if (this.parent) this.parent.remove(this);
   }
 
-  triggerAbilityAnimation(stage = 1, duration = 1000) {
-    spawnBossAbilityEffect(this, stage, duration);
+    triggerAbilityAnimation(stageOffset = 0, duration = 1000) {
+      const stage = (this.bossIndex || 1) + stageOffset;
+      spawnBossAbilityEffect(this, stage, duration);
+    }
   }
-}

--- a/modules/agents/AethelUmbraAI.js
+++ b/modules/agents/AethelUmbraAI.js
@@ -47,6 +47,6 @@ export class AethelUmbraAI extends BaseAgent {
     const healthBonus = this.maxHP * 0.5;
     this.maxHP += healthBonus;
     this.health += healthBonus;
-    this.triggerAbilityAnimation(3, 1500);
+    this.triggerAbilityAnimation(2, 1500);
   }
 }

--- a/modules/agents/ReflectorAI.js
+++ b/modules/agents/ReflectorAI.js
@@ -36,7 +36,7 @@ export class ReflectorAI extends BaseAgent {
         if (this.cycles % 3 === 0) {
           this.reflecting = true;
           const stage = Math.min(3, Math.floor(this.cycles / 3));
-          this.triggerAbilityAnimation(stage, 1000);
+          this.triggerAbilityAnimation(stage - 1, 1000);
           setTimeout(() => { this.reflecting = false; }, 2000);
         }
       }

--- a/modules/agents/SplitterAI.js
+++ b/modules/agents/SplitterAI.js
@@ -22,7 +22,7 @@ export class SplitterAI extends BaseAgent {
     if (!this.alive) return;
     super.die(); // This sets this.alive = false
     gameHelpers.play('splitterOnDeath');
-    this.triggerAbilityAnimation(2, 1200);
+    this.triggerAbilityAnimation(1, 1200);
 
     const spawnInOrbit = (count, orbitRadius) => {
         const centerVec = this.position.clone().normalize();

--- a/modules/config.js
+++ b/modules/config.js
@@ -93,6 +93,17 @@ export const STAGE_CONFIG = [
     { stage: 30, displayName: 'The Pantheon',         bosses: ['pantheon'] }
 ];
 
+// Flattened list of boss IDs in their encounter order.
+// Used to derive a boss's progression index regardless of stage grouping.
+export const BOSS_SEQUENCE = STAGE_CONFIG.flatMap(s => s.bosses);
+
+// Given a boss ID, return its 1-based index within the 30-boss sequence.
+// If the boss ID is not found, default to 1 so effects still render.
+export function getBossIndex(bossId) {
+    const idx = BOSS_SEQUENCE.indexOf(bossId);
+    return idx >= 0 ? idx + 1 : 1;
+}
+
 // Global tuning values for the VR prototype
 // Scale factor applied to all enemy projectile velocities. Can be tweaked for
 // comfort as the VR movement speed is refined.

--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -1,6 +1,6 @@
 import * as THREE from '../vendor/three.module.js';
 import { state, savePlayerState } from './state.js';
-import { LEVELING_CONFIG, THEMATIC_UNLOCKS, SPAWN_WEIGHTS, STAGE_CONFIG, MODEL_SCALE } from './config.js';
+import { LEVELING_CONFIG, THEMATIC_UNLOCKS, SPAWN_WEIGHTS, STAGE_CONFIG, MODEL_SCALE, getBossIndex } from './config.js';
 import { powers } from './powers.js';
 import { bossData } from './bosses.js';
 import { showUnlockNotification, showBossBanner, updateHud } from './UIManager.js';
@@ -201,15 +201,17 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
         console.error("Scene not available for spawning enemy.");
         return null;
     }
-    
+
     let enemy;
     const AIClass = isBoss ? bossAIClassMap[bossId] : null;
+    const bossIndex = isBoss && bossId ? getBossIndex(bossId) : 0;
 
     if (isBoss && AIClass) {
         // Special multi-part boss spawns need to be added to scene individually
         if (bossId === 'aethel_and_umbra') {
             const partnerA = new AethelUmbraAI('Aethel');
             partnerA.boss = true;
+            partnerA.bossIndex = bossIndex;
             partnerA.position.copy(getSafeSpawnLocation());
             partnerA.scale.multiplyScalar(MODEL_SCALE);
             partnerA.r = (partnerA.r || 1) * MODEL_SCALE;
@@ -218,6 +220,7 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
 
             const partnerB = new AethelUmbraAI('Umbra', partnerA);
             partnerB.boss = true;
+            partnerB.bossIndex = bossIndex;
             partnerA.partner = partnerB;
             partnerB.partner = partnerA;
             partnerB.position.copy(getSafeSpawnLocation());
@@ -230,6 +233,7 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
         if (bossId === 'sentinel_pair') {
             const sentinelA = new SentinelPairAI();
             sentinelA.boss = true;
+            sentinelA.bossIndex = bossIndex;
             sentinelA.position.copy(getSafeSpawnLocation());
             sentinelA.scale.multiplyScalar(MODEL_SCALE);
             sentinelA.r = (sentinelA.r || 1) * MODEL_SCALE;
@@ -238,6 +242,7 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
 
             const sentinelB = new SentinelPairAI(sentinelA);
             sentinelB.boss = true;
+            sentinelB.bossIndex = bossIndex;
             sentinelB.position.copy(getSafeSpawnLocation());
             sentinelA.partner = sentinelB;
             sentinelB.partner = sentinelA;
@@ -250,6 +255,7 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
         if (bossId === 'obelisk') {
             const obelisk = new ObeliskAI();
             obelisk.boss = true;
+            obelisk.bossIndex = bossIndex;
             obelisk.scale.multiplyScalar(MODEL_SCALE);
             obelisk.r = (obelisk.r || 1) * MODEL_SCALE;
             state.enemies.push(obelisk);
@@ -258,6 +264,7 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
             for(let i = 0; i < 3; i++) {
                 const conduit = new ObeliskConduitAI(obelisk, conduitTypes[i].type, conduitTypes[i].color, (i / 3) * Math.PI * 2);
                 conduit.boss = true;
+                conduit.bossIndex = bossIndex;
                 conduit.scale.multiplyScalar(MODEL_SCALE);
                 conduit.r = (conduit.r || 1) * MODEL_SCALE;
                 state.enemies.push(conduit);
@@ -268,6 +275,7 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
         // Standard single boss spawn
         enemy = new AIClass();
         enemy.boss = true;
+        enemy.bossIndex = bossIndex;
     } else if (!isBoss) {
         const minionGeo = new THREE.SphereGeometry(0.3, 8, 8);
         const minionMat = new THREE.MeshStandardMaterial({ color: 0xc0392b, emissive: 0xc0392b, emissiveIntensity: 0.3 });


### PR DESCRIPTION
## Summary
- Track each boss's encounter index from `STAGE_CONFIG` and expose helper `getBossIndex`
- Tag spawned bosses with this index so ability visuals escalate with boss order
- Drive ability animations via boss index with optional per-boss offsets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893b70477288331bffecc042ec1f1da