### PR TITLE
Retune gravity pull effects to match 2D gameplay

### DIFF
--- a/modules/agents/GravityAI.js
+++ b/modules/agents/GravityAI.js
@@ -15,7 +15,7 @@ export class GravityAI extends BaseAgent {
     this.add(this.wellObjects);
 
     for (let i = 0; i < 8; i++) {
-        const well = { angle: i * (Math.PI / 4), dist: 8, radius: 2 }; // World units
+        const well = { angle: i * (Math.PI / 4), dist: 5, radius: 1 }; // World units
         this.wells.push(well);
 
         const wellGeo = new THREE.TorusGeometry(well.radius, 0.2, 8, 24);
@@ -61,11 +61,10 @@ export class GravityAI extends BaseAgent {
 
         // Apply gravitational pull to the player
         const playerPos = state.player.position;
-        const distance = playerPos.distanceTo(worldWellPos);
+        const offset = worldWellPos.clone().sub(playerPos);
+        const distance = offset.length();
         if (distance < well.radius + state.player.r) {
-            const pullDirection = worldWellPos.clone().sub(playerPos).normalize();
-            const pullStrength = 1.0 - (distance / well.radius);
-            playerPos.add(pullDirection.multiplyScalar(pullStrength * 0.1));
+            playerPos.add(offset.multiplyScalar(0.05));
             playerPos.normalize().multiplyScalar(ARENA_RADIUS);
         }
     });

--- a/modules/powers.js
+++ b/modules/powers.js
@@ -243,7 +243,7 @@ export const powers = {
   black_hole: {emoji: "⚫", desc: "Pulls and damages enemies for 4s", apply:(options = {}) => {
       const { damageModifier = 1.0, origin = state.player } = options;
       let damage = (((state.player.berserkUntil > Date.now()) ? 6 : 3) * state.player.talent_modifiers.damage_multiplier) * damageModifier;
-      let radius = 20; // World units
+      let radius = 11; // World units (~350px in the original game)
       const blackHoleEffect = {
           type: 'black_hole',
           position: state.cursorDir.clone().multiplyScalar(ARENA_RADIUS),

--- a/modules/projectilePhysics3d.js
+++ b/modules/projectilePhysics3d.js
@@ -304,7 +304,29 @@ export function updateEffects3d(radius = 50, deltaMs = 16){
 
         const progress = Math.min(1, (now - ef.startTime) / ef.duration);
         const pullRadius = ef.maxRadius * progress;
-        state.enemies.forEach(e=>{ if(!e.alive) return; const d = e.position.distanceTo(ef.position); if(d < pullRadius){ let pull = e.boss ? 0.02 : 0.05; pull *= deltaFactor; e.position.add(ef.position.clone().sub(e.position).multiplyScalar(pull)); if(state.player.purchasedTalents.has('unstable-singularity') && d < ef.radius && now - (ef.lastDamage.get(e)||0) > ef.damageRate){ if(canDamage(ef.caster, e)){ e.takeDamage(ef.damage, ef.caster===state.player); } ef.lastDamage.set(e, now); } }});
+        state.enemies.forEach(e => {
+          if(!e.alive) return;
+          const d = e.position.distanceTo(ef.position);
+          if(d < pullRadius){
+            let pull = e.boss ? 0.03 : 0.1;
+            pull *= deltaFactor;
+            e.position.add(ef.position.clone().sub(e.position).multiplyScalar(pull));
+            if(state.player.purchasedTalents.has('unstable-singularity') && d < ef.radius && now - (ef.lastDamage.get(e)||0) > ef.damageRate){
+              if(canDamage(ef.caster, e)){
+                e.takeDamage(ef.damage, ef.caster===state.player);
+              }
+              ef.lastDamage.set(e, now);
+            }
+          }
+        });
+        if(ef.caster !== state.player){
+          const pd = state.player.position.distanceTo(ef.position);
+          if(pd < pullRadius){
+            const pullPlayer = 0.08 * deltaFactor;
+            state.player.position.add(ef.position.clone().sub(state.player.position).multiplyScalar(pullPlayer));
+            state.player.position.normalize().multiplyScalar(radius);
+          }
+        }
         if(now > ef.endTime){
           if(ef.mesh){
             if(projectileGroup) projectileGroup.remove(ef.mesh);

--- a/task_log.md
+++ b/task_log.md
@@ -154,3 +154,4 @@
 * [x] Styled unlock notification banner with patterned background and cyan border so VR alerts mirror the 2D UI.
 * [x] Hid the arena mesh while retaining it for raycasts so gravity wells and other objects remain visible against the backdrop.
 * [x] Added a compact, semi-transparent hex platform beneath the player for orientation without blocking the view.
+* [x] Rebalanced Gravity Tyrant wells and Black Hole pull strength to match the original 2D tuning.


### PR DESCRIPTION
## Summary
- Reposition and resize Gravity Tyrant wells and apply 5% radial pull when the player enters
- Shrink Black Hole power radius to the 2D-equivalent and boost pull strength on enemies and bosses
- Tug the player toward hostile black holes and document the change in the task log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3abbf2f608331a997d8df9a6d1a48