### PR TITLE
Fix Mirror Mirage clone spawn location

### DIFF
--- a/modules/agents/MirrorMirageAI.js
+++ b/modules/agents/MirrorMirageAI.js
@@ -32,8 +32,6 @@ export class MirrorMirageAI extends BaseAgent {
 
     this.realIndex = 0;
     this.lastSwapTime = Date.now();
-    this.randomizeClones();
-    this.updateGroupPosition();
   }
 
   randomPosOnSphere() {
@@ -52,6 +50,18 @@ export class MirrorMirageAI extends BaseAgent {
       const offset = realClone.position.clone();
       this.position.copy(offset);
       this.clones.forEach(c => c.position.sub(offset));
+  }
+
+  // Called by the game loop after the boss has been positioned and scaled
+  initialize() {
+      // Convert any parent scaling into per-clone scaling so positions stay on the arena
+      const scale = this.scale.x || 1;
+      if (scale !== 1) {
+          this.scale.setScalar(1);
+          this.clones.forEach(clone => clone.scale.multiplyScalar(scale));
+      }
+      this.randomizeClones();
+      this.updateGroupPosition();
   }
 
   swapClones() {

--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -310,6 +310,9 @@ export function spawnEnemy(isBoss = false, bossId = null, location = null) {
     } else {
         enemy.r = MODEL_SCALE;
     }
+    if (typeof enemy.initialize === 'function') {
+        enemy.initialize();
+    }
     state.enemies.push(enemy);
     scene.add(enemy); // ** THE CRITICAL FIX: Add the enemy's 3D object to the scene **
     return enemy;

--- a/task_log.md
+++ b/task_log.md
@@ -135,6 +135,7 @@
 * [x] Prevented boss spawn crashes by replacing nonexistent geometries, importing missing Pantheon aspects, and correcting the Annihilator's shadow check.
 * [x] Stabilized Swarm Link's tail so segments follow the spherical surface and consistently damage the player on contact.
 * [x] Reworked Mirror Mirage clone swapping to match the original game's mechanics and prevent ability-related crashes.
+* [x] Fixed Mirror Mirage clone spawning so decoys appear on the arena instead of the player's position.
 * [x] Hardened rotateAroundNormal to return the original vector when given zero-length normals or invalid angles.
 * [x] Fixed race condition in Miasma boss slam by using current timestamps when purifying vents.
 * [x] Corrected controller menu sound toggle to update its icon reliably in VR.


### PR DESCRIPTION
## Summary
- Ensure Mirror Mirage clones appear around the arena instead of on the player by re-randomizing after spawn
- Invoke optional `initialize` hook when spawning enemies
- Log Mirror Mirage clone spawn fix

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b37b6f6c688331be4f29a67a9fb1e6