### PR TITLE
Refine ascension tooltip styling

### DIFF
--- a/modules/ModalManager.js
+++ b/modules/ModalManager.js
@@ -1033,11 +1033,16 @@ function createAscensionModal() {
             new THREE.PlaneGeometry(0.7, 0.3),
             holoMaterial(0x101020, 1)
         );
-        const border = new THREE.Mesh(
-            new THREE.PlaneGeometry(0.72, 0.32),
-            holoMaterial(0x00ffff, 0.4)
+        // The old 2D tooltip used a thin cyan outline rather than a filled
+        // rectangle.  Rendering the border as line segments avoids tinting the
+        // background and improves text legibility in VR.
+        const borderEdges = new THREE.EdgesGeometry(new THREE.PlaneGeometry(0.72, 0.32));
+        const border = new THREE.LineSegments(
+            borderEdges,
+            new THREE.LineBasicMaterial({ color: 0x00ffff, transparent: true, opacity: 0.4 })
         );
-        border.position.z = -0.001;
+        border.position.z = 0.011;
+        border.name = 'tooltip_border';
 
         const icon = createTextSprite('', 28, '#ffffff', 'left');
         icon.position.set(-0.32, 0.06, 0.01);

--- a/task_log.md
+++ b/task_log.md
@@ -69,6 +69,7 @@
     * [x] Added tooltip footer divider and 1.15 hover scale so Ascension talents mirror 2D visuals precisely.
     * [x] Matched talent tooltip text colors and opacity with the original 2D styling.
     * [x] Wired talent tooltip hover events so Ascension descriptions display in VR.
+    * [x] Replaced filled tooltip borders with thin cyan outlines so Ascension tooltips match 2D visuals and remain readable.
     * [x] Synced talent purchases with HUD updates and drew connector lines without depth testing so the Ascension grid layers exactly like the 2D menu.
     * [x] Resolved CSS color variables so Ascension constellations use the original cyan and orange hues.
 * [x] Raised modal positions so menus appear higher with their bottoms at waist height.

--- a/tests/ascensionNexus.test.js
+++ b/tests/ascensionNexus.test.js
@@ -146,6 +146,21 @@ test('ascension tooltip shows Mastery and cost for unpurchased talent', async ()
   assert.equal(divider.material.color.getHex(), 0x00ffff);
 });
 
+test('ascension tooltip uses cyan line border', async () => {
+  const { initModals, showModal, getModalObjects } = await setup();
+  initModals();
+  showModal('ascension');
+  const ascensionModal = getModalObjects().find(m => m.name === 'modal_ascension');
+  const grid = ascensionModal.children.find(c => c.name === 'ascension_grid');
+  const coreBtn = grid.children.find(c => c.userData && c.userData.talentId === 'core-nexus');
+  coreBtn.userData.onHover(true);
+  const tooltip = grid.children.find(c => c.userData && c.userData.rank);
+  const border = tooltip.children.find(c => c.name === 'tooltip_border');
+  assert.ok(border && border.isLineSegments, 'tooltip border should be line segments');
+  assert.equal(border.material.color.getHex(), 0x00ffff);
+  assert.equal(border.material.opacity, 0.4);
+});
+
 test('talent button uses 1.15 hover scale', async () => {
   const { initModals, showModal, getModalObjects } = await setup();
   initModals();


### PR DESCRIPTION
## Summary
- Render VR ascension tooltips with thin cyan line borders for 2D parity and better readability
- Add unit test covering tooltip border material
- Log tooltip styling update in task log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3be1e2d348331b67b1b97aa1b7170