### PR TITLE
Default pointer to right hand and menu to left

### DIFF
--- a/modules/state.js
+++ b/modules/state.js
@@ -48,7 +48,7 @@ export const state = {
     
     // VR-specific state
     settings: {
-        handedness: 'left',
+        handedness: 'right',
         musicVolume: 75,
         sfxVolume: 85,
     },

--- a/task_log.md
+++ b/task_log.md
@@ -156,3 +156,4 @@
 * [x] Added a compact, semi-transparent hex platform beneath the player for orientation without blocking the view.
 * [x] Rebalanced Gravity Tyrant wells and Black Hole pull strength to match the original 2D tuning.
 * [x] Restored slot and aberration core unlock logic so VR progression mirrors the 2D game.
+* [x] Switched default handedness to right so the pointer starts on the right hand and the menu on the left.


### PR DESCRIPTION
## Summary
- Set default controller handedness to right so the laser pointer uses the right hand and menus attach to the left
- Update task log to record new handedness default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3b208f3ac8331a6d28d0b21fdcada