### PR TITLE
Fix gravity tyrant gravity well orbit

### DIFF
--- a/task_log.md
+++ b/task_log.md
@@ -40,7 +40,8 @@
     * [x] Added extra rings, shards, and orbiting details so later bosses look increasingly epic and aligned with their lore.
     * [x] Introduced progressive ability animations with lore-based shapes for Aethel & Umbra, Splitter, and Reflector bosses.
     * [x] Expanded ability animations for Vampire, Gravity, Syphon, Centurion, and Puppeteer bosses so effects scale with each stage.
-    * [x] Stabilized Gravity Tyrant wells near poles and reattached Swarm Link tail segments.
+* [x] Stabilized Gravity Tyrant wells near poles and reattached Swarm Link tail segments.
+* [x] Fixed Gravity Tyrant well positions so they orbit the boss and affect the player.
 * [x] **Sizing:** Increase the size of the player, bosses, and enemies by 30%. — Completed
 
 ## UI

--- a/tests/gravityWells.test.js
+++ b/tests/gravityWells.test.js
@@ -14,8 +14,9 @@ test('gravity wells remain stable at poles', () => {
   boss.position.set(0, 0, ARENA_RADIUS); // place at north pole
   boss.update(16);
   boss.wellObjects.children.forEach(mesh => {
-    assert.ok(Number.isFinite(mesh.position.x), 'x should be finite');
-    assert.ok(Math.abs(mesh.position.length() - ARENA_RADIUS) < 1e-3,
+    const worldPos = mesh.getWorldPosition(new THREE.Vector3());
+    assert.ok(Number.isFinite(worldPos.x), 'x should be finite');
+    assert.ok(Math.abs(worldPos.length() - ARENA_RADIUS) < 1e-3,
       'well should remain on arena radius');
   });
   state.player.position.copy(original);


### PR DESCRIPTION
## Summary
- Ensure gravity wells orbit the Gravity Tyrant by positioning meshes relative to the boss
- Test gravity well positions using world coordinates to stay on arena radius
- Document fix in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b387dec13883318d52acf5246e4762