### PR TITLE
Fix early boss AI crashes

### DIFF
--- a/modules/agents/SplitterAI.js
+++ b/modules/agents/SplitterAI.js
@@ -1,6 +1,7 @@
 import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { gameHelpers } from '../gameHelpers.js';
+import { state } from '../state.js';
 
 const ARENA_RADIUS = 50;
 

--- a/modules/agents/VampireAI.js
+++ b/modules/agents/VampireAI.js
@@ -2,6 +2,7 @@ import * as THREE from "../../vendor/three.module.js";
 import { BaseAgent } from '../BaseAgent.js';
 import { state } from '../state.js';
 import { gameHelpers } from '../gameHelpers.js';
+import { applyPlayerHeal } from '../helpers.js';
 
 export class VampireAI extends BaseAgent {
   constructor() {
@@ -38,12 +39,10 @@ export class VampireAI extends BaseAgent {
         emoji: '🩸',
         lifeEnd: Date.now() + 8000,
         isSeeking: true,
-        seekTarget: this,
-        customApply: (target) => {
-          if (target === this) {
-            this.health = Math.min(this.maxHP, this.health + 20);
-          }
-        }
+        seekTarget: state.player,
+        customApply: () => {
+          applyPlayerHeal(20);
+        },
       });
     }
     

--- a/task_log.md
+++ b/task_log.md
@@ -141,3 +141,4 @@
 * [x] Restored scrollbar behavior so lists scroll in the correct direction and handles can be dragged like the 2D game.
 * [x] Anchored boss info and lore text within their modals and wrapped long lines so menu content stays inside its container.
 * [x] Added utility safeguards: particle spawner handles polar positions and negative lifetimes, screen shake and fog drawing validate contexts, lightning rendering tolerates missing contexts, and `playerHasCore` ignores non-array buff lists.
+* [x] Debugged first 10 boss AIs, importing missing state in Splitter and redirecting Vampire blood orbs to heal the player.


### PR DESCRIPTION
## Summary
- Import global state into Splitter boss to avoid reference errors when spawning minions
- Redirect Vampire boss blood orbs to heal the player using centralized helper
- Update task log for boss AI fixes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b379697dd083319a963c24fcd0a6a9