### PR TITLE
Anchor menus in world space

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -739,24 +739,6 @@ export function showModal(id) {
     }
 }
 
-export function updateActiveModalTransform() {
-    if (!modalGroup || !state.activeModalId) return;
-    const camera = getCamera();
-    if (!camera) return;
-    const modal = modals[state.activeModalId];
-    const forward = new THREE.Vector3(0, 0, -1)
-        .applyQuaternion(camera.quaternion)
-        .setY(0)
-        .normalize();
-    modalGroup.position.copy(camera.position).addScaledVector(forward, 2);
-    const modalHeight = (modal?.userData?.height || 0) * modalGroup.scale.y;
-    const waistOffset = 0.6;
-    modalGroup.position.y = camera.position.y - waistOffset + modalHeight / 2;
-    const lookTarget = camera.position.clone();
-    lookTarget.y = modalGroup.position.y;
-    modalGroup.lookAt(lookTarget);
-}
-
 export function hideModal() {
     if (state.activeModalId && modals[state.activeModalId]) {
         const modal = modals[state.activeModalId];

--- a/task_log.md
+++ b/task_log.md
@@ -122,6 +122,7 @@
 * [x] Fixed additional gameplay bugs: projectile updates now validate callbacks, shield timers clear on break, player health clamps non-negative, circle drawing guards against invalid contexts, and particle spawner verifies inputs.
 * [x] Hardened drawing helpers against bad inputs: crystal and player rendering now validate contexts, shadow cones require valid radii, particle updates avoid divide-by-zero alpha, and screen shake clamps magnitude and duration.
 * [x] Corrected modal orientation so menus face the player instead of showing their backs.
+* [x] Anchored modals to world space so they no longer follow the player's head.
 * [x] Fixed missile explosions so nearby bosses and enemies take damage even if they lack an explicit `alive` flag.
 * [x] Added enemy separation logic to keep foes from occupying the same spot.
 * [x] Replaced death audio with the original 2D "stone cracking" sound effect.

--- a/tests/vrMain.test.js
+++ b/tests/vrMain.test.js
@@ -36,7 +36,7 @@ async function setupLaunch() {
   });
 
     await mock.module('../modules/ModalManager.js', {
-      namedExports: { initModals: mock.fn(), showModal: mock.fn(), updateActiveModalTransform: mock.fn() }
+      namedExports: { initModals: mock.fn(), showModal: mock.fn() }
     });
 
   await mock.module('../modules/vrGameLoop.js', {

--- a/vrMain.js
+++ b/vrMain.js
@@ -3,7 +3,7 @@ import { XRButton } from './vendor/addons/webxr/XRButton.js';
 import { initScene, getScene, getRenderer, getCamera } from './modules/scene.js';
 import { initPlayerController, updatePlayerController } from './modules/PlayerController.js';
 import { initUI, updateHud, showHud } from './modules/UIManager.js';
-import { initModals, showModal, updateActiveModalTransform } from './modules/ModalManager.js';
+import { initModals, showModal } from './modules/ModalManager.js';
 import { vrGameLoop } from './modules/vrGameLoop.js';
 import { Telemetry } from './modules/telemetry.js';
 import { state, resetGame } from './modules/state.js';
@@ -24,8 +24,6 @@ function render(timestamp, frame) {
     if (state.gameOver && !state.isPaused) {
         showModal('gameOver');
     }
-
-    updateActiveModalTransform();
 
     updateHud();
     renderer.render(getScene(), getCamera());


### PR DESCRIPTION
## Summary
- Stop per-frame modal repositioning so menus stay anchored in the world instead of tracking the player's head
- Adjust VR main loop and tests accordingly
- Log this UI stability improvement in task_log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b38c9a715c8331a5d4b45301438640