### PR TITLE
feat(ui): mirror 2D ascension panel styling

### DIFF
--- a/task_log.md
+++ b/task_log.md
@@ -53,6 +53,7 @@
     * [x] Refined Ascension Conduit menu with header/footer dividers and button colors matching the 2D game.
     * [x] Synced Ascension Conduit title glow and 16:9 talent grid with the 2D version.
     * [x] Added cyan glow around Ascension Conduit modal to mirror the 2D box-shadow.
+    * [x] Rounded Ascension Conduit modal corners and strengthened cyan glow to recreate the 2D border radius and box-shadow.
     * [x] Aligned Ascension Point header with side-by-side label and value to match the 2D layout.
     * [x] Left-aligned Ascension Conduit title and right-aligned AP display to mirror the original menu.
     * [x] Restored AP header styling and hover sound cues to match the 2D Ascension interface.

--- a/tests/ascensionModalStyle.test.js
+++ b/tests/ascensionModalStyle.test.js
@@ -1,0 +1,68 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from '../vendor/three.module.js';
+
+async function setup() {
+  mock.reset();
+  global.requestAnimationFrame = (fn) => fn();
+  const scene = { children: [], add(obj) { this.children.push(obj); } };
+  await mock.module('../modules/scene.js', {
+    namedExports: {
+      getScene: () => scene,
+      getCamera: () => ({ position: new THREE.Vector3(), rotation: new THREE.Euler(), quaternion: new THREE.Quaternion() }),
+      getRenderer: () => ({}),
+      getPrimaryController: () => ({})
+    }
+  });
+  const state = {
+    activeModalId: null,
+    isPaused: false,
+    uiInteractionCooldownUntil: 0,
+    player: { ascensionPoints: 0, purchasedTalents: new Map(), unlockedPowers: new Set() }
+  };
+  await mock.module('../modules/state.js', { namedExports: { state, savePlayerState: mock.fn(), resetGame: mock.fn() } });
+  await mock.module('../modules/PlayerController.js', { namedExports: { refreshPrimaryController: mock.fn(), resetInputFlags: mock.fn() } });
+  await mock.module('../modules/audio.js', { namedExports: { AudioManager: { playSfx: mock.fn() } } });
+  await mock.module('../modules/gameHelpers.js', { namedExports: { gameHelpers: {}, initGameHelpers: () => {} } });
+  await mock.module('../modules/UIManager.js', {
+    namedExports: {
+      holoMaterial: (color = 0x1e1e2f, opacity = 0.85) => ({
+        color: new THREE.Color(color),
+        emissive: new THREE.Color(color),
+        emissiveIntensity: 1,
+        transparent: true,
+        opacity,
+        dispose: () => {}
+      }),
+      createTextSprite: (text = '') => {
+        const obj = new THREE.Object3D();
+        obj.material = { color: new THREE.Color(0xffffff), opacity: 1, dispose: () => {} };
+        obj.userData = { text };
+        return obj;
+      },
+      updateTextSprite: (obj, newText) => { obj.userData.text = newText; },
+      getBgTexture: () => null,
+      showUnlockNotification: () => {},
+      showBossBanner: () => {},
+      updateHud: () => {},
+      showHud: () => {},
+      hideHud: () => {},
+      PIXELS_PER_UNIT: 1000
+    }
+  });
+  const { initModals, showModal, getModalObjects } = await import('../modules/ModalManager.js');
+  return { initModals, showModal, getModalObjects };
+}
+
+test('ascension modal uses rounded corners and cyan glow', async () => {
+  const { initModals, showModal, getModalObjects } = await setup();
+  initModals();
+  showModal('ascension');
+  const ascensionModal = getModalObjects().find(m => m.name === 'modal_ascension');
+  assert.ok(ascensionModal, 'ascension modal should exist');
+  assert.ok(ascensionModal.userData.cornerRadius > 0, 'modal should have rounded corners');
+  const glow = ascensionModal.children.find(c => c.name === 'ascension_modal_glow');
+  assert.ok(glow, 'glow plane should exist');
+  assert.ok(glow.geometry.parameters.width > ascensionModal.userData.width, 'glow should extend past modal width');
+  assert.ok(glow.geometry.parameters.height > ascensionModal.userData.height, 'glow should extend past modal height');
+});


### PR DESCRIPTION
## Summary
- add rounded rectangle geometry helper for modals
- round Ascension Conduit modal corners and intensify cyan glow
- cover Ascension Conduit styling with regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3a0475e208331af89a278735ca9a5