### PR TITLE
Fix modal text alignment and wrapping

### DIFF
--- a/modules/UIManager.js
+++ b/modules/UIManager.js
@@ -20,8 +20,8 @@ const AP_RIGHT_EDGE = 0.44;
 // Text sprites are rendered to a canvas and then scaled into world units.
 // Centralizing these factors means every UI element uses the same
 // pixel-to-world conversion, making tweaks easy and avoiding magic numbers.
-const SPRITE_SCALE = 0.001; // world units per canvas pixel
-const PIXELS_PER_UNIT = 1 / SPRITE_SCALE; // helper for world->pixel math
+export const SPRITE_SCALE = 0.001; // world units per canvas pixel
+export const PIXELS_PER_UNIT = 1 / SPRITE_SCALE; // helper for world->pixel math
 
 let bgTexture = null;
 // Cache the shared menu background texture and configure it to behave like the

--- a/task_log.md
+++ b/task_log.md
@@ -139,3 +139,4 @@
 * [x] Fixed race condition in Miasma boss slam by using current timestamps when purifying vents.
 * [x] Corrected controller menu sound toggle to update its icon reliably in VR.
 * [x] Restored scrollbar behavior so lists scroll in the correct direction and handles can be dragged like the 2D game.
+* [x] Anchored boss info and lore text within their modals and wrapped long lines so menu content stays inside its container.

--- a/tests/ascensionLegacyTalents.test.js
+++ b/tests/ascensionLegacyTalents.test.js
@@ -70,7 +70,8 @@ async function setup(purchasedTalents) {
       showBossBanner: () => {},
       updateHud: () => {},
       showHud: () => {},
-      hideHud: () => {}
+      hideHud: () => {},
+      PIXELS_PER_UNIT: 1000
     }
   });
 

--- a/tests/ascensionNexus.test.js
+++ b/tests/ascensionNexus.test.js
@@ -71,7 +71,8 @@ async function setup() {
       showBossBanner: () => {},
       updateHud: () => {},
       showHud: () => {},
-      hideHud: () => {}
+      hideHud: () => {},
+      PIXELS_PER_UNIT: 1000
     }
   });
 

--- a/tests/berserkPower.test.js
+++ b/tests/berserkPower.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
 
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/bulletNova.test.js
+++ b/tests/bulletNova.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
 
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/chainLightning.test.js
+++ b/tests/chainLightning.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
 
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/healSparkleEffect.test.js
+++ b/tests/healSparkleEffect.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
 
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/missileFireball.test.js
+++ b/tests/missileFireball.test.js
@@ -4,7 +4,7 @@ import * as THREE from '../vendor/three.module.js';
 
 // Mock modules to avoid DOM/WebXR dependencies
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/orbitalStrike.test.js
+++ b/tests/orbitalStrike.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
 
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/paradoxEcho.test.js
+++ b/tests/paradoxEcho.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
 
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/pickupAfterReset.test.js
+++ b/tests/pickupAfterReset.test.js
@@ -4,7 +4,7 @@ import * as THREE from '../vendor/three.module.js';
 
 // Mock UI and scene dependencies to avoid DOM and WebXR
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/playerControllerInit.test.js
+++ b/tests/playerControllerInit.test.js
@@ -24,7 +24,7 @@ test('initPlayerController resets previous avatar meshes', async () => {
       getCamera: () => ({})
     }
   });
-  await mock.module('../modules/UIManager.js', { namedExports: { attachBossUI: mock.fn() } });
+  await mock.module('../modules/UIManager.js', { namedExports: { attachBossUI: mock.fn(), PIXELS_PER_UNIT: 1000 } });
   await mock.module('../modules/PowerManager.js', { namedExports: { useOffensivePower: mock.fn(), useDefensivePower: mock.fn() } });
   await mock.module('../modules/CoreManager.js', { namedExports: { useCoreActive: mock.fn() } });
   await mock.module('../modules/ModalManager.js', { namedExports: { getModalObjects: () => [] } });

--- a/tests/powerManager.test.js
+++ b/tests/powerManager.test.js
@@ -4,7 +4,7 @@ import * as THREE from '../vendor/three.module.js';
 
 // Mock UI and scene dependencies to avoid DOM and WebXR
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/powerUpFlow.test.js
+++ b/tests/powerUpFlow.test.js
@@ -4,7 +4,7 @@ import * as THREE from '../vendor/three.module.js';
 
 // Mock UI and scene dependencies to avoid DOM and WebXR
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/repulsionField.test.js
+++ b/tests/repulsionField.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
 
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/ricochetShot.test.js
+++ b/tests/ricochetShot.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
 
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/shieldEffect.test.js
+++ b/tests/shieldEffect.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
 
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/shockwaveVisual.test.js
+++ b/tests/shockwaveVisual.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as THREE from '../vendor/three.module.js';
 
 await mock.module('../modules/UIManager.js', {
-  namedExports: { createTextSprite: () => new THREE.Object3D() }
+  namedExports: { createTextSprite: () => new THREE.Object3D(), PIXELS_PER_UNIT: 1000 }
 });
 await mock.module('../modules/scene.js', {
   namedExports: {

--- a/tests/vrMain.test.js
+++ b/tests/vrMain.test.js
@@ -32,7 +32,7 @@ async function setupLaunch() {
   });
 
   await mock.module('../modules/UIManager.js', {
-    namedExports: { initUI: mock.fn(), updateHud: mock.fn(), showHud }
+    namedExports: { initUI: mock.fn(), updateHud: mock.fn(), showHud, PIXELS_PER_UNIT: 1000 }
   });
 
     await mock.module('../modules/ModalManager.js', {


### PR DESCRIPTION
## Summary
- expose pixel scaling constants for UI layouts
- wrap and anchor lore and boss info text to keep pop-ups within bounds
- update tests for new UI constant

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894d089c1888331a642f86dd367096d