### PR TITLE
Reuse HUD icon slots and dispose materials correctly

### DIFF
--- a/task_log.md
+++ b/task_log.md
@@ -165,5 +165,6 @@
 * [x] Restored slot and aberration core unlock logic so VR progression mirrors the 2D game.
 * [x] Switched default handedness to right so the pointer starts on the right hand and the menu on the left.
 * [x] Added wallpaper-backed panel to the controller menu and removed wallpaper from HUD notifications to complete the original 2D aesthetic.
+* [x] Reused HUD status and pantheon icon slots to avoid per-frame allocations and ensured meshes/textures are disposed when icons expire.
 * [x] Introduced context-aware haptic feedback: firing weapons delivers a crisp double-pulse while taking damage scales rumble intensity for deeper Quest 3 immersion.
 * [x] Standardized menu styling with the 2D game's cyan glow, font stack, hover/click audio cues, and non-repeating wallpaper so every VR menu shares the original look.


### PR DESCRIPTION
## Summary
- reuse HUD status and pantheon icon slots instead of recreating meshes every frame
- add disposal helpers so HUD cleanup no longer leaks textures or leaves parent links behind
- document the HUD pooling refinement in the task log

## Testing
- node --test --experimental-test-module-mocks tests/*.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dae030b3bc8331ac9e812fc7bb0bf8