### PR TITLE
fix: use current time for Miasma vent slam

### DIFF
--- a/modules/agents/MiasmaAI.js
+++ b/modules/agents/MiasmaAI.js
@@ -56,12 +56,13 @@ export class MiasmaAI extends BaseAgent {
             if (!this.alive) return;
             gameHelpers.play('miasmaSlam');
 
+            const currentTime = Date.now();
             this.vents.forEach(vent => {
-                if (now > vent.cooldownUntil && this.position.distanceTo(vent.position) < 10) {
-                    vent.cooldownUntil = now + 10000;
+                if (currentTime > vent.cooldownUntil && this.position.distanceTo(vent.position) < 10) {
+                    vent.cooldownUntil = currentTime + 10000;
                     this.isGasActive = false;
                     state.effects = state.effects.filter(e => !(e.type === 'miasma_gas' && e.id === this.instanceId));
-                    this.lastGasAttack = now;
+                    this.lastGasAttack = currentTime;
                     gameHelpers.play('ventPurify');
                 }
             });

--- a/task_log.md
+++ b/task_log.md
@@ -135,3 +135,4 @@
 * [x] Stabilized Swarm Link's tail so segments follow the spherical surface and consistently damage the player on contact.
 * [x] Reworked Mirror Mirage clone swapping to match the original game's mechanics and prevent ability-related crashes.
 * [x] Hardened rotateAroundNormal to return the original vector when given zero-length normals or invalid angles.
+* [x] Fixed race condition in Miasma boss slam by using current timestamps when purifying vents.

--- a/tests/miasmaSlamTiming.test.js
+++ b/tests/miasmaSlamTiming.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { MiasmaAI } from '../modules/agents/MiasmaAI.js';
+import { state } from '../modules/state.js';
+import { gameHelpers } from '../modules/gameHelpers.js';
+
+test('miasma slam uses current time when purifying vents', () => {
+  // Prepare stubbed time and timers
+  const originalDateNow = Date.now;
+  const originalSetTimeout = global.setTimeout;
+  let currentTime = 0;
+  Date.now = () => currentTime;
+
+  // Stub gameHelpers to avoid side effects
+  gameHelpers.play = () => {};
+
+  // Replace setTimeout to run instantly while advancing time
+  global.setTimeout = (fn, ms) => {
+    currentTime += ms;
+    fn();
+    return 0;
+  };
+
+  // Reset state and create boss
+  state.effects = [];
+  const boss = new MiasmaAI();
+  boss.isGasActive = true;
+  boss.position.copy(boss.vents[0].position.clone());
+
+  // Trigger the slam
+  boss.update(0);
+
+  // After the instant timeout, the cooldown and timestamps should use advanced time
+  assert.equal(boss.isChargingSlam, false);
+  assert.equal(boss.isGasActive, false);
+  assert.equal(boss.lastGasAttack, currentTime);
+  assert.equal(boss.vents[0].cooldownUntil, currentTime + 10000);
+
+  // Restore globals
+  Date.now = originalDateNow;
+  global.setTimeout = originalSetTimeout;
+  state.effects = [];
+  delete gameHelpers.play;
+});
+


### PR DESCRIPTION
## Summary
- avoid stale timestamps when Miasma purifies vents
- cover Miasma vent slam timing with a unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68941f6521648331ab7fd25ce1cb5566