### PR TITLE
Add home ascension entry and tune damage flash

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,6 +69,7 @@ async function preloadAssets() {
 function setupHomeScreen() {
     const newGameBtn = document.getElementById('new-game-btn');
     const continueGameBtn = document.getElementById('continue-game-btn');
+    const ascensionHomeBtn = document.getElementById('ascension-home-btn');
     const eraseGameBtn = document.getElementById('erase-game-btn');
 
     const hasSaveData = !!localStorage.getItem('eternalMomentumSave');
@@ -80,17 +81,27 @@ function setupHomeScreen() {
         newGameBtn.style.display = 'block';
     }
 
-    const startVRSequence = (stage) => {
+    const startVRSequence = ({ stage = 1, startPaused = false, modalId = null } = {}) => {
         AudioManager.unlockAudio();
         homeScreen.style.display = 'none';
-        launchVR(stage);
+        launchVR(stage, { startPaused, initialModalId: modalId });
     };
 
-    newGameBtn.addEventListener('click', () => startVRSequence(1));
-    continueGameBtn.addEventListener('click', () => {
-        const startStage = state.player.highestStageBeaten > 0 ? state.player.highestStageBeaten + 1 : 1;
-        startVRSequence(startStage);
-    });
+    if (newGameBtn) {
+        newGameBtn.addEventListener('click', () => startVRSequence({ stage: 1 }));
+    }
+    if (continueGameBtn) {
+        continueGameBtn.addEventListener('click', () => {
+            const startStage = state.player.highestStageBeaten > 0 ? state.player.highestStageBeaten + 1 : 1;
+            startVRSequence({ stage: startStage });
+        });
+    }
+    if (ascensionHomeBtn) {
+        ascensionHomeBtn.addEventListener('click', () => {
+            const startStage = state.player.highestStageBeaten > 0 ? state.player.highestStageBeaten + 1 : 1;
+            startVRSequence({ stage: startStage, startPaused: true, modalId: 'ascension' });
+        });
+    }
     eraseGameBtn.addEventListener('click', () => {
         if (confirm("This timeline will be erased. All progress will be lost.")) {
             localStorage.removeItem('eternalMomentumSave');

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       <div id="home-actions">
         <button id="new-game-btn" class="home-btn" style="display: none;">AWAKEN</button>
         <button id="continue-game-btn" class="home-btn" style="display: none;">CONTINUE MOMENTUM</button>
+        <button id="ascension-home-btn" class="home-btn">ASCENSION CONDUIT</button>
         <button id="erase-game-btn" class="home-btn erase" style="display: none;">SEVER TIMELINE</button>
       </div>
     </div>

--- a/modules/agentAnimations.js
+++ b/modules/agentAnimations.js
@@ -132,8 +132,18 @@ export function notifyAgentDamaged(agent, severity = 1) {
   if (!model) return;
   const anim = ensureAnimationState(agent);
   if (!anim) return;
-  const magnitude = Math.max(0.1, severity);
-  anim.hitFlash = Math.min(anim.hitFlashMax, anim.hitFlash + magnitude * 18);
+
+  const magnitude = Math.max(0, severity);
+  if (magnitude === 0) return;
+
+  // Map incoming severity to a target flash level so heavier hits immediately
+  // brighten the emissive glow beyond any idle pulse.  Using the maximum
+  // between the current flash value and this severity-derived target mirrors
+  // the 2D game's behaviour where successive hits extend the flash rather than
+  // stacking infinitely.
+  const normalized = Math.min(1, magnitude / 6);
+  const target = normalized * anim.hitFlashMax;
+  anim.hitFlash = Math.max(anim.hitFlash, target);
 }
 
 export function resetAgentAnimation(agent) {

--- a/task_log.md
+++ b/task_log.md
@@ -168,3 +168,5 @@
 * [x] Reused HUD status and pantheon icon slots to avoid per-frame allocations and ensured meshes/textures are disposed when icons expire.
 * [x] Introduced context-aware haptic feedback: firing weapons delivers a crisp double-pulse while taking damage scales rumble intensity for deeper Quest 3 immersion.
 * [x] Standardized menu styling with the 2D game's cyan glow, font stack, hover/click audio cues, and non-repeating wallpaper so every VR menu shares the original look.
+* [x] Added a home-screen Ascension Conduit button that launches VR paused and opens the ascension modal so players can respec before entering a run.
+* [x] Remapped agent damage flashes to severity-driven targets so emissive highlights burst above idle pulses and decay back to their cached base color.

--- a/vrMain.js
+++ b/vrMain.js
@@ -29,7 +29,8 @@ function render(timestamp, frame) {
     renderer.render(getScene(), getCamera());
 }
 
-export async function launchVR(initialStage = 1) {
+export async function launchVR(initialStage = 1, options = {}) {
+    const { startPaused = false, initialModalId = null } = options;
     initScene();
     renderer = getRenderer();
     document.getElementById('vrContainer').appendChild(renderer.domElement);
@@ -43,7 +44,7 @@ export async function launchVR(initialStage = 1) {
     // Pass bossData to resetGame to prevent the crash
     resetGame(bossData);
     state.currentStage = initialStage;
-    state.isPaused = false;
+    state.isPaused = !!startPaused;
 
     renderer.setAnimationLoop(render);
 
@@ -74,6 +75,10 @@ export async function launchVR(initialStage = 1) {
             showModal('levelSelect');
         }
     });
+
+    if (initialModalId) {
+        showModal(initialModalId);
+    }
 
     // Session end will return control to the page without reloading
 }


### PR DESCRIPTION
## Summary
- add an Ascension Conduit button to the home screen that launches VR straight into the modal
- let `launchVR` start paused and optionally show an initial modal so the ascension conduit mirrors the 2D flow
- remap agent damage flash intensity to severity-based targets so the glow spikes above idle pulses and then decays

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68dae1a84850833181378020b3c05f70