### PR TITLE
Ensure ascension menu renders without RAF

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -726,8 +726,12 @@ export function showModal(id) {
     AudioManager.playSfx('uiModalOpen');
 
     if (modal.userData.refresh) {
-        // Defer refresh to the next frame so the paused state takes effect
-        requestAnimationFrame(() => {
+        // Refresh immediately so the grid is populated even if the environment
+        // lacks requestAnimationFrame (Node tests, some headsets, etc.) and
+        // schedule a second pass on the next frame using the RAF fallback
+        // defined above.
+        modal.userData.refresh();
+        RAF(() => {
             if (state.activeModalId === id) {
                 modal.userData.refresh();
             }

--- a/task_log.md
+++ b/task_log.md
@@ -130,6 +130,7 @@
 * [x] Fixed ascension menu so talents render correctly even when `purchasedTalents` loads from a legacy array save, ensuring the Core Nexus is always visible.
 * [x] Hardened ascension menu against legacy saves storing `purchasedTalents` as plain objects so the Core Nexus always renders.
 * [x] Aligned Ascension modal borders and talent nodes with their backgrounds so frames no longer flicker or drift in VR.
+* [x] Refreshed Ascension modal immediately and added requestAnimationFrame fallback so talents always display even in RAF-free environments.
 * [x] Corrected boss health bar logic so colored fills track each boss's `health` value instead of a nonexistent `hp` field.
 * [x] Disabled HUD raycasts so the cursor passes through without affecting player movement.
 * [x] Prevented boss spawn crashes by replacing nonexistent geometries, importing missing Pantheon aspects, and correcting the Annihilator's shadow check.

--- a/tests/ascensionMenuRafFallback.test.js
+++ b/tests/ascensionMenuRafFallback.test.js
@@ -1,0 +1,97 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+// Replicate the minimal environment used in other ascension tests but omit
+// requestAnimationFrame so ModalManager must rely on its internal RAF
+// fallback. This guards against a blank Ascension menu on platforms that do
+// not provide the API (e.g. some headless or legacy WebXR runtimes).
+
+async function setup() {
+  mock.reset();
+  delete global.requestAnimationFrame;
+  delete global.cancelAnimationFrame;
+
+  const scene = { children: [], add(obj) { this.children.push(obj); } };
+  await mock.module('../modules/scene.js', {
+    namedExports: {
+      getScene: () => scene,
+      getCamera: () => ({
+        position: new THREE.Vector3(),
+        rotation: new THREE.Euler(),
+        quaternion: new THREE.Quaternion()
+      }),
+      getRenderer: () => ({}),
+      getPrimaryController: () => ({})
+    }
+  });
+
+  const state = {
+    activeModalId: null,
+    isPaused: false,
+    uiInteractionCooldownUntil: 0,
+    player: {
+      ascensionPoints: 0,
+      purchasedTalents: new Map(),
+      unlockedPowers: new Set()
+    }
+  };
+
+  await mock.module('../modules/state.js', {
+    namedExports: { state, savePlayerState: mock.fn(), resetGame: mock.fn() }
+  });
+
+  await mock.module('../modules/PlayerController.js', {
+    namedExports: { refreshPrimaryController: mock.fn(), resetInputFlags: mock.fn() }
+  });
+
+  await mock.module('../modules/audio.js', {
+    namedExports: { AudioManager: { playSfx: mock.fn() } }
+  });
+
+  await mock.module('../modules/gameHelpers.js', {
+    namedExports: { gameHelpers: {}, initGameHelpers: () => {} }
+  });
+
+  await mock.module('../modules/UIManager.js', {
+    namedExports: {
+      holoMaterial: (color = 0x1e1e2f, opacity = 0.85) => ({
+        color: new THREE.Color(color),
+        emissive: new THREE.Color(color),
+        emissiveIntensity: 1,
+        transparent: true,
+        opacity,
+        dispose: () => {}
+      }),
+      createTextSprite: (text = '') => {
+        const obj = new THREE.Object3D();
+        obj.material = { color: new THREE.Color(0xffffff), opacity: 1, dispose: () => {} };
+        obj.userData = { text };
+        return obj;
+      },
+      updateTextSprite: (obj, newText) => {
+        obj.userData.text = newText;
+      },
+      getBgTexture: () => null,
+      showUnlockNotification: () => {},
+      showBossBanner: () => {},
+      updateHud: () => {},
+      showHud: () => {},
+      hideHud: () => {},
+      PIXELS_PER_UNIT: 1000
+    }
+  });
+
+  const { showModal, getModalObjects } = await import('../modules/ModalManager.js');
+  return { showModal, getModalObjects };
+}
+
+test('ascension modal renders without requestAnimationFrame', async () => {
+  const { showModal, getModalObjects } = await setup();
+  showModal('ascension');
+  const modal = getModalObjects().find(m => m.name === 'modal_ascension');
+  assert.ok(modal, 'ascension modal should exist');
+  const grid = modal.children.find(c => c.name === 'ascension_grid');
+  assert.ok(grid, 'talent grid should exist');
+  assert.ok(grid.children.length > 0, 'talent grid should populate immediately');
+});


### PR DESCRIPTION
## Summary
- Refresh modal contents immediately and fall back to a timeout when `requestAnimationFrame` is unavailable so the Ascension grid always shows its talents
- Add regression test covering Ascension menu in environments lacking `requestAnimationFrame`
- Document the fix in the task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b37c9dae1c8331a6658d5fc0d27afc