### PR TITLE
Handle degenerate rotation inputs

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -343,8 +343,14 @@ export function toCanvasPos(vec, width = 2048, height = 1024) {
  * @returns {THREE.Vector3} Rotated direction vector.
  */
 export function rotateAroundNormal(dir, normal, angle){
-  const q = new THREE.Quaternion();
-  q.setFromAxisAngle(normal.clone().normalize(), angle);
+  if(!dir || typeof dir.clone !== 'function') return new THREE.Vector3();
+  if(!normal || normal.lengthSq() === 0 || !Number.isFinite(angle)) {
+    return dir.clone();
+  }
+  const q = new THREE.Quaternion().setFromAxisAngle(
+    normal.clone().normalize(),
+    angle
+  ).normalize();
   return dir.clone().applyQuaternion(q);
 }
 

--- a/task_log.md
+++ b/task_log.md
@@ -134,3 +134,4 @@
 * [x] Prevented boss spawn crashes by replacing nonexistent geometries, importing missing Pantheon aspects, and correcting the Annihilator's shadow check.
 * [x] Stabilized Swarm Link's tail so segments follow the spherical surface and consistently damage the player on contact.
 * [x] Reworked Mirror Mirage clone swapping to match the original game's mechanics and prevent ability-related crashes.
+* [x] Hardened rotateAroundNormal to return the original vector when given zero-length normals or invalid angles.

--- a/tests/utilsEdgeCases.test.js
+++ b/tests/utilsEdgeCases.test.js
@@ -1,7 +1,8 @@
 import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
 
-const { randomInRange, safeAddEventListener, drawLightning, lineCircleCollision } = await import('../modules/utils.js');
+const { randomInRange, safeAddEventListener, drawLightning, lineCircleCollision, rotateAroundNormal } = await import('../modules/utils.js');
 
 test('randomInRange handles reversed and invalid ranges', () => {
   const originalRandom = Math.random;
@@ -35,4 +36,12 @@ test('drawLightning clamps width to non-negative values', () => {
 test('lineCircleCollision respects radius and segment bounds', () => {
   assert.equal(lineCircleCollision(0,0,10,0,5,0,-3), false);
   assert.equal(lineCircleCollision(0,0,10,0,5,0,3), true);
+});
+
+test('rotateAroundNormal returns original vector for degenerate inputs', () => {
+  const dir = new THREE.Vector3(1, 0, 0);
+  const result = rotateAroundNormal(dir, new THREE.Vector3(0, 0, 0), Math.PI / 2);
+  assert.deepEqual(result, dir);
+  const resultNaN = rotateAroundNormal(dir, new THREE.Vector3(0, 1, 0), NaN);
+  assert.deepEqual(resultNaN, dir);
 });


### PR DESCRIPTION
## Summary
- avoid invalid quaternion rotations by returning the original vector when `rotateAroundNormal` receives a zero-length normal or non-finite angle
- cover the new behavior with unit tests for degenerate rotation inputs
- document the fix in the task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68941c2d96208331b352336be8d305e4