### PR TITLE
Harden helpers and asset loader

### DIFF
--- a/modules/AssetManager.js
+++ b/modules/AssetManager.js
@@ -27,12 +27,12 @@ export class AssetManager {
         }
     }
 
-    loadModel(url) {
+    async loadModel(url) {
         if (this.modelCache.has(url)) {
-            return Promise.resolve(this.modelCache.get(url));
+            return this.modelCache.get(url);
         }
-        return new Promise(async (resolve, reject) => {
-            await this._ensureGltfLoader();
+        await this._ensureGltfLoader();
+        return await new Promise((resolve, reject) => {
             this.gltfLoader.load(url,
                 (gltf) => {
                     this.modelCache.set(url, gltf);

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -83,8 +83,8 @@ export function applyPlayerDamage(amount, source = null, gameHelpers = {}) {
   if (damage <= 0) return 0;
 
   // Phase Momentum negates contact damage from non-boss enemies
-  const pmState = state.player.talent_states.phaseMomentum;
-  if (pmState.active && (!source || !source.boss)) {
+  const pmState = state.player.talent_states?.phaseMomentum;
+  if (pmState && pmState.active && (!source || !source.boss)) {
     pmState.lastDamageTime = Date.now();
     pmState.active = false;
     return 0;
@@ -130,6 +130,7 @@ export function applyPlayerDamage(amount, source = null, gameHelpers = {}) {
  * @returns {number} The clamped value.
  */
 export function clamp(value, min, max) {
+  value = Number.isFinite(value) ? value : 0;
   if (min > max) [min, max] = [max, min];
   return Math.min(max, Math.max(min, value));
 }

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -32,8 +32,8 @@ export function drawCrystal(ctx, x, y, size, color) {
   const sides = 6;
   ctx.fillStyle = color;
   ctx.beginPath();
-  ctx.moveTo(x + s * Math.cos(0), y + s * Math.sin(0));
-  for (let i = 1; i <= sides; i++) {
+  ctx.moveTo(x + s, y); // start at angle 0 without redundant cos/sin
+  for (let i = 1; i < sides; i++) {
     const angle = i * 2 * Math.PI / sides;
     const modSize = (i % 2 === 0) ? s : s * 0.6;
     ctx.lineTo(x + modSize * Math.cos(angle), y + modSize * Math.sin(angle));
@@ -390,6 +390,7 @@ export function pixelsToArc(pixels, width = 2048){
  */
 export function safeAddEventListener(el, type, handler, options){
   if(!el || typeof el.addEventListener !== 'function') return false;
+  if(typeof type !== 'string' || !type) return false;
   if(typeof handler !== 'function') return false;
   el.addEventListener(type, handler, options ?? false);
   return true;


### PR DESCRIPTION
## Summary
- Prevent crystal drawing from duplicating points and validate event listener inputs
- Safeguard player damage logic when phase momentum state is missing and clamp non-numeric values
- Rewrite model loader to use async/await for clearer error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b37e51f8ac83319abffc34bd0c60b2