### PR TITLE
Add Quest 3 haptic feedback for weapons and damage

### DIFF
--- a/modules/gameLoop.js
+++ b/modules/gameLoop.js
@@ -6,7 +6,7 @@ import { bossData } from './bosses.js';
 import { showUnlockNotification, showBossBanner, updateHud } from './UIManager.js';
 import { AudioManager } from './audio.js';
 import { initGameHelpers } from './gameHelpers.js';
-import { getScene } from './scene.js';
+import { getScene, getPrimaryController, getSecondaryController } from './scene.js';
 import { uvToSpherePos } from './utils.js';
 import { applyPlayerHeal } from './helpers.js';
 
@@ -60,11 +60,24 @@ const bossAIClassMap = {
     time_eater: TimeEaterAI, vampire: VampireAI
 };
 
+function pulseControllers(duration = 20, strength = 0.5) {
+    const controllers = [getPrimaryController(), getSecondaryController()];
+    for (const ctrl of controllers) {
+        const actuator = ctrl?.gamepad?.hapticActuators?.[0];
+        try {
+            actuator?.pulse?.(strength, duration);
+        } catch {
+            /* ignore unsupported haptics */
+        }
+    }
+}
+
 const gameHelpers = {
     addStatusEffect, spawnEnemy, spawnPickup,
     play: (id, obj) => AudioManager.playSfx(id, obj),
     playLooping: (id, obj) => AudioManager.playLoopingSfx(id, obj),
     stopLoopingSfx: (id) => AudioManager.stopLoopingSfx(id),
+    pulseControllers,
     addEssence,
     updateHud,
 };

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -118,6 +118,15 @@ export function applyPlayerDamage(amount, source = null, gameHelpers = {}) {
   }
   if (state.player.health < 0) state.player.health = 0;
 
+  if (gameHelpers && typeof gameHelpers.pulseControllers === 'function') {
+    const intensity = Math.min(1, 0.3 + damage / 20);
+    const duration = 40 + Math.min(200, damage * 8);
+    gameHelpers.pulseControllers(duration, intensity);
+    if (damage > 5) {
+      setTimeout(() => gameHelpers.pulseControllers(duration * 0.6, intensity * 0.8), 60);
+    }
+  }
+
   return damage;
 }
 

--- a/modules/powers.js
+++ b/modules/powers.js
@@ -327,11 +327,17 @@ export function usePower(powerKey, isFreeCast = false, options = {}){
   }
 
   power.apply(...applyArgs);
-  if(gameHelpers.pulseControllers) gameHelpers.pulseControllers(60,0.6);
-  
+  if (queueType === 'offensive' && gameHelpers.pulseControllers) {
+      gameHelpers.pulseControllers(25, 0.7);
+      setTimeout(() => gameHelpers.pulseControllers(35, 0.4), 40);
+  }
+
   if (stackedEffect && powerKey !== 'stack') {
       power.apply(...applyArgs);
-      if(gameHelpers.pulseControllers) gameHelpers.pulseControllers(60,0.6);
+      if (queueType === 'offensive' && gameHelpers.pulseControllers) {
+          gameHelpers.pulseControllers(25, 0.7);
+          setTimeout(() => gameHelpers.pulseControllers(35, 0.4), 40);
+      }
       if(state.stacked) {
           state.stacked = false;
           state.player.statusEffects = state.player.statusEffects.filter(e => e.name !== 'Stacked');

--- a/task_log.md
+++ b/task_log.md
@@ -161,3 +161,4 @@
 * [x] Restored slot and aberration core unlock logic so VR progression mirrors the 2D game.
 * [x] Switched default handedness to right so the pointer starts on the right hand and the menu on the left.
 * [x] Added wallpaper-backed panel to the controller menu and removed wallpaper from HUD notifications to complete the original 2D aesthetic.
+* [x] Introduced context-aware haptic feedback: firing weapons delivers a crisp double-pulse while taking damage scales rumble intensity for deeper Quest 3 immersion.

--- a/tests/hapticsDamage.test.js
+++ b/tests/hapticsDamage.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { state } from '../modules/state.js';
+import { applyPlayerDamage } from '../modules/helpers.js';
+import * as CoreManager from '../modules/CoreManager.js';
+
+CoreManager._setTestHooks({
+  onPlayerDamage: d => d,
+  onShieldBreak: () => {},
+  onFatalDamage: () => true,
+});
+
+test('applyPlayerDamage triggers haptic pulse', () => {
+  state.player.health = 50;
+  state.player.maxHealth = 100;
+  state.player.shield = false;
+  state.player.talent_states.phaseMomentum.active = false;
+  state.player.talent_modifiers.damage_taken_multiplier = 1;
+  let called = false;
+  const helpers = {
+    play: () => {},
+    pulseControllers: (duration, intensity) => {
+      called = true;
+      assert.ok(duration > 0);
+      assert.ok(intensity > 0);
+    }
+  };
+  applyPlayerDamage(5, null, helpers);
+  assert.ok(called);
+});


### PR DESCRIPTION
## Summary
- add helper to pulse Quest 3 controllers
- fire weapons with a crisp double-pulse haptic effect
- scale rumble intensity based on damage taken and test haptics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3b910d89c83319e0898ae3aaa8551