### PR TITLE
Hide arena sphere for unobstructed view

### DIFF
--- a/modules/scene.js
+++ b/modules/scene.js
@@ -16,7 +16,13 @@ export function initScene() {
 
     const arenaGeometry = new THREE.SphereGeometry(ARENA_RADIUS, 64, 32);
     const arenaMaterial = new THREE.MeshStandardMaterial({
-        color: 0x333333, side: THREE.BackSide, metalness: 0.1, roughness: 0.8
+        color: 0x333333,
+        side: THREE.BackSide,
+        metalness: 0.1,
+        roughness: 0.8,
+        transparent: true,
+        opacity: 0,
+        depthWrite: false
     });
     arena = new THREE.Mesh(arenaGeometry, arenaMaterial);
     arena.name = 'arena';

--- a/task_log.md
+++ b/task_log.md
@@ -152,3 +152,4 @@
 * [x] Debugged first 10 boss AIs, importing missing state in Splitter and redirecting Vampire blood orbs to heal the player.
 * [x] Fixed controller handedness swaps so the cursor and menu stay on their intended hands.
 * [x] Styled unlock notification banner with patterned background and cyan border so VR alerts mirror the 2D UI.
+* [x] Hid the arena mesh while retaining it for raycasts so gravity wells and other objects remain visible against the backdrop.


### PR DESCRIPTION
## Summary
- Make arena sphere fully transparent and non-blocking while retaining geometry for gameplay logic
- Log visibility improvement in task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3a953742883319ca5656ce6b70d44