### PR TITLE
Normalize ascension talent saves

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -913,10 +913,17 @@ function createAscensionModal() {
             });
         });
 
-        const purchasedTalents =
-            state.player.purchasedTalents && typeof state.player.purchasedTalents.get === 'function'
-                ? state.player.purchasedTalents
-                : new Map(state.player.purchasedTalents || []);
+        // Normalize purchasedTalents in case legacy saves stored it as an array or plain object.
+        let purchasedTalents = state.player.purchasedTalents;
+        if (purchasedTalents instanceof Map) {
+            // already correct
+        } else if (Array.isArray(purchasedTalents)) {
+            purchasedTalents = new Map(purchasedTalents);
+        } else if (purchasedTalents && typeof purchasedTalents === 'object') {
+            purchasedTalents = new Map(Object.entries(purchasedTalents));
+        } else {
+            purchasedTalents = new Map();
+        }
         if (purchasedTalents !== state.player.purchasedTalents) {
             state.player.purchasedTalents = purchasedTalents;
         }

--- a/modules/ascension.js
+++ b/modules/ascension.js
@@ -166,9 +166,20 @@ export function isTalentVisible(talent) {
     const prereqs = talent.prerequisites || [];
     if (prereqs.length === 0) return true;
 
-    const purchased = state.player.purchasedTalents && typeof state.player.purchasedTalents.get === 'function'
-        ? state.player.purchasedTalents
-        : new Map();
+    // Handle legacy saves where purchasedTalents may be an array or plain object.
+    let purchased = state.player.purchasedTalents;
+    if (purchased instanceof Map) {
+        // already good
+    } else if (Array.isArray(purchased)) {
+        purchased = new Map(purchased);
+    } else if (purchased && typeof purchased === 'object') {
+        purchased = new Map(Object.entries(purchased));
+    } else {
+        purchased = new Map();
+    }
+    if (purchased !== state.player.purchasedTalents) {
+        state.player.purchasedTalents = purchased;
+    }
 
     return prereqs.every(prereqId => {
         const prereqTalent = allTalents[prereqId];

--- a/task_log.md
+++ b/task_log.md
@@ -127,6 +127,7 @@
 * [x] Restored hit sound on fatal player damage.
 * [x] Awarded essence on enemy and boss deaths, clearing stages and resuming enemy and power-up spawns.
 * [x] Fixed ascension menu so talents render correctly even when `purchasedTalents` loads from a legacy array save, ensuring the Core Nexus is always visible.
+* [x] Hardened ascension menu against legacy saves storing `purchasedTalents` as plain objects so the Core Nexus always renders.
 * [x] Aligned Ascension modal borders and talent nodes with their backgrounds so frames no longer flicker or drift in VR.
 * [x] Corrected boss health bar logic so colored fills track each boss's `health` value instead of a nonexistent `hp` field.
 * [x] Disabled HUD raycasts so the cursor passes through without affecting player movement.

--- a/tests/ascensionLegacyTalents.test.js
+++ b/tests/ascensionLegacyTalents.test.js
@@ -89,3 +89,15 @@ test('ascension modal shows core nexus with array purchasedTalents', async () =>
   const nexusButton = grid.children.find(c => c.userData && c.userData.talentId === 'core-nexus');
   assert.ok(nexusButton, 'core nexus button should exist');
 });
+
+// Also handle legacy saves where purchasedTalents was a plain object.
+test('ascension modal shows core nexus with object purchasedTalents', async () => {
+  const { initModals, showModal, getModalObjects } = await setup({});
+  initModals();
+  showModal('ascension');
+  const ascensionModal = getModalObjects().find(m => m.name === 'modal_ascension');
+  assert.ok(ascensionModal);
+  const grid = ascensionModal.children.find(c => c.name === 'ascension_grid');
+  const nexusButton = grid.children.find(c => c.userData && c.userData.talentId === 'core-nexus');
+  assert.ok(nexusButton, 'core nexus button should exist');
+});


### PR DESCRIPTION
## Summary
- Normalize `purchasedTalents` in ascension routines so legacy object or array saves convert to a Map
- Cover legacy object `purchasedTalents` with tests to ensure Core Nexus always renders
- Document fix in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689406ea46ec8331882a05a2bc349186